### PR TITLE
Add aggregate MV3 verification gate

### DIFF
--- a/.github/workflows/mv3.yml
+++ b/.github/workflows/mv3.yml
@@ -52,6 +52,9 @@ jobs:
       - name: Build MV3
         run: npm --prefix ./extensions/chromium/runet-censorship-bypass run build:mv3
 
+      - name: Run aggregate verification
+        run: npm --prefix ./extensions/chromium/runet-censorship-bypass run verify
+
       - name: Validate exact MV3 output
         run: |
           package_dir='./extensions/chromium/runet-censorship-bypass/build/extension-chromium-mv3'


### PR DESCRIPTION
## Summary

The trusted MV3 workflow already runs the individual PAC, MV3, lint, build, exact-output, tracked-worktree, and package-integrity checks. Those checks passed on the previous trusted-main run, but beta2 release qualification also requires the aggregate extension `verify` script and the workflow previously omitted that command.

This PR adds one explicit `Run aggregate verification` step:

```text
npm --prefix ./extensions/chromium/runet-censorship-bypass run verify
```

The step is defense-in-depth and runs before the existing exact-output/worktree validation and trusted-main artifact upload. Existing checks and upload conditions remain unchanged. Runtime and package contents are unchanged.

## Local verification

- Aggregate verify: 323 passing
- PAC: 26 passing
- MV3: 320 passing
- MV3 lint: passed
- MV3 build: passed
- Runtime icons: 32 verified
- Package integrity: 76 files
- `git diff --check`: passed