### PR TITLE
Remove unused gulp-changed plugin

### DIFF
--- a/extensions/chromium/runet-censorship-bypass/gulpfile.js
+++ b/extensions/chromium/runet-censorship-bypass/gulpfile.js
@@ -4,7 +4,6 @@ const gulp = require('gulp');
 const del = require('del');
 const through = require('through2');
 const PluginError = require('plugin-error');
-const changed = require('gulp-changed');
 
 const PluginName = 'Template literals';
 

--- a/extensions/chromium/runet-censorship-bypass/package-lock.json
+++ b/extensions/chromium/runet-censorship-bypass/package-lock.json
@@ -19,7 +19,6 @@
         "chai": "^4.3.0",
         "eslint": "^7.19.0",
         "eslint-config-google": "^0.14.0",
-        "gulp-changed": "^4.0.2",
         "mocha": "^8.2.1",
         "sinon-chrome": "^3.0.1"
       }
@@ -237,12 +236,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
       "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
-      "dev": true
-    },
-    "node_modules/abbrev": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true
     },
     "node_modules/acorn": {
@@ -2797,40 +2790,6 @@
         "vinyl-fs": "^3.0.0"
       }
     },
-    "node_modules/gulp-changed": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/gulp-changed/-/gulp-changed-4.0.3.tgz",
-      "integrity": "sha512-oIymgTNmmIvdqRRpdtohmELix81q+CA/D9DgVCvaM4Ulai0xgalf+XS6A95JwskbxRGQKtzzhMmdWZEuikX67w==",
-      "dev": true,
-      "dependencies": {
-        "make-dir": "^3.0.0",
-        "plugin-error": "^1.0.1",
-        "replace-ext": "^1.0.0",
-        "through2": "^3.0.1",
-        "touch": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "peerDependencies": {
-        "gulp": ">=4"
-      },
-      "peerDependenciesMeta": {
-        "gulp": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/gulp-changed/node_modules/through2": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.2.tgz",
-      "integrity": "sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==",
-      "dev": true,
-      "dependencies": {
-        "inherits": "^2.0.4",
-        "readable-stream": "2 || 3"
-      }
-    },
     "node_modules/gulp/node_modules/gulp-cli": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/gulp-cli/-/gulp-cli-2.2.0.tgz",
@@ -3360,30 +3319,6 @@
       "resolved": "https://registry.npmjs.org/lolex/-/lolex-4.2.0.tgz",
       "integrity": "sha512-gKO5uExCXvSm6zbF562EvM+rd1kQDnB9AZBbiQVzf1ZmdDpxUSvpnAaVOP83N/31mRK8Ml8/VE8DMvsAZQ+7wg==",
       "dev": true
-    },
-    "node_modules/make-dir": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-      "dev": true,
-      "dependencies": {
-        "semver": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/make-dir/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      }
     },
     "node_modules/make-iterator": {
       "version": "1.0.1",
@@ -3985,15 +3920,6 @@
       "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^1.7.0"
-      }
-    },
-    "node_modules/nopt": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
-      "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
-      "dev": true,
-      "dependencies": {
-        "abbrev": "1"
       }
     },
     "node_modules/normalize-package-data": {
@@ -5309,15 +5235,6 @@
         "xtend": "~4.0.1"
       }
     },
-    "node_modules/touch": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.0.tgz",
-      "integrity": "sha512-WBx8Uy5TLtOSRtIq+M03/sKDrXCLHxwDcquSP2c43Le03/9serjQBIztjRz6FkJez9D/hleyAXTBGLwwZUw9lA==",
-      "dev": true,
-      "dependencies": {
-        "nopt": "~1.0.10"
-      }
-    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -5879,12 +5796,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
       "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
-      "dev": true
-    },
-    "abbrev": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true
     },
     "acorn": {
@@ -8063,31 +7974,6 @@
         }
       }
     },
