### PR TITLE
Restore proxy control after browser restart

### DIFF
--- a/extensions/chromium/runet-censorship-bypass/src/extension-chromium-mv3/background/service-worker.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-chromium-mv3/background/service-worker.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /* global importScripts, mv3LegacyMigrationApply, mv3LegacyMigrationAudit */
-/* global mv3ActionStatus, mv3PacArtifacts, mv3PacCook, mv3PacDownload */
+/* global mv3ActionStatus, mv3Hash, mv3PacArtifacts, mv3PacCook, mv3PacDownload */
 /* global mv3PacMods, mv3PeriodicUpdate, mv3SiteScope */
 /* global mv3Providers, mv3ProxyAuth, mv3ProxyHealth, mv3ProxySettings */
 /* global mv3State */
@@ -125,6 +125,14 @@ function getProviderForState(state, providerKey, ifIncludeDisabled) {
 function invalidatePacApplyFreshness() {
 
   activePacApplyOperation = null;
+
+}
+
+function invalidateStartupProxyRestoreFreshness() {
+
+  if (activePacApplyOperation && activePacApplyOperation.startupRestore) {
+    activePacApplyOperation = null;
+  }
 
 }
 
@@ -262,6 +270,9 @@ async function finishActionOperation(operation) {
 
 async function runWithActionOperation(kind, execute) {
 
+  if (kind === 'apply' || kind === 'clear') {
+    invalidatePacApplyFreshness();
+  }
   const operation = await beginActionOperation(kind);
   try {
     return await execute();
@@ -328,9 +339,13 @@ async function savePacWorkflowStatePatch(workflow, patch) {
 
 }
 
-function beginPacApplyOperation(workflow) {
+function beginPacApplyOperation(workflow, options = {}) {
 
-  const operation = Object.freeze({workflow});
+  const operation = Object.freeze({
+    startupAuthorization: options.startupAuthorization || null,
+    startupRestore: options.startupRestore === true,
+    workflow,
+  });
   activePacApplyOperation = operation;
   return operation;
 
@@ -383,6 +398,120 @@ function createPacApplyFingerprint(state) {
 function ifPacApplyFingerprintsMatch(left, right) {
 
   return Object.keys(left).every((key) => left[key] === right[key]);
+
+}
+
+function createStartupProxyRestoreSkip(reason, state) {
+
+  return {
+    allowed: false,
+    reason,
+    state,
+  };
+
+}
+
+function createStartupProxyRestoreAuthorization(state) {
+
+  const proxyApply = state.proxyApply || {};
+  return Object.freeze({
+    appliedAt: proxyApply.appliedAt || null,
+    cookedPacSha256: proxyApply.cookedPacSha256 || null,
+    providerKey: proxyApply.providerKey || null,
+    status: proxyApply.status || null,
+  });
+
+}
+
+function ifStartupProxyRestoreAuthorizationMatches(authorization, state) {
+
+  if (!authorization) {
+    return true;
+  }
+  const proxyApply = state && state.proxyApply || {};
+  return authorization.status === 'applied' &&
+    proxyApply.status === authorization.status &&
+    proxyApply.providerKey === authorization.providerKey &&
+    proxyApply.cookedPacSha256 === authorization.cookedPacSha256 &&
+    proxyApply.appliedAt === authorization.appliedAt;
+
+}
+
+async function createStartupProxyRestorePlan(state) {
+
+  const proxyApply = state.proxyApply || {};
+  const control = state.proxyControl || {};
+  if (proxyApply.status !== 'applied') {
+    return createStartupProxyRestoreSkip('persisted proxy intent is off', state);
+  }
+  if (control.controlledByThisExtension === true) {
+    return createStartupProxyRestoreSkip('proxy control is already restored', state);
+  }
+  if (control.levelOfControl !== 'controllable_by_this_extension') {
+    return createStartupProxyRestoreSkip('live proxy settings are not available', state);
+  }
+
+  const providerKey = state.currentPacProviderKey;
+  const provider = getProviderForState(state, providerKey);
+  const rawCache = state.pacCache || {};
+  const cookedCache = state.cookedPacCache || {};
+  if (
+    !providerKey ||
+    !provider ||
+    !proxyApply.appliedAt ||
+    proxyApply.levelOfControl !== 'controlled_by_this_extension' ||
+    proxyApply.providerKey !== providerKey ||
+    proxyApply.cookedPacSha256 !== cookedCache.cookedPacSha256 ||
+    cookedCache.providerKey !== providerKey ||
+    !cookedCache.cookedPacSha256 ||
+    !cookedCache.artifactRef ||
+    !cookedCache.sourceRawPacSha256 ||
+    !cookedCache.pacModsSha256 ||
+    rawCache.providerKey !== providerKey ||
+    rawCache.rawPacSha256 !== cookedCache.sourceRawPacSha256 ||
+    !rawCache.artifactRef
+  ) {
+    return createStartupProxyRestoreSkip(
+        'persisted PAC provenance is incomplete or mismatched',
+        state,
+    );
+  }
+
+  const stale = await getCookedPacStaleness(state);
+  if (stale.stale) {
+    return createStartupProxyRestoreSkip(
+        'persisted PAC provenance is stale',
+        state,
+    );
+  }
+  return {
+    allowed: true,
+    authorization: createStartupProxyRestoreAuthorization(state),
+    state,
+    workflow: Object.freeze({generation: state.pacWorkflowGeneration}),
+  };
+
+}
+
+async function reconcileProxyOwnershipOnWorkerStart(reconstructedState) {
+
+  const plan = await createStartupProxyRestorePlan(reconstructedState);
+  if (!plan.allowed) {
+    return plan;
+  }
+  const result = await applyCookedPacAndPersist(
+      {},
+      plan.workflow,
+      {
+        startupAuthorization: plan.authorization,
+        startupRestore: true,
+      },
+  );
+  return {
+    allowed: true,
+    result,
+    state: await mv3State.loadState(),
+  };
 
 }
 
@@ -472,6 +601,7 @@ async function addCustomPacProvider(params) {
 
 async function updateCustomPacProvider(params) {
 
+  invalidateStartupProxyRestoreFreshness();
   const key = String(params.key || '');
   if (mv3Providers.isBuiltInProviderKey(key)) {
     throw createProviderError(
@@ -556,6 +686,7 @@ async function updateCustomPacProvider(params) {
 
 async function deleteCustomPacProvider(params) {
 
+  invalidateStartupProxyRestoreFreshness();
   const key = String(params.key || '');
   if (mv3Providers.isBuiltInProviderKey(key)) {
     throw createProviderError(
@@ -655,6 +786,7 @@ const RPC_METHODS = Object.freeze({
 
   async setPacMods(params = {}) {
 
+    invalidateStartupProxyRestoreFreshness();
     cancelActiveProxyHealthCheck('proxy-configuration-changed');
     let state = await mv3State.saveRpcPacMods(params.pacMods, {
       ifResetProxyHealth(previousPacMods, nextPacMods) {
@@ -762,6 +894,7 @@ const RPC_METHODS = Object.freeze({
 
   async setCurrentPacProvider(params = {}) {
 
+    invalidateStartupProxyRestoreFreshness();
     const providerKey = params.providerKey === undefined ? null : params.providerKey;
     let ifProviderChanged = false;
     const state = await mv3State.updateStateAtomically((currentState) => {
@@ -965,8 +1098,9 @@ const RPC_METHODS = Object.freeze({
           'Periodic PAC update is already running.',
       );
     }
+    const workflow = await beginPacWorkflow();
     return runWithActionOperation('apply', async () => {
-      const result = await applyCookedPacAndPersist(params);
+      const result = await applyCookedPacAndPersist(params, workflow);
       await handleProxyOperationResult(result, 'Proxy apply failed.');
       await reconcileProxyHealthSupervisor({startupDelay: true});
       return result;
@@ -976,8 +1110,9 @@ const RPC_METHODS = Object.freeze({
 
   async clearProxy() {
 
+    const invalidation = invalidatePacWorkflowFreshness();
     return runWithActionOperation('clear', async () => {
-      const result = await clearProxyAndPersist();
+      const result = await clearProxyAndPersist(invalidation);
       await handleProxyOperationResult(result, 'Proxy clear failed.');
       await reconcileProxyHealthSupervisor({startupDelay: false});
       return result;
@@ -1291,9 +1426,10 @@ function initializeAutomaticPacUpdates(trigger) {
 async function recoverActionStatusOnWorkerStart() {
 
   const refreshed = await refreshProxyControlAndPersistWithState();
+  const ownership = await reconcileProxyOwnershipOnWorkerStart(refreshed.state);
   const state = await initializeProxyHealthSupervisor(
       'service-worker-startup',
-      refreshed.state,
+      ownership.state,
   );
   return requestActionStatusRefresh({state});
 
@@ -1417,6 +1553,7 @@ async function updatePopupDraft(params = {}) {
 
 async function applyPopupChanges(params = {}) {
 
+  invalidateStartupProxyRestoreFreshness();
   const operation = params.operation || 'apply';
   if (!['save', 'updatePac', 'apply'].includes(operation)) {
     throw new TypeError('Unsupported popup operation.');
@@ -2736,6 +2873,10 @@ async function assertPacApplyIsFresh(operation, fingerprint) {
   if (
     !ifPacApplyOperationIsFresh(operation) ||
     !ifPacWorkflowIsFresh(operation.workflow, latestState) ||
+    !ifStartupProxyRestoreAuthorizationMatches(
+        operation.startupAuthorization,
+        latestState,
+    ) ||
     !ifPacApplyFingerprintsMatch(
         fingerprint,
         createPacApplyFingerprint(latestState),
@@ -2784,6 +2925,41 @@ function createProxyApplyState(status, metadata = {}) {
     error: metadata.error || null,
     warnings: metadata.warnings || [],
   };
+
+}
+
+async function assertCookedPacArtifactMatchesCache(artifact, cache) {
+
+  const metadataMatches = Boolean(
+      artifact &&
+      artifact.artifactRef === cache.artifactRef &&
+      artifact.providerKey === cache.providerKey &&
+      artifact.cookedPacSha256 === cache.cookedPacSha256 &&
+      artifact.sourceRawPacSha256 === cache.sourceRawPacSha256 &&
+      artifact.pacModsSha256 === cache.pacModsSha256 &&
+      artifact.cookedPacSize === cache.cookedPacSize,
+  );
+  if (!metadataMatches) {
+    throw createStructuredError(
+        'PAC_ARTIFACT_MISMATCH',
+        'Cooked PAC artifact provenance does not match current PAC metadata.',
+        {
+          providerKey: cache.providerKey,
+          cookedPacSha256: cache.cookedPacSha256,
+        },
+    );
+  }
+  const actualSha256 = await mv3Hash.sha256Hex(artifact.cookedPacData);
+  if (actualSha256 !== cache.cookedPacSha256) {
+    throw createStructuredError(
+        'PAC_ARTIFACT_MISMATCH',
+        'Cooked PAC artifact content does not match its recorded hash.',
+        {
+          providerKey: cache.providerKey,
+          cookedPacSha256: cache.cookedPacSha256,
+        },
+    );
+  }
 
 }
 
@@ -3849,13 +4025,17 @@ async function persistProxyFailure(
 
 }
 
-async function applyCookedPacAndPersist(params = {}, workflow = null) {
+async function applyCookedPacAndPersist(
+    params = {},
+    workflow = null,
+    operationOptions = {},
+) {
 
   const currentWorkflow = workflow || await beginPacWorkflow();
   if (!await getFreshPacWorkflowState(currentWorkflow)) {
     return createPacApplyStaleResult();
   }
-  const operation = beginPacApplyOperation(currentWorkflow);
+  const operation = beginPacApplyOperation(currentWorkflow, operationOptions);
   return enqueuePacProxyOperation(() =>
     applyCookedPacAndPersistForOperation(params, operation),
   ).finally(() => {
@@ -3869,7 +4049,14 @@ async function applyCookedPacAndPersist(params = {}, workflow = null) {
 async function applyCookedPacAndPersistForOperation(params, operation) {
 
   const state = await getFreshPacWorkflowState(operation.workflow);
-  if (!state || !ifPacApplyOperationIsFresh(operation)) {
+  if (
+    !state ||
+    !ifPacApplyOperationIsFresh(operation) ||
+    !ifStartupProxyRestoreAuthorizationMatches(
+        operation.startupAuthorization,
+        state,
+    )
+  ) {
     return createPacApplyStaleResult();
   }
   const providerKey = state.currentPacProviderKey;
@@ -3968,6 +4155,10 @@ async function applyCookedPacAndPersistForOperation(params, operation) {
           {providerKey, cookedPacSha256: cache.cookedPacSha256},
       );
     }
+    await assertCookedPacArtifactMatchesCache(cookedArtifact, cache);
+    if (!ifPacApplyOperationIsFresh(operation)) {
+      return createPacApplyStaleResult();
+    }
     await mv3ProxySettings.applyPacScript({
       cookedPacData: cookedArtifact.cookedPacData,
       beforeSet: () => assertPacApplyIsFresh(operation, fingerprint),
@@ -4056,9 +4247,11 @@ async function applyCookedPacAndPersistForOperation(params, operation) {
 
 }
 
-function clearProxyAndPersist() {
+function clearProxyAndPersist(
+    invalidation = invalidatePacWorkflowFreshness(),
+) {
 
-  const invalidation = invalidatePacWorkflowFreshness();
+  invalidatePacApplyFreshness();
   return enqueuePacProxyOperation(async () => {
     await invalidation;
     return clearProxyAndPersistForOperation();

--- a/extensions/chromium/runet-censorship-bypass/src/extension-chromium-mv3/test/proxy-ownership-startup-recovery.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-chromium-mv3/test/proxy-ownership-startup-recovery.js
@@ -1,0 +1,327 @@
+'use strict';
+
+/* eslint-env node, mocha */
+
+const Crypto = require('crypto');
+const Chai = require('chai');
+const Mocha = require('mocha');
+const {createRuntimeHarness} = require('./runtime-performance-harness');
+
+const SYSTEM_PROXY_DETAILS = Object.freeze({
+  levelOfControl: 'controllable_by_this_extension',
+  value: {mode: 'system'},
+});
+
+function sha256(text) {
+
+  return Crypto.createHash('sha256').update(text).digest('hex');
+
+}
+
+async function createAppliedState(options = {}) {
+
+  const harness = await createRuntimeHarness(options);
+  return harness.getState();
+
+}
+
+function restartAppliedState(state, options = {}) {
+
+  return createRuntimeHarness(Object.assign({
+    initialProxyDetails: SYSTEM_PROXY_DETAILS,
+    initialState: state,
+    pacMods: state.pacMods,
+  }, options));
+
+}
+
+function createTorPacMods() {
+
+  return {
+    torBrowser: {enabled: true, port: 9150},
+    exceptions: [{
+      pattern: 'audit.example',
+      action: 'PROXY',
+      enabled: true,
+    }],
+  };
+
+}
+
+Mocha.describe('MV3 startup proxy-ownership recovery', function() {
+  Mocha.it('restores an applied PAC when live system proxy is controllable',
+      async function() {
+
+        const state = await createAppliedState();
+        const harness = await restartAppliedState(state);
+
+        Chai.expect(harness.counts.proxySettingsWrites).to.equal(1);
+        Chai.expect(harness.getProxyDetails().levelOfControl)
+            .to.equal('controlled_by_this_extension');
+        Chai.expect(harness.getProxyDetails().value.mode).to.equal('pac_script');
+        Chai.expect(harness.getState().proxyApply.status).to.equal('applied');
+
+      });
+
+  Mocha.it('restores the exact current artifact without downloading or cooking',
+      async function() {
+
+        const state = await createAppliedState();
+        const harness = await restartAppliedState(state);
+        const values = harness.getProxySettingsSetValues();
+
+        Chai.expect(values).to.have.length(1);
+        Chai.expect(sha256(values[0].pacScript.data))
+            .to.equal(state.proxyApply.cookedPacSha256);
+        Chai.expect(state.proxyApply.cookedPacSha256)
+            .to.equal(state.cookedPacCache.cookedPacSha256);
+        Chai.expect(harness.counts.pacDownloads).to.equal(0);
+        Chai.expect(harness.counts.pacCooks).to.equal(0);
+
+      });
+
+  Mocha.it('does not restore persisted cleared intent', async function() {
+
+    const state = await createAppliedState();
+    state.proxyApply.status = 'cleared';
+    state.proxyApply.clearedAt = state.proxyApply.appliedAt + 1;
+    const harness = await restartAppliedState(state);
+
+    Chai.expect(harness.counts.proxySettingsWrites).to.equal(0);
+    Chai.expect(harness.getProxyDetails().value.mode).to.equal('system');
+    Chai.expect(harness.getState().proxyApply.status).to.equal('cleared');
+
+  });
+
+  Mocha.it('does not restore without a previous successful Apply',
+      async function() {
+
+        const state = await createAppliedState();
+        state.proxyApply = {status: 'idle'};
+        const harness = await restartAppliedState(state);
+
+        Chai.expect(harness.counts.proxySettingsWrites).to.equal(0);
+        Chai.expect(harness.getProxyDetails().value.mode).to.equal('system');
+        Chai.expect(harness.getState().proxyApply.status).to.equal('idle');
+
+      });
+
+  Mocha.it('rejects mismatched applied PAC provenance', async function() {
+
+    const state = await createAppliedState();
+    state.proxyApply.cookedPacSha256 = 'stale-applied-pac-sha256';
+    const harness = await restartAppliedState(state);
+
+    Chai.expect(harness.counts.proxySettingsWrites).to.equal(0);
+    Chai.expect(harness.getProxyDetails().value.mode).to.equal('system');
+    Chai.expect(harness.getState().proxyApply.cookedPacSha256)
+        .to.equal('stale-applied-pac-sha256');
+
+  });
+
+  Mocha.it('never takes control from another extension', async function() {
+
+    const state = await createAppliedState();
+    const harness = await restartAppliedState(state, {
+      initialProxyDetails: {
+        levelOfControl: 'controlled_by_other_extensions',
+        value: {mode: 'fixed_servers'},
+      },
+    });
+
+    Chai.expect(harness.counts.proxySettingsWrites).to.equal(0);
+    Chai.expect(harness.getProxyDetails().levelOfControl)
+        .to.equal('controlled_by_other_extensions');
+    Chai.expect(harness.getState().proxyControl.canControl).to.equal(false);
+
+  });
+
+  Mocha.it('does not write proxy settings when policy makes them uncontrollable',
+      async function() {
+
+        const state = await createAppliedState();
+        const harness = await restartAppliedState(state, {
+          initialProxyDetails: {
+            levelOfControl: 'not_controllable',
+            value: {mode: 'system'},
+          },
+        });
+
+        Chai.expect(harness.counts.proxySettingsWrites).to.equal(0);
+        Chai.expect(harness.getState().proxyControl.levelOfControl)
+            .to.equal('not_controllable');
+
+      });
+
+  Mocha.it('does not redundantly reapply while already controlling the PAC',
+      async function() {
+
+        const state = await createAppliedState();
+        const harness = await createRuntimeHarness({
+          initialState: state,
+          pacMods: state.pacMods,
+        });
+
+        Chai.expect(harness.counts.proxySettingsWrites).to.equal(0);
+        Chai.expect(harness.getState().proxyControl.controlledByThisExtension)
+            .to.equal(true);
+
+      });
+
+  Mocha.it('does not reapply on worker restart or duplicate startup events',
+      async function() {
+
+        const state = await createAppliedState();
+        const first = await restartAppliedState(state);
+        const second = await createRuntimeHarness({
+          initialProxyDetails: first.getProxyDetails(),
+          initialState: first.getState(),
+          pacMods: first.getState().pacMods,
+        });
+
+        second.events.startup.dispatch();
+        second.events.startup.dispatch();
+        await second.callRpc('getState');
+
+        Chai.expect(first.counts.proxySettingsWrites).to.equal(1);
+        Chai.expect(second.counts.proxySettingsWrites).to.equal(0);
+
+      });
+
+  Mocha.it('lets Clear during startup reconciliation win', async function() {
+
+    const state = await createAppliedState();
+    let clear;
+    const harness = await restartAppliedState(state, {
+      onProxySettingsRead(context) {
+
+        clear = context.__runtimeAudit.RPC_METHODS.clearProxy();
+
+      },
+    });
+    const result = await clear;
+
+    Chai.expect(result).to.include({ok: true, status: 'cleared'});
+    Chai.expect(harness.getState().proxyApply.status).to.equal('cleared');
+    Chai.expect(harness.getProxyDetails().value.mode).to.equal('direct');
+    Chai.expect(harness.counts.proxySettingsWrites).to.equal(0);
+    Chai.expect(harness.counts.proxySettingsClears).to.equal(1);
+
+  });
+
+  Mocha.it('lets a newer manual Apply supersede startup restoration',
+      async function() {
+
+        const state = await createAppliedState();
+        let manualApply;
+        const harness = await restartAppliedState(state, {
+          onProxySettingsRead(context) {
+
+            manualApply = context.__runtimeAudit.RPC_METHODS.applyCookedPac({});
+
+          },
+        });
+        const result = await manualApply;
+
+        Chai.expect(result).to.include({ok: true, status: 'applied'});
+        Chai.expect(harness.counts.proxySettingsWrites).to.equal(1);
+        Chai.expect(harness.getState().pacWorkflowGeneration)
+            .to.equal(state.pacWorkflowGeneration + 1);
+        Chai.expect(harness.getState().proxyApply.status).to.equal('applied');
+
+      });
+
+  Mocha.it('invalidates restoration when proxy configuration changes',
+      async function() {
+
+        const state = await createAppliedState();
+        let configurationChange;
+        const harness = await restartAppliedState(state, {
+          onProxySettingsRead(context) {
+
+            const model = context.mv3PacMods.serializePacModsForRpc(
+                state.pacMods,
+                state.pacModsRevision,
+            );
+            model.exceptions = [{
+              pattern: 'configuration-change.example',
+              action: 'DIRECT',
+              enabled: true,
+            }];
+            configurationChange =
+              context.__runtimeAudit.RPC_METHODS.setPacMods({pacMods: model});
+
+          },
+        });
+        await configurationChange;
+
+        Chai.expect(harness.counts.proxySettingsWrites).to.equal(0);
+        Chai.expect(harness.getState().pacWorkflowGeneration)
+            .to.equal(state.pacWorkflowGeneration + 1);
+        Chai.expect(harness.getProxyDetails().value.mode).to.equal('system');
+
+      });
+
+  Mocha.it('records a failed restoration without claiming success',
+      async function() {
+
+        const state = await createAppliedState();
+        const harness = await restartAppliedState(state, {
+          initialProxySettingsSetError: 'Synthetic startup restoration failure.',
+        });
+
+        Chai.expect(harness.counts.proxySettingsWrites).to.equal(1);
+        Chai.expect(harness.getState().proxyApply.status).to.equal('error');
+        Chai.expect(harness.getState().proxyApply.error.code)
+            .to.equal('PROXY_SET_FAILED');
+        Chai.expect(harness.getState().proxyControl.controlledByThisExtension)
+            .to.equal(false);
+        Chai.expect(harness.getProxyDetails().value.mode).to.equal('system');
+        Chai.expect(harness.getState().proxyHealth.status).to.equal('unknown');
+        Chai.expect(harness.getAlarms().filter((alarm) =>
+          alarm.name === harness.context.mv3ProxyHealth.ALARM_NAME,
+        )).to.have.length(0);
+
+      });
+
+  Mocha.it('makes the existing health supervisor relevant after restoration',
+      async function() {
+
+        const state = await createAppliedState({pacMods: createTorPacMods()});
+        state.proxyHealth.targetOrigin = 'https://audit.example';
+        const harness = await restartAppliedState(state, {
+          initialSessionStorage: {},
+        });
+        const health = harness.getState().proxyHealth;
+
+        Chai.expect(health).to.include({
+          status: 'unknown',
+          candidateType: 'torBrowser',
+          candidateEndpoint: '127.0.0.1:9150',
+          targetOrigin: 'https://audit.example',
+        });
+        Chai.expect(health.nextCheckAt).to.be.a('number');
+        Chai.expect(harness.counts.proxySettingsWrites).to.equal(1);
+
+      });
+
+  Mocha.it('schedules exactly one normal startup health alarm after restoration',
+      async function() {
+
+        const state = await createAppliedState({pacMods: createTorPacMods()});
+        state.proxyHealth.targetOrigin = 'https://audit.example';
+        const harness = await restartAppliedState(state, {
+          initialSessionStorage: {},
+        });
+        const alarmName = harness.context.mv3ProxyHealth.ALARM_NAME;
+        const healthAlarms = harness.getAlarms().filter((alarm) =>
+          alarm.name === alarmName,
+        );
+
+        Chai.expect(healthAlarms).to.have.length(1);
+        Chai.expect(harness.getAlarmCreateCount(alarmName)).to.equal(1);
+        Chai.expect(healthAlarms[0].scheduledTime)
+            .to.equal(harness.getState().proxyHealth.nextCheckAt);
+
+      });
+});

--- a/extensions/chromium/runet-censorship-bypass/src/extension-chromium-mv3/test/runtime-performance-harness.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-chromium-mv3/test/runtime-performance-harness.js
@@ -119,6 +119,7 @@ async function createRuntimeHarness(options = {}) {
   const storageData = {};
   const sessionStorageData = clone(options.initialSessionStorage || {});
   const alarms = new Map();
+  const alarmCreateNames = [];
   (options.initialAlarms || []).forEach((alarm) => {
     alarms.set(alarm.name, clone(alarm));
   });
@@ -163,17 +164,19 @@ async function createRuntimeHarness(options = {}) {
   let markPacCookStarted = null;
   let cookedArtifactReads = 0;
   let cookedArtifactReadGate = null;
+  let ifCookedArtifactReadHookCalled = false;
+  let ifProxySettingsReadHookCalled = false;
   let proxySettingsReadGate = null;
   let proxySettingsSetGate = null;
-  let nextProxySettingsSetError = null;
+  let nextProxySettingsSetError = options.initialProxySettingsSetError || null;
   const proxySettingsSetValues = [];
-  let proxyDetails = {
+  let proxyDetails = clone(options.initialProxyDetails || {
     levelOfControl: 'controlled_by_this_extension',
     value: {
       mode: 'pac_script',
       pacScript: {data: 'installed PAC', mandatory: false},
     },
-  };
+  });
   const NativeDate = Date;
   const RuntimeDate = options.clock ? class extends NativeDate {
     constructor(...args) {
@@ -230,6 +233,7 @@ async function createRuntimeHarness(options = {}) {
       create(name, details) {
 
         ++counts.alarmCreates;
+        alarmCreateNames.push(name);
         alarms.set(name, Object.assign({
           name,
           scheduledTime: details.when,
@@ -279,6 +283,13 @@ async function createRuntimeHarness(options = {}) {
         get(details, callback) {
 
           ++counts.proxySettingsReads;
+          if (
+            !ifProxySettingsReadHookCalled &&
+            typeof options.onProxySettingsRead === 'function'
+          ) {
+            ifProxySettingsReadHookCalled = true;
+            options.onProxySettingsRead(context);
+          }
           if (
             proxySettingsReadGate &&
             counts.proxySettingsReads === proxySettingsReadGate.target
@@ -699,6 +710,13 @@ async function createRuntimeHarness(options = {}) {
       countIndexedDb('read');
       ++cookedArtifactReads;
       if (
+        !ifCookedArtifactReadHookCalled &&
+        typeof options.onCookedArtifactRead === 'function'
+      ) {
+        ifCookedArtifactReadHookCalled = true;
+        options.onCookedArtifactRead(context);
+      }
+      if (
         cookedArtifactReadGate &&
         cookedArtifactReads >= cookedArtifactReadGate.target
       ) {
@@ -763,6 +781,7 @@ async function createRuntimeHarness(options = {}) {
     '  executePeriodicUpdatePipeline,\n' +
     '  handleProxySettingsChanged,\n' +
     '  initializeProxyHealthSupervisor,\n' +
+    '  reconcileProxyOwnershipOnWorkerStart,\n' +
     '  reconcileProxyHealthSupervisor,\n' +
     '  recordProxyHealthFailure,\n' +
     '  runAutomaticProxyHealthCheck,\n' +
@@ -943,6 +962,11 @@ async function createRuntimeHarness(options = {}) {
     getAlarms() {
 
       return Array.from(alarms.values()).map(clone);
+
+    },
+    getAlarmCreateCount(name) {
+
+      return alarmCreateNames.filter((createdName) => createdName === name).length;
 
     },
     getSessionStorage() {

--- a/extensions/chromium/runet-censorship-bypass/src/extension-chromium-mv3/test/runtime-performance.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-chromium-mv3/test/runtime-performance.js
@@ -285,7 +285,7 @@ Mocha.describe('MV3 runtime performance operation counts', function() {
           tabGets: 2,
           pacDownloads: 1,
           pacCooks: 1,
-          hashOperations: 8,
+          hashOperations: 9,
           proxySettingsWrites: 1,
           actionCalls: 8,
         });


### PR DESCRIPTION
## Summary

Chromium/Brave can restart with durable `proxyApply.status = applied` while live proxy settings have fallen back to `system`. This change reconciles that mismatch during service-worker startup and restores ownership only through the existing guarded Apply pipeline.

Restoration requires the previously successful Apply record, selected provider, current raw/cooked artifact identities, PAC-modifier hash, recorded cooked PAC hash, current workflow generation, and `controllable_by_this_extension`. The IndexedDB artifact metadata and actual PAC-body SHA-256 are verified before the existing proxy setter runs.

The extension skips restoration when intent is cleared/off, provenance is stale or incomplete, configuration changed, it already owns the PAC, or Chromium reports `controlled_by_other_extensions` / `not_controllable`. Clear, newer Apply, and config mutation invalidate an older startup restoration; Clear wins. A failed restore records the existing recoverable Apply error state without claiming ownership or scheduling health work.

After a successful restore, the existing proxy-health supervisor receives the reconstructed owning state and applies its normal startup/stale policy. No Tor-specific recovery path was added; Tor Browser remains exactly `127.0.0.1:9150` with no `9050` fallback.

## Verification

- `npm ci --prefix ./extensions/chromium/runet-censorship-bypass`
- PAC regression: 26 passing
- MV3 suite: 320 passing, twice
- Aggregate suite: 323 passing
- MV3 lint passed
- MV2 and MV3 builds passed
- 32 packaged runtime icons and 76-file package integrity passed
- No manifest, permission, or dependency changes

Packaged Brave QA used Brave 1.93.134 / Chromium 151 and the exact local MV3 build. Three full Tor-before-Brave restarts restored the identical cooked PAC SHA-256, live PAC ownership, popup/options state, and healthy `9150`. Brave-before-Tor restored ownership, the supervisor's single startup alarm recorded a real `ERR_PROXY_CONNECTION_FAILED` on `9150`, and its scheduled retry recovered automatically after Tor started; only the long TTL/backoff clocks were accelerated, with no UI Apply/Check during recovery. A temporary external proxy extension produced `controlled_by_other_extensions`; this extension did not write, its `appliedAt` remained unchanged, and health stayed irrelevant. Clearing through the real popup followed by a full restart remained `system` with no PAC resurrection.

## Beta 2

This startup ownership fix is required for beta2. Do not create beta2 until this PR is merged and the release-candidate checks are run separately.