### PR TITLE
Update documentation for beta3

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -12,7 +12,7 @@ body:
     id: version
     attributes:
       label: Версия расширения или commit
-      placeholder: v0.0.2.0-beta2
+      placeholder: v0.0.2.1-beta3
     validations:
       required: true
   - type: input

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ PAC-правилам. Текущий продукт использует Manifes
 всего на Brave.
 
 > **Статус: ограниченная бета.** Текущий публичный выпуск —
-> [`v0.0.2.0-beta2`](https://github.com/aVitomin/runet-censorship-bypass-mv3/releases/tag/v0.0.2.0-beta2).
+> [`v0.0.2.1-beta3`](https://github.com/aVitomin/runet-censorship-bypass-mv3/releases/tag/v0.0.2.1-beta3).
 > Он предназначен для ручной установки и тестирования, а не объявлен стабильным
 > магазинным выпуском.
 
@@ -19,20 +19,20 @@ PAC-правилам. Текущий продукт использует Manifes
 
 ## Текущий выпуск
 
-- Версия: [`v0.0.2.0-beta2`](https://github.com/aVitomin/runet-censorship-bypass-mv3/releases/tag/v0.0.2.0-beta2)
-- Архив (356 944 байта):
-  [`runet-censorship-bypass-mv3-0.0.2.0-beta2-b6b5cd6.zip`](https://github.com/aVitomin/runet-censorship-bypass-mv3/releases/download/v0.0.2.0-beta2/runet-censorship-bypass-mv3-0.0.2.0-beta2-b6b5cd6.zip)
+- Версия: [`v0.0.2.1-beta3`](https://github.com/aVitomin/runet-censorship-bypass-mv3/releases/tag/v0.0.2.1-beta3)
+- Архив (353 022 байта):
+  [`runet-censorship-bypass-mv3-0.0.2.1-beta3-323cd19.zip`](https://github.com/aVitomin/runet-censorship-bypass-mv3/releases/download/v0.0.2.1-beta3/runet-censorship-bypass-mv3-0.0.2.1-beta3-323cd19.zip)
 - SHA-256:
-  `ad9462f19b02c64f2a2e2cff0363612bd7467f978608cd9dfe183b26899915ef`
+  `d3248319705a69c335f7b69f56e3afe95856756233dfff6e6de02c203d9d99e5`
 - Опубликованный файл контрольной суммы:
-  [`runet-censorship-bypass-mv3-0.0.2.0-beta2-b6b5cd6.sha256.txt`](https://github.com/aVitomin/runet-censorship-bypass-mv3/releases/download/v0.0.2.0-beta2/runet-censorship-bypass-mv3-0.0.2.0-beta2-b6b5cd6.sha256.txt)
+  [`runet-censorship-bypass-mv3-0.0.2.1-beta3-323cd19.sha256.txt`](https://github.com/aVitomin/runet-censorship-bypass-mv3/releases/download/v0.0.2.1-beta3/runet-censorship-bypass-mv3-0.0.2.1-beta3-323cd19.sha256.txt)
 - Установка: [пошаговая инструкция](docs/user/INSTALLATION.md)
 
 <details>
 <summary>English summary</summary>
 
 Runet Censorship Bypass is a limited-beta Chromium Manifest V3 extension for
-selective PAC-based routing. The latest public beta is `v0.0.2.0-beta2`. Its
+selective PAC-based routing. The latest public beta is `v0.0.2.1-beta3`. Its
 exact archive was tested in Brave; stable Google Chrome was not available for
 final validation. Other Chromium-compatible browsers are not independently
 verified. Install the unpacked ZIP from this repository's release page.
@@ -41,6 +41,14 @@ Firefox is not part of the current MV3 release. See the
 [privacy and security notes](docs/user/PRIVACY_AND_SECURITY.md).
 
 </details>
+
+## Что нового в beta3
+
+- Улучшена информация о проекте и ссылки на репозиторий, выпуски, сообщения об
+  ошибках, лицензию и upstream.
+- Удалены дублирующие элементы popup/options, устаревшие диагностические и
+  миграционные элементы, а также недостижимые страницы-заглушки.
+- Очищена английская и русская локализация; пакет сокращён с 76 до 70 файлов.
 
 ## Интерфейс
 
@@ -71,7 +79,7 @@ Firefox is not part of the current MV3 release. See the
 - Архитектура Manifest V3 с восстанавливаемым service worker.
 - Русский и английский интерфейс.
 
-## Поведение beta2
+## Надёжность, уже включённая в beta2
 
 - После полного перезапуска Chromium/Brave ранее применённый PAC безопасно
   восстанавливается только при совпадении сохранённой конфигурации, происхождения
@@ -86,7 +94,7 @@ Firefox is not part of the current MV3 release. See the
 
 ## Установка
 
-1. Откройте [страницу `v0.0.2.0-beta2`](https://github.com/aVitomin/runet-censorship-bypass-mv3/releases/tag/v0.0.2.0-beta2)
+1. Откройте [страницу `v0.0.2.1-beta3`](https://github.com/aVitomin/runet-censorship-bypass-mv3/releases/tag/v0.0.2.1-beta3)
    и скачайте указанный выше ZIP-архив текущего выпуска.
 2. При необходимости сверьте SHA-256 с приложенным файлом `*.sha256.txt`.
 3. Полностью распакуйте архив в постоянную папку.
@@ -127,9 +135,9 @@ Firefox is not part of the current MV3 release. See the
 
 | Браузер | Текущий статус |
 | --- | --- |
-| Brave | Точный архив beta2 прошёл restart, автоматическое восстановление Tor Browser на порту 9150, Clear/restart, popup и options smoke QA в Brave 1.93.134 / Chromium 151.0.7922.108. |
+| Brave | Точный архив beta3 прошёл обновление профиля beta2, Apply с точным endpoint `127.0.0.1:9150`, Clear/restart, popup и options smoke QA в Chromium 151.0.7922.169. |
 | Другие Chromium-совместимые браузеры | Ожидается совместимость с необходимыми MV3 API; требуется проверка конкретного браузера и версии. |
-| Google Chrome Stable | Финальная beta2 не была отдельно проверена в стабильном Chrome; стабильная Chrome-валидация не заявляется. |
+| Google Chrome Stable | Финальная beta3 не была отдельно проверена в стабильном Chrome; стабильная Chrome-валидация не заявляется. |
 | Firefox | Не входит в текущий выпуск MV3. |
 
 ## Безопасность и приватность
@@ -146,7 +154,7 @@ Firefox is not part of the current MV3 release. See the
 - Расширение проверяет владельца настройки прокси и не должно молча
   перезаписывать управление другого расширения или политики.
 
-Известные границы beta2: PAC применяется с `mandatory: false`; реальный обмен
+Известные границы beta3: PAC применяется с `mandatory: false`; реальный обмен
 с внешним аутентифицируемым прокси покрыт не полностью; Chromium сохраняет
 узкую нативную границу времени между последней проверкой владельца и применением
 настройки; ручная установка требует ручных обновлений.

--- a/docs/release-current.json
+++ b/docs/release-current.json
@@ -1,12 +1,12 @@
 {
-  "versionName": "0.0.2.0-beta2",
-  "tag": "v0.0.2.0-beta2",
-  "releaseUrl": "https://github.com/aVitomin/runet-censorship-bypass-mv3/releases/tag/v0.0.2.0-beta2",
-  "targetCommit": "b6b5cd6b0db9e206299266efd47eb8fefe8fe098",
+  "versionName": "0.0.2.1-beta3",
+  "tag": "v0.0.2.1-beta3",
+  "releaseUrl": "https://github.com/aVitomin/runet-censorship-bypass-mv3/releases/tag/v0.0.2.1-beta3",
+  "targetCommit": "323cd1926cb0a3658ed12fb123fdadeba5f2f7cf",
   "prerelease": true,
-  "publishedAt": "2026-08-12T19:37:25Z",
-  "zipFilename": "runet-censorship-bypass-mv3-0.0.2.0-beta2-b6b5cd6.zip",
-  "zipSize": 356944,
-  "zipSha256": "ad9462f19b02c64f2a2e2cff0363612bd7467f978608cd9dfe183b26899915ef",
-  "checksumFilename": "runet-censorship-bypass-mv3-0.0.2.0-beta2-b6b5cd6.sha256.txt"
+  "publishedAt": "2026-08-20T12:57:48Z",
+  "zipFilename": "runet-censorship-bypass-mv3-0.0.2.1-beta3-323cd19.zip",
+  "zipSize": 353022,
+  "zipSha256": "d3248319705a69c335f7b69f56e3afe95856756233dfff6e6de02c203d9d99e5",
+  "checksumFilename": "runet-censorship-bypass-mv3-0.0.2.1-beta3-323cd19.sha256.txt"
 }

--- a/docs/user/INSTALLATION.md
+++ b/docs/user/INSTALLATION.md
@@ -5,7 +5,7 @@
 
 ## Скачать выпуск
 
-1. Откройте [текущий публичный prerelease `v0.0.2.0-beta2`](https://github.com/aVitomin/runet-censorship-bypass-mv3/releases/tag/v0.0.2.0-beta2).
+1. Откройте [текущий публичный prerelease `v0.0.2.1-beta3`](https://github.com/aVitomin/runet-censorship-bypass-mv3/releases/tag/v0.0.2.1-beta3).
 2. В блоке **Assets** скачайте ZIP расширения и соответствующий файл
    `*.sha256.txt`. Точные имена и опубликованный SHA-256 также приведены в
    [блоке текущего выпуска](../../README.md#текущий-выпуск).


### PR DESCRIPTION
## Published release

- Release: https://github.com/aVitomin/runet-censorship-bypass-mv3/releases/tag/v0.0.2.1-beta3
- Tag: `v0.0.2.1-beta3`
- Tag target: `323cd1926cb0a3658ed12fb123fdadeba5f2f7cf`
- ZIP: `runet-censorship-bypass-mv3-0.0.2.1-beta3-323cd19.zip`
- ZIP size: 353022 bytes
- ZIP SHA-256: `d3248319705a69c335f7b69f56e3afe95856756233dfff6e6de02c203d9d99e5`
- Checksum asset: `runet-censorship-bypass-mv3-0.0.2.1-beta3-323cd19.sha256.txt`
- Checksum SHA-256: `67f4ae58b26e3f46fab96e689489f0b4c7f73c6a62c563007b3159d8eac10f66`

Both published assets were redownloaded from GitHub after publication. Their hashes and sizes match the upload records; the checksum content references the exact ZIP and hash. The redownloaded ZIP extracts to 70 files with a root `manifest.json`, version `0.0.2.1`, and version name `0.0.2.01`. Every runtime file is byte-identical to trusted-main artifact `9407021467`.

## Documentation changes

- updates the README current-release block and concise beta3 What's New section
- updates `docs/release-current.json` with actual published release metadata
- updates installation guidance to the beta3 release
- updates the bug-report version placeholder
- leaves historical beta1/beta2 documentation intact

## Verification

- documentation integrity: passed
- PAC: 26 passing
- MV3: 321 passing
- aggregate: 337 passing
- cleanup/tooling: 9 passing
- lint and MV2/MV3 builds: passed
- runtime icons: 32 verified
- package integrity: 70 files
- production npm audit: 0
- clean canonical build from this docs commit: 70/70 files, zero SHA-256 differences from the released trusted artifact

This PR contains documentation/current-release metadata only and does not change runtime behavior or dependencies.