### PR TITLE
Remove unused symlink tooling

### DIFF
--- a/extensions/chromium/runet-censorship-bypass/package-lock.json
+++ b/extensions/chromium/runet-censorship-bypass/package-lock.json
@@ -21,8 +21,7 @@
         "eslint-config-google": "^0.14.0",
         "gulp-changed": "^4.0.2",
         "mocha": "^8.2.1",
-        "sinon-chrome": "^3.0.1",
-        "symlink-to": "^0.0.4"
+        "sinon-chrome": "^3.0.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -5099,12 +5098,6 @@
         "es6-symbol": "^3.1.1"
       }
     },
-    "node_modules/symlink-to": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/symlink-to/-/symlink-to-0.0.4.tgz",
-      "integrity": "sha512-l83Ta9ZYKYTK51WMWBBbSgRSIoA+utHzLoEMVSU6+ip/X5zvxXeYCe2xhL2cfeDg0wVyhpPgve6EKfauwtXY6A==",
-      "dev": true
-    },
     "node_modules/table": {
       "version": "6.0.7",
       "resolved": "https://registry.npmjs.org/table/-/table-6.0.7.tgz",
@@ -10084,12 +10077,6 @@
         "es6-iterator": "^2.0.1",
         "es6-symbol": "^3.1.1"
       }
-    },
-    "symlink-to": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/symlink-to/-/symlink-to-0.0.4.tgz",
-      "integrity": "sha512-l83Ta9ZYKYTK51WMWBBbSgRSIoA+utHzLoEMVSU6+ip/X5zvxXeYCe2xhL2cfeDg0wVyhpPgve6EKfauwtXY6A==",
-      "dev": true
     },
     "table": {
       "version": "6.0.7",

--- a/extensions/chromium/runet-censorship-bypass/package.json
+++ b/extensions/chromium/runet-censorship-bypass/package.json
@@ -27,8 +27,7 @@
     "eslint-config-google": "^0.14.0",
     "gulp-changed": "^4.0.2",
     "mocha": "^8.2.1",
-    "sinon-chrome": "^3.0.1",
-    "symlink-to": "^0.0.4"
+    "sinon-chrome": "^3.0.1"
   },
   "dependencies": {
     "del": "^6.0.0",


### PR DESCRIPTION
### Summary

- removes the unused `symlink-to` development dependency;
- repository-wide inspection found no executable use;
- no source or build-script change.

### Dependency impact

- direct dependencies: 12 -> 11;
- installed package paths: 607 -> 606;
- lockfile package entries: 609 -> 608;
- full audit remains 40 affected packages (3 low, 10 moderate, 23 high, 4 critical; 74 unique advisories);
- production-only audit remains 26 affected packages (2 low, 6 moderate, 14 high, 4 critical; 44 unique advisories);
- `symlink-to` had no transitive dependencies or advisory path, so no advisory disappeared;
- the broader npm security backlog is unchanged.

### Verification

- clean extension-only `npm ci`: passed;
- `npm ls --all`: only the unchanged optional Darwin-only `fsevents` platform issue is reported on Windows; no removal-related missing or extraneous package;
- PAC tests: 26 passing;
- MV3 tests: 283 passing;
- focused MV3 lint: passed;
- full `verify`: 286 passing, including the MV2 compatibility build;
- runtime icons: 32 verified;
- package integrity: 76 files;
- runtime identity: all 76 paths and SHA-256 hashes are byte-for-byte identical before and after.

### Release impact

- packaged extension bytes are unchanged;
- `v0.0.2.0-beta1` remains valid;
- beta2 is not required.