### PR TITLE
docs: add Codex instruction hierarchy and repository skills

### DIFF
--- a/.agents/skills/mv3-security-review/SKILL.md
+++ b/.agents/skills/mv3-security-review/SKILL.md
@@ -7,7 +7,7 @@ description: Perform a focused MV3 security review after changes to permissions,
 
 Work from the repository root. Set `$Project = '.\extensions\chromium\runet-censorship-bypass'` and read `AGENTS.md` plus `$Project\src\extension-chromium-mv3\background\AGENTS.md`. Review the complete relevant diff and enough callers to prove impact. Do not echo secrets, credential-bearing strings, full custom provider URLs, or browser-profile data; cite their locations and redact values.
 
-Review, in order:
+Review the affected boundary and any plausible adjacent effects. Use the following order for applicable items; do not add ceremonial `N/A` sections for unrelated categories:
 
 1. Permission or host-access expansion in `manifest.tmpl.json`, including whether `<all_urls>` use grew.
 2. CSP/script execution and the PAC trust boundary: downloaded PAC stays data until Chromium receives it; flag dynamic extension execution.

--- a/.agents/skills/pac-regression/SKILL.md
+++ b/.agents/skills/pac-regression/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pac-regression
-description: Review and test this repository's PAC routing semantics after changes to PAC generation or cooking, site rules, provider fallback, candidate selection or ordering, Direct/noDirect behavior, own-proxy scope, or related state; do not trigger for copy, styling, documentation, or unrelated build-only changes.
+description: Review and test this repository's PAC routing semantics when a task changes or audits PAC generation/cooking, site-rule matching or precedence, provider fallback, proxy candidate selection/order, Direct/noDirect behavior, or own-proxy scope; do not trigger for copy, styling, documentation, state changes unrelated to routing, or build-only work.
 ---
 
 # PAC regression
@@ -8,7 +8,7 @@ description: Review and test this repository's PAC routing semantics after chang
 Work from the repository root. Set `$Project = '.\extensions\chromium\runet-censorship-bypass'`, read `AGENTS.md` and `$Project\src\extension-chromium-mv3\background\AGENTS.md`, then inspect the complete relevant working-tree and staged diff. Read relevant untracked files because `git diff` cannot show them. Never print credential values or private provider URLs.
 
 1. State the affected routing branch and expected result. Trace `background/pac-mods.js`, `pac-cook.js`, the relevant service-worker site-rule code, and changed callers only as needed.