-    "gulp-changed": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/gulp-changed/-/gulp-changed-4.0.3.tgz",
-      "integrity": "sha512-oIymgTNmmIvdqRRpdtohmELix81q+CA/D9DgVCvaM4Ulai0xgalf+XS6A95JwskbxRGQKtzzhMmdWZEuikX67w==",
-      "dev": true,
-      "requires": {
-        "make-dir": "^3.0.0",
-        "plugin-error": "^1.0.1",
-        "replace-ext": "^1.0.0",
-        "through2": "^3.0.1",
-        "touch": "^3.1.0"
-      },
-      "dependencies": {
-        "through2": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.2.tgz",
-          "integrity": "sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==",
-          "dev": true,
-          "requires": {
-            "inherits": "^2.0.4",
-            "readable-stream": "2 || 3"
-          }
-        }
-      }
-    },
     "gulplog": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
@@ -8559,23 +8445,6 @@
       "resolved": "https://registry.npmjs.org/lolex/-/lolex-4.2.0.tgz",
       "integrity": "sha512-gKO5uExCXvSm6zbF562EvM+rd1kQDnB9AZBbiQVzf1ZmdDpxUSvpnAaVOP83N/31mRK8Ml8/VE8DMvsAZQ+7wg==",
       "dev": true
-    },
-    "make-dir": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-      "dev": true,
-      "requires": {
-        "semver": "^6.0.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
-        }
-      }
     },
     "make-iterator": {
       "version": "1.0.1",
@@ -9060,15 +8929,6 @@
             "@sinonjs/commons": "^1.7.0"
           }
         }
-      }
-    },
-    "nopt": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
-      "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
-      "dev": true,
-      "requires": {
-        "abbrev": "1"
       }
     },
     "normalize-package-data": {
@@ -10270,15 +10130,6 @@
             "xtend": "~4.0.1"
           }
         }
-      }
-    },
-    "touch": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.0.tgz",
-      "integrity": "sha512-WBx8Uy5TLtOSRtIq+M03/sKDrXCLHxwDcquSP2c43Le03/9serjQBIztjRz6FkJez9D/hleyAXTBGLwwZUw9lA==",
-      "dev": true,
-      "requires": {
-        "nopt": "~1.0.10"
       }
     },
     "type-check": {

--- a/extensions/chromium/runet-censorship-bypass/package.json
+++ b/extensions/chromium/runet-censorship-bypass/package.json
@@ -25,7 +25,6 @@
     "chai": "^4.3.0",
     "eslint": "^7.19.0",
     "eslint-config-google": "^0.14.0",
-    "gulp-changed": "^4.0.2",
     "mocha": "^8.2.1",
     "sinon-chrome": "^3.0.1"
   },


### PR DESCRIPTION
### Summary

- removes the inactive top-level `gulp-changed` import;
- removes the corresponding development dependency;
- active Gulp pipelines and tasks do not use the plugin.

### Dependency impact

- direct dependencies: 11 -> 10; dev dependencies: 6 -> 5;
- installed package paths: 606 -> 599; lockfile package entries: 608 -> 601;
- removed path: `gulp-changed@4.0.3` -> `make-dir@3.1.0` -> `semver@6.3.0`, nested `through2@3.0.2`, and `touch@3.1.0` -> `nopt@1.0.10` -> `abbrev@1.1.1`;
- full audit remains 40 affected packages (3 low, 10 moderate, 23 high, 4 critical); production-only remains 26 (2 low, 6 moderate, 14 high, 4 critical);
- npm advisory source records decrease from 74 to 73 by removing source `1112922` and the dev-only `semver@6.3.0` node for GHSA-c2qf-rxjj-qqgw; the GHSA and affected `semver` package remain through other paths;
- production findings and the optional Darwin `fsevents` path remain unchanged; the broader legacy-toolchain risks are not resolved.

### Verification

- clean extension-only `npm ci`: passed and preserved the lockfile;
- `npm ls --all`: only the unchanged optional Darwin-only `fsevents@1.2.9` platform issue is reported on Windows; no removal-related missing or extraneous package;
- PAC tests: 26 passing;
- MV3 tests: 283 passing;
- focused MV3 lint: passed;
- full `verify`: 286 passing;
- MV2 compatibility `buildAll`: passed;
- runtime icons: 32 verified;
- package integrity: 76 files;
- local 76-file output is byte-for-byte identical before and after; Linux-equivalent output matches every path and hash in the previous main CI runtime artifact.

### Release impact

- packaged runtime content is unchanged;
- the known eight Windows CRLF versus Linux LF text differences are pre-existing and normalize identically;
- `v0.0.2.0-beta1` remains valid;
- beta2 is not required.