### PR TITLE
Prepare beta3 version candidate

### DIFF
--- a/extensions/chromium/runet-censorship-bypass/src/extension-chromium-mv3/test/options-ui.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-chromium-mv3/test/options-ui.js
@@ -577,7 +577,7 @@ async function createHarness(options = {}) {
       runtime: {
         getManifest() {
 
-          return {version: '0.0.2.0', version_name: '0.0.2.00'};
+          return {version: '0.0.2.1', version_name: '0.0.2.01'};
 
         },
       },
@@ -707,7 +707,7 @@ describe('MV3 options UI', function() {
         ]);
         expect(harness.root.textContent).to.include('Overview');
         expect(harness.root.textContent).to.include('Routing sources');
-        expect(harness.root.textContent).to.include('0.0.2.00');
+        expect(harness.root.textContent).to.include('0.0.2.01');
         expect(harness.root.textContent).to.include('Limited MV3 beta');
         expect(harness.root.textContent).not.to.include('MV3 migration:');
         const aboutLinks = harness.root.querySelectorAll('.about-links a');

--- a/extensions/chromium/runet-censorship-bypass/src/extension-chromium-mv3/test/verify-package-integrity.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-chromium-mv3/test/verify-package-integrity.js
@@ -22,6 +22,8 @@ const COMMON_SOURCE_ROOT = Path.resolve(
     'extension-common',
 );
 const MV3_LOCALES = Object.freeze(['en', 'ru']);
+const EXPECTED_MV3_VERSION = '0.0.2.1';
+const EXPECTED_MV3_VERSION_NAME = '0.0.2.01';
 
 const ALLOWED_RUNTIME_DIRECTORIES = new Set([
   'background/vendor/tldts/dist',
@@ -215,6 +217,23 @@ function verifyPackagedLocalesMatchMv3Sources(
 
 }
 
+function verifyPackagedManifestIdentity(root) {
+
+  const manifestPath = Path.join(root, 'manifest.json');
+  Assert.ok(
+      Fs.existsSync(manifestPath),
+      `Missing MV3 manifest: ${manifestPath}`,
+  );
+  const manifest = JSON.parse(Fs.readFileSync(manifestPath, 'utf8'));
+  Assert.strictEqual(manifest.version, EXPECTED_MV3_VERSION);
+  Assert.strictEqual(manifest.version_name, EXPECTED_MV3_VERSION_NAME);
+  return {
+    version: manifest.version,
+    versionName: manifest.version_name,
+  };
+
+}
+
 if (typeof describe === 'function') {
   describe('MV3 package integrity', function() {
 
@@ -318,8 +337,13 @@ if (typeof describe === 'function') {
 
 if (require.main === module) {
   const fileCount = verifyPackageIntegrity(PACKAGED_MV3_ROOT);
+  const manifestIdentity = verifyPackagedManifestIdentity(PACKAGED_MV3_ROOT);
   const localeCount = verifyPackagedLocalesMatchMv3Sources(PACKAGED_MV3_ROOT);
   console.log(`Verified MV3 package integrity: ${fileCount} files.`);
+  console.log(
+      'Verified packaged MV3 version: ' +
+      `${manifestIdentity.version} (${manifestIdentity.versionName}).`,
+  );
   console.log(
       `Verified packaged MV3 locales: ${localeCount} source-identical files.`,
   );
@@ -331,5 +355,6 @@ module.exports = {
   listPackageEntries,
   PACKAGED_MV3_ROOT,
   verifyPackageIntegrity,
+  verifyPackagedManifestIdentity,
   verifyPackagedLocalesMatchMv3Sources,
 };

--- a/extensions/chromium/runet-censorship-bypass/src/templates-data.js
+++ b/extensions/chromium/runet-censorship-bypass/src/templates-data.js
@@ -41,7 +41,8 @@ exports.contexts.mini = Object.assign({}, commonContext, {
 });
 
 exports.contexts.chromiumMv3 = Object.assign({}, commonContext, {
-  storeVersion: '2.0',
+  version: '2.01',
+  storeVersion: '2.1',
   versionSuffix: '-mv3',
   nameSuffixEn: '',
   nameSuffixRu: '',


### PR DESCRIPTION
### Version

- `version` 0.0.2.0 -> 0.0.2.1
- `version_name` 0.0.2.00 -> 0.0.2.01
- future tag `v0.0.2.1-beta3`

### Reason

Chromium numeric `version` must supersede beta2; a GitHub beta3 suffix alone is insufficient.

### Runtime impact

The canonical release build was compared byte-for-byte with trusted artifact `9403631620`:

- 70 candidate paths vs 70 trusted paths
- added: 0
- missing: 0
- modified packaged path: `manifest.json` only
- unchanged: 69
- old manifest SHA-256: `c47e78af79989423b69504dc009155ca7b944836494f372d15380bbab8703743`
- candidate manifest SHA-256: `026f23223d92e524817b17176511d526de5109e60760d67236275682bb06d648`

After excluding `version` and `version_name`, the packaged manifests are identical. Consecutive canonical builds produced identical hashes for all 70 paths. No permissions, host permissions, runtime behavior, dependencies, PAC/routing, UI, or release metadata changed.

### Verification

- documentation integrity: passed (39 Markdown files, 109 relative links, 16 images, 73 unique external URLs)
- PAC: 26 passing
- MV3: 321 passing twice
- aggregate: 337 passing
- cleanup/tooling: 9 passing
- MV3 lint: passed
- MV2 build: passed
- MV3 build: passed
- runtime icons: 32 verified
- package integrity: 70 files
- packaged version assertion: 0.0.2.1 / 0.0.2.01
- production npm audit: 0
- full npm audit: 3, unchanged and Mocha/dev-only
- version ordering: 0.0.2.1 > 0.0.2.0 under Chromium numeric manifest semantics
- beta2-profile upgrade smoke: passed in Brave 151.0.7922.169; persisted provider, rules, exact 127.0.0.1:9150 proxy endpoint, Apply/Clear state, popup/options, and restart state remained valid with no runtime errors
- `git diff --check`: passed

### Publication

- beta3 has **NOT** been published
- README and `docs/release-current.json` intentionally still point to beta2
- no tag, release, ZIP, or checksum asset is created by this PR
- release/tag/assets will be created only from the trusted post-merge artifact
- intended future ZIP: `runet-censorship-bypass-mv3-0.0.2.1-beta3-5102c8e.zip`
- intended future checksum: matching `.sha256.txt`