-2. Build a compact matrix covering exact host and `*.domain` base/subdomain scope; Auto/provider behavior; explicit Proxy; explicit Direct; zero, one, and multiple candidates; candidate order; `noDirect`; and the four safe defaults. Include conflicting-rule precedence when relevant.
+2. Build a compact matrix for the affected semantics and adjacent invariants. Include exact-host and `*.domain` base/subdomain scope; Auto, Proxy, and Direct; candidate counts and order; `noDirect`; safe defaults; and conflicting-rule precedence only where the change can affect them.
 3. Run from the root:
 
    ```powershell

--- a/.agents/skills/release-candidate/SKILL.md
+++ b/.agents/skills/release-candidate/SKILL.md
@@ -1,9 +1,11 @@
 ---
 name: release-candidate
-description: Prepare or audit a local Chromium MV3 release candidate for this repository, including version consistency, tests, MV3 and relevant MV2 builds, packaging, hashing, secret/private-URL checks, staged-output checks, and a release summary; do not trigger for ordinary development builds or when no release artifact is requested.
+description: Prepare or audit a local Chromium MV3 release preflight for this repository, including version consistency, tests, MV3 and relevant MV2 builds, local packaging, hashing, secret/private-URL checks, staged-output checks, and a release summary; do not trigger for ordinary development builds or when no release artifact is requested.
 ---
 
-# Release candidate
+# Local release preflight
+
+This workflow produces a local preflight artifact only. Its locally built and packaged archive is not the canonical public release artifact and must not be published as one. Every public beta or release must follow `docs/development/RELEASE_PROCESS.md` and use the exact artifact from successful trusted-main CI for the validated `main` commit.
 
 Work from the repository root, set `$Project = '.\extensions\chromium\runet-censorship-bypass'`, and read `AGENTS.md`. Do not commit, publish, upload, clean user changes, overwrite an existing archive, or reveal matched secret/private URL values.
 
@@ -17,7 +19,7 @@ Work from the repository root, set `$Project = '.\extensions\chromium\runet-cens
    npm --prefix $Project run build:mv3
    ```
 
-3. Validate `$Project\build\extension-chromium-mv3\manifest.json`, derive a new archive name from its version, and package the contents of that build directory at archive root with PowerShell `Compress-Archive`. Confirm `manifest.json` is at archive root and calculate SHA-256 with `Get-FileHash`.
+3. Validate `$Project\build\extension-chromium-mv3\manifest.json`, derive a new local archive name from its version, and package the contents of that build directory at archive root with PowerShell `Compress-Archive`. Confirm `manifest.json` is at archive root and calculate SHA-256 with `Get-FileHash`.
 4. If the ignored legacy options bundle is unavailable, report that the MV2 result was copy/template sanity only; do not call it a functional legacy UI build. Rebuild that bundle with its existing nested lockfile when legacy/shared changes require it.
 5. Scan staged paths, generated output, and the archive without printing matched values. Reject dependency, cache, profile, log, environment, key, coverage, nested build/dist, secret, credential, or private-URL material.
-6. Return version/version-name, archive path relative to the project, SHA-256, commands and results, dirty-tree state, legacy-build scope, a concise change/security summary, and remaining browser QA. Browser QA includes load-unpacked startup/restart, provider refresh without auto-enable, Proxy/Auto/Direct, real Tor and authenticated proxy behavior, proxy errors/takeover, IndexedDB persistence, and upgraded-profile migration.
+6. Return version/version-name, local preflight archive path relative to the project, SHA-256, commands and results, dirty-tree state, legacy-build scope, a concise change/security summary, and remaining browser QA. Label the archive as local preflight output, not a public release source. Browser QA includes load-unpacked startup/restart, provider refresh without auto-enable, Proxy/Auto/Direct, real Tor and authenticated proxy behavior, proxy errors/takeover, IndexedDB persistence, and upgraded-profile migration.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,12 +6,13 @@ This fork keeps the legacy Runet Censorship Bypass extension while developing a 
 
 - Extension tooling root: `extensions/chromium/runet-censorship-bypass`.
 - MV3 runtime: `src/extension-chromium-mv3`; `background/service-worker.js` is the entry point and `pages/` is the MV3 UI.
+- Instruction routing: before modifying files under `extensions/chromium/runet-censorship-bypass/src/extension-chromium-mv3/background/`, read and follow its `AGENTS.md`; before modifying files under `extensions/chromium/runet-censorship-bypass/src/extension-chromium-mv3/pages/`, read and follow its `AGENTS.md`. Do this even when Codex starts from the repository root.
 - Shared inputs: selected icons, locales, and page libraries under `src/extension-common`. Gulp deliberately excludes the legacy common background scripts and page implementations from MV3.
 - Legacy MV2: `src/extension-common` plus `src/extension-full` or `src/extension-mini`; beta also uses full sources with a separate template context.
 - Build/version authority: `src/templates-data.js`, `gulpfile.js`, and the manifest templates. The repository intentionally has no root npm package: never run `npm install`, `npm ci`, or npm scripts at the repository root; scope every package command to the authoritative `extensions/chromium/runet-censorship-bypass` package.
 - Generated/local-only context: any `node_modules`, `build`, `dist`, `coverage`, `.tmp`, browser profile, archive, log, or options-page `dist`. Do not broadly inspect vendored/minified Ace files.
 
-From the repository root in PowerShell:
+When required by the change rules below, run these commands from the repository root in PowerShell:
 
 ```powershell
 $Project = '.\extensions\chromium\runet-censorship-bypass'
@@ -22,6 +23,13 @@ npm --prefix $Project run verify:mv3
 ```
 
 Use Windows PowerShell-compatible commands. Use `npm ci --prefix $Project` only when extension dependencies are missing. A functional legacy options bundle additionally needs `npm ci --prefix "$Project\src\extension-common\pages\options"` followed by `npm --prefix "$Project\src\extension-common\pages\options" run build`. `build:mv2` deletes the complete `build` directory, so always build MV2 before the final MV3 build. Whole-tree `npm run lint` has pre-existing legacy failures; use the focused `lint:mv3` check for MV3 work and report the legacy baseline rather than reformatting it.
+
+## Coding approach
+
+- Resolve uncertainty from code, tests, and current documentation. Ask for clarification only when remaining ambiguity would materially affect behavior, security, stored data, release scope, or a destructive action; otherwise make a reasonable low-risk assumption and surface it only when it affects the approach or result.
+- For non-trivial work, use observable success criteria to guide implementation and verification. State them only when they help align scope or explain the evidence.
+- Prefer the simplest solution that fully meets the requirement and fits the existing architecture. Add features, configuration, flexibility, or abstractions only for a demonstrated requirement or design need.
+- Make focused changes and preserve unrelated behavior and user work. Do not reformat legacy files, regenerate lockfiles unnecessarily, or alter production behavior as cleanup.
 
 ## Documentation and release ownership
 
@@ -46,11 +54,10 @@ Use Windows PowerShell-compatible commands. Use `npm ci --prefix $Project` only 
 
 ## Change rules and required checks
 
-- Keep changes focused; do not reformat legacy files, regenerate lockfiles unnecessarily, or modify production behavior as cleanup.
 - PAC/routing/candidate changes: use `$pac-regression`, run `test:pac` and `test:mv3`, and add semantic cases when behavior changes.
 - MV3 permissions, service worker, downloads, storage, auth, migration, external requests, or proxy errors: use `$mv3-security-review`, run `lint:mv3`, `test:mv3`, and `build:mv3`; identify real-browser QA.
 - Shared/template/gulp/MV2 changes: run the full tests and `build:mv2`, then rebuild MV3. Report when the legacy options bundle could not be rebuilt.
 - MV3 UI/localization changes: update both `en` and `ru`, build MV3, and manually check affected controls. Never render stored values with HTML injection sinks.
 - Agent/docs-only changes: run `node ./scripts/verify-docs.mjs`, validate skill frontmatter/paths when relevant, and run `git diff --check`; do not claim product checks were necessary if no runtime file changed.
 
-Done means the relevant tests and builds actually ran, the complete diff was reviewed, generated/profile/secret material is neither staged nor packaged, unrelated changes remain intact, and browser-dependent gaps are named. Report files changed, commands with pass/fail, security/routing impact, remaining product issues, generated artifacts, and final `git status --short`. Never commit, push, publish, or upload unless separately authorized.
+Before calling work complete, review the complete relevant diff and run the checks required above. If a required check cannot run, report the work as incomplete and explain why. Confirm that generated/profile/secret material is neither staged nor packaged, preserve unrelated changes, and name browser-dependent gaps. Report changed files and checks with pass/fail results; mention security/routing impact, unresolved product issues, generated artifacts, and browser QA only when relevant. Include final `git status --short`. Never commit, push, publish, or upload unless separately authorized.

--- a/extensions/chromium/runet-censorship-bypass/src/extension-chromium-mv3/background/AGENTS.md
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-chromium-mv3/background/AGENTS.md
@@ -5,10 +5,7 @@ These files form one service-worker runtime. Preserve the top-level `importScrip
 - Keep downloaded PAC as text. Validate/hash/store/cook it without extension-side execution. Apply only a current cooked artifact whose provider, raw hash, modifier hash, and live proxy-control checks agree.
 - Store new PAC bodies in `mv3PacArtifacts`; keep only summaries/references in normal state and RPC results. Do not delete legacy inline data unless its artifact write succeeded.
 - Normalize settings through the module APIs. State reads and whole-state writers are serialized per active worker, with each queued mutation rereading storage. Do not bypass that queue or derive same-field updates across separate state calls when concurrent callers can intervene; the queue itself does not survive worker restart.
-- Generated explicit Proxy branches require at least one usable candidate and contain no provider or `DIRECT` fallback. Do not overstate browser fail-closed behavior while PAC application is non-mandatory or candidate text can be malformed.
 - Never serialize valid own-proxy username/password fields into PAC. Auth challenges must be proxy challenges for an exact host/port, bounded by retry limits. Persist only redacted auth/health/migration events.
 - Sanitize request URLs before state, notifications, or logs. Treat custom URL query strings as sensitive. Validate custom input URLs before fetch and revalidate the final URL after followed redirects before accepting a PAC body. Permission, redirect, provider fallback, and error-listener changes require security review.
-- Automatic refresh may download/cook while disabled, but may reapply only after both persisted metadata and live Chromium control confirm the same active PAC.
-- Migration remains an explicit audit and selected-field apply. It neither clears legacy storage nor invokes proxy application.
 
 Run `test:pac` for routing changes; run `lint:mv3`, `test:mv3`, and `build:mv3` for any background change. Add browser QA for PAC parse/runtime fallback, real proxies/auth, external takeover, worker interruption, alarms, IndexedDB, or offscreen migration.

--- a/extensions/chromium/runet-censorship-bypass/src/extension-chromium-mv3/pages/AGENTS.md
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-chromium-mv3/pages/AGENTS.md
@@ -2,10 +2,10 @@
 
 MV3 pages communicate through `pages/shared/rpc-client.js`; do not reach into background globals or add remote scripts. Build DOM with text nodes/`textContent` and existing helpers, not HTML injection sinks.
 
-- Background state may contain structured proxy credentials. Display a password only as `***`, restore the original value when that placeholder is saved unchanged, and keep credentials out of DOM attributes, errors, diagnostics, and logs. Treat full custom provider URLs as sensitive.
-- Keep popup and options routing language aligned: Auto removes the applicable override, Proxy requires a candidate, and Direct is explicit. Exact-host and domain/subdomain controls need both forms tested; the current two-label domain heuristic is not public-suffix safe.
+- Background state may contain structured proxy credentials. Display a password only as `***`, restore the original value when that placeholder is saved unchanged, and keep credentials out of DOM attributes, errors, diagnostics, and logs. Treat full custom provider URLs as sensitive outside the dedicated provider input, especially in errors, diagnostics, and logs.
+- Keep popup and options routing language aligned: Auto removes the applicable override, Proxy requires a candidate, and Direct is explicit. Exact-host and domain/subdomain controls need both forms tested; current domain scope uses bundled `tldts` public-suffix data with private domains enabled, while legacy two-label wildcards are recognized only for compatibility.
 - Migration UI stays collapsed/explicit, requires field selection and confirmation, and must not imply that it applied browser proxy settings.
 - Add every normal user-facing string to both `_locales/en/messages.json` and `_locales/ru/messages.json`. Preserve keys and placeholder shapes.
 - MV3 owns these pages; the legacy Inferno options app under `extension-common/pages/options` is separate.
 
-After changes, run `lint:mv3`, `test:mv3`, and `build:mv3`, then inspect the affected page in Chromium. Manually verify secret masking, keyboard/form behavior, both languages, and any routing action.
+After page changes, run `lint:mv3`, `test:mv3`, and `build:mv3`, then inspect the affected page in Chromium. Manually verify the behaviors the change can affect, including secret masking, keyboard/form behavior, both languages, and routing actions as applicable.


### PR DESCRIPTION
## Scope

- Refines the root and nested Codex instruction hierarchy.
- Narrows the PAC/security skill triggers and clarifies local release-preflight behavior.

## Runtime and release impact

- Documentation and repository-skill Markdown only; no runtime logic, dependency, workflow, version, or release-metadata changes.
- Nested `AGENTS.md` files remain excluded from the MV3 package. No release or version bump.

## Validation

- `node .\scripts\verify-docs.mjs`
- `git diff --check origin/main...HEAD`
- `npm --prefix .\extensions\chromium\runet-censorship-bypass run build:mv3` (package integrity passed; no Markdown/instruction files packaged)