### PR TITLE
test: add Chrome Stable MV3 browser smoke

### DIFF
--- a/.github/workflows/mv3.yml
+++ b/.github/workflows/mv3.yml
@@ -17,6 +17,7 @@ concurrency:
 
 env:
   CI: 'true'
+  CHROME_BIN: /usr/bin/google-chrome
 
 jobs:
   verify:
@@ -54,6 +55,9 @@ jobs:
 
       - name: Build MV3
         run: npm --prefix ./extensions/chromium/runet-censorship-bypass run build:mv3
+
+      - name: Run Chrome Stable MV3 browser smoke
+        run: npm --prefix ./extensions/chromium/runet-censorship-bypass run test:browser:mv3
 
       - name: Run aggregate verification
         run: npm --prefix ./extensions/chromium/runet-censorship-bypass run verify

--- a/docs/development/TESTING.md
+++ b/docs/development/TESTING.md
@@ -67,6 +67,30 @@ npm --prefix $Project run build:mv3
 Количество файлов выводится проверкой; не фиксируйте его в документации без
 необходимости.
 
+### Chrome Stable MV3 smoke
+
+После MV3 build можно запустить короткий browser-level smoke на установленном
+Google Chrome Stable:
+
+```powershell
+$env:CHROME_BIN = 'C:\Program Files\Google\Chrome\Application\chrome.exe'
+npm --prefix $Project run test:browser:mv3
+```
+
+`CHROME_BIN` — явный авторитетный override. Без него скрипт проверяет только
+несколько стандартных путей установки и никогда не скачивает браузер. Тест
+запускает собранное unpacked MV3-расширение в одноразовом профиле и поднимает
+локальные PAC, origin и два proxy на динамических loopback-портах. Через
+production RPC он сохраняет provider и PAC modifiers, применяет реальный
+`chrome.proxy.settings` и проверяет фактические HTTP receivers для Auto, Proxy
+и Direct. Затем Chrome перезапускается с тем же профилем и повторяется один
+Proxy route для проверки startup recovery. Внешняя сеть не нужна; PAC исполняет
+сам Chrome, а не Node.
+
+Smoke не заменяет ручные проверки Chrome Stable: external-controller takeover,
+остановка worker через DevTools, upgrade существующего профиля и UI остаются в
+browser QA. Authenticated HTTP 407 proxy проверяется отдельной будущей задачей.
+
 ### Полная MV3 verification
 
 ```powershell

--- a/extensions/chromium/runet-censorship-bypass/package-lock.json
+++ b/extensions/chromium/runet-censorship-bypass/package-lock.json
@@ -20,7 +20,8 @@
         "eslint": "^10.8.1",
         "eslint-config-google": "^0.14.0",
         "globals": "^17.11.0",
-        "mocha": "^11.8.0"
+        "mocha": "^11.8.0",
+        "puppeteer-core": "^25.8.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -416,6 +417,198 @@
         "node": ">=14"
       }
     },
+    "node_modules/@puppeteer/browsers": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-3.2.1.tgz",
+      "integrity": "sha512-KDz+3qDRdBAlRlMjmKyj6dEs33YHTk/xRHEENSXq6TNnhgoU15ruSHtEBeVF6OZ9tBDY55Se4P0nFMNsipzU9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "modern-tar": "^0.8.0",
+        "yargs": "^18.0.0"
+      },
+      "bin": {
+        "browsers": "lib/main-cli.js"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      },
+      "peerDependencies": {
+        "proxy-agent": ">=8.0.1",
+        "yauzl": "^2.10.0 || ^3.4.0"
+      },
+      "peerDependenciesMeta": {
+        "proxy-agent": {
+          "optional": true
+        },
+        "yauzl": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/ansi-regex": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+      "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/cliui/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@puppeteer/browsers/node_modules/string-width": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+      "integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/yargs": {
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.1.0.tgz",
+      "integrity": "sha512-2rAgRKu54VsHkqI0/tYkmluGXHD4KW7yZoycuqDQ15QOTnc2VVfy0nN/1eMhnQLO00A+dwtK20xuCnc1YGeUyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^8.2.1",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
@@ -806,6 +999,23 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/chromium-bidi": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-17.0.2.tgz",
+      "integrity": "sha512-5v9GQFhTktFvotn/OFNJBmKLKRAb6n9r0bVCwf7sHgWc3/JryK0bj1nn93L3pHFrfgcsu6Be6EWsDi+1XHTGDg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mitt": "^3.0.1",
+        "zod": "^3.24.1"
+      },
+      "engines": {
+        "node": ">=20.19.0 <22.0.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "devtools-protocol": "*"
+      }
+    },
     "node_modules/cliui": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
@@ -928,6 +1138,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/devtools-protocol": {
+      "version": "0.0.1666840",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1666840.tgz",
+      "integrity": "sha512-gCcO42XCHKEs7Ag0S7aGYsnJ7hlgrO3qderYqeiY0Eqk+0GFfuvT13IA0hHreJTa2KCdDVyGMeOhdMNmrrTjVg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/diff": {
       "version": "7.0.0",
@@ -1557,6 +1774,19 @@
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-func-name": {
@@ -2213,6 +2443,13 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/mocha": {
       "version": "11.8.0",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.8.0.tgz",
@@ -2464,6 +2701,16 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/modern-tar": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/modern-tar/-/modern-tar-0.8.4.tgz",
+      "integrity": "sha512-gN54ddmyzEg10orwZ2u4OOv+bjpMWdIl5jIkodK97bMq8QBSL5c0D7YX0lT1Ooz+99S7+PvFbnxzdjgHo1r41g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/mute-stdout": {
@@ -2726,6 +2973,24 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/puppeteer-core": {
+      "version": "25.8.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-25.8.0.tgz",
+      "integrity": "sha512-LDOrawV8vfCVk+yLj2ozvajNP4Sv3OV9y3Tpiyy2g2Z+aQlbcozP6KJfI4iSBq7YQER+86ihEtPa5ioiZyWxMQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@puppeteer/browsers": "3.2.1",
+        "chromium-bidi": "17.0.2",
+        "devtools-protocol": "0.0.1666840",
+        "typed-query-selector": "^2.12.2",
+        "webdriver-bidi-protocol": "0.4.2",
+        "ws": "^8.21.1"
+      },
+      "engines": {
+        "node": ">=22.12.0"
       }
     },
     "node_modules/randombytes": {
@@ -3171,6 +3436,13 @@
         "node": ">=4"
       }
     },
+    "node_modules/typed-query-selector": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.2.tgz",
+      "integrity": "sha512-EOPFbyIub4ngnEdqi2yOcNeDLaX/0jcE1JoAXQDDMIthap7FoN795lc/SHfIq2d416VufXpM8z/lD+WRm2gfOQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/unc-path-regex": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
@@ -3316,6 +3588,13 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/webdriver-bidi-protocol": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.2.tgz",
+      "integrity": "sha512-VSV+fzfChirL3e7jay2yUC7B4HQCGtEWEg/MSSQbK+qWbqeGlRLlXTzPpYr3XGUvbpDHumWZBJxgesg4N7dbtA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/which": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
@@ -3386,6 +3665,28 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/y18n": {
       "version": "5.0.8",
@@ -3472,6 +3773,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   },
@@ -3714,6 +4025,123 @@
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
       "dev": true,
       "optional": true
+    },
+    "@puppeteer/browsers": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-3.2.1.tgz",
+      "integrity": "sha512-KDz+3qDRdBAlRlMjmKyj6dEs33YHTk/xRHEENSXq6TNnhgoU15ruSHtEBeVF6OZ9tBDY55Se4P0nFMNsipzU9A==",
+      "dev": true,
+      "requires": {
+        "modern-tar": "^0.8.0",
+        "yargs": "^18.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+          "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "6.2.3",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+          "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+          "dev": true
+        },
+        "cliui": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+          "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+          "dev": true,
+          "requires": {
+            "string-width": "^7.2.0",
+            "strip-ansi": "^7.1.0",
+            "wrap-ansi": "^9.0.0"
+          },
+          "dependencies": {
+            "string-width": {
+              "version": "7.2.0",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+              "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+              "dev": true,
+              "requires": {
+                "emoji-regex": "^10.3.0",
+                "get-east-asian-width": "^1.0.0",
+                "strip-ansi": "^7.1.0"
+              }
+            }
+          }
+        },
+        "emoji-regex": {
+          "version": "10.6.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+          "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "8.2.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+          "integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
+          "dev": true,
+          "requires": {
+            "get-east-asian-width": "^1.5.0",
+            "strip-ansi": "^7.1.2"
+          }
+        },
+        "strip-ansi": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+          "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^6.2.2"
+          }
+        },
+        "wrap-ansi": {
+          "version": "9.0.2",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+          "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^6.2.1",
+            "string-width": "^7.0.0",
+            "strip-ansi": "^7.1.0"
+          },
+          "dependencies": {
+            "string-width": {
+              "version": "7.2.0",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+              "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+              "dev": true,
+              "requires": {
+                "emoji-regex": "^10.3.0",
+                "get-east-asian-width": "^1.0.0",
+                "strip-ansi": "^7.1.0"
+              }
+            }
+          }
+        },
+        "yargs": {
+          "version": "18.1.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.1.0.tgz",
+          "integrity": "sha512-2rAgRKu54VsHkqI0/tYkmluGXHD4KW7yZoycuqDQ15QOTnc2VVfy0nN/1eMhnQLO00A+dwtK20xuCnc1YGeUyg==",
+          "dev": true,
+          "requires": {
+            "cliui": "^9.0.1",
+            "escalade": "^3.1.1",
+            "get-caller-file": "^2.0.5",
+            "string-width": "^8.2.1",
+            "y18n": "^5.0.5",
+            "yargs-parser": "^22.0.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "22.0.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+          "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+          "dev": true
+        }
+      }
     },
     "@types/esrecurse": {
       "version": "4.3.1",
@@ -3969,6 +4397,16 @@
         "readdirp": "~3.6.0"
       }
     },
+    "chromium-bidi": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-17.0.2.tgz",
+      "integrity": "sha512-5v9GQFhTktFvotn/OFNJBmKLKRAb6n9r0bVCwf7sHgWc3/JryK0bj1nn93L3pHFrfgcsu6Be6EWsDi+1XHTGDg==",
+      "dev": true,
+      "requires": {
+        "mitt": "^3.0.1",
+        "zod": "^3.24.1"
+      }
+    },
     "cliui": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
@@ -4059,6 +4497,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
       "integrity": "sha512-DtCOLG98P007x7wiiOmfI0fi3eIKyWiLTGJ2MDnVi/E04lWGbf+JzrRHMm0rgIIZJGtHpKpbVgLWHrv8xXpc3Q=="
+    },
+    "devtools-protocol": {
+      "version": "0.0.1666840",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1666840.tgz",
+      "integrity": "sha512-gCcO42XCHKEs7Ag0S7aGYsnJ7hlgrO3qderYqeiY0Eqk+0GFfuvT13IA0hHreJTa2KCdDVyGMeOhdMNmrrTjVg==",
+      "dev": true
     },
     "diff": {
       "version": "7.0.0",
@@ -4484,6 +4928,12 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
+    },
+    "get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true
     },
     "get-func-name": {
       "version": "2.0.2",
@@ -4926,6 +5376,12 @@
       "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
       "dev": true
     },
+    "mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "dev": true
+    },
     "mocha": {
       "version": "11.8.0",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.8.0.tgz",
@@ -5090,6 +5546,12 @@
           "dev": true
         }
       }
+    },
+    "modern-tar": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/modern-tar/-/modern-tar-0.8.4.tgz",
+      "integrity": "sha512-gN54ddmyzEg10orwZ2u4OOv+bjpMWdIl5jIkodK97bMq8QBSL5c0D7YX0lT1Ooz+99S7+PvFbnxzdjgHo1r41g==",
+      "dev": true
     },
     "mute-stdout": {
       "version": "2.0.0",
@@ -5268,6 +5730,20 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true
+    },
+    "puppeteer-core": {
+      "version": "25.8.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-25.8.0.tgz",
+      "integrity": "sha512-LDOrawV8vfCVk+yLj2ozvajNP4Sv3OV9y3Tpiyy2g2Z+aQlbcozP6KJfI4iSBq7YQER+86ihEtPa5ioiZyWxMQ==",
+      "dev": true,
+      "requires": {
+        "@puppeteer/browsers": "3.2.1",
+        "chromium-bidi": "17.0.2",
+        "devtools-protocol": "0.0.1666840",
+        "typed-query-selector": "^2.12.2",
+        "webdriver-bidi-protocol": "0.4.2",
+        "ws": "^8.21.1"
+      }
     },
     "randombytes": {
       "version": "2.1.0",
@@ -5580,6 +6056,12 @@
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "dev": true
     },
+    "typed-query-selector": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.2.tgz",
+      "integrity": "sha512-EOPFbyIub4ngnEdqi2yOcNeDLaX/0jcE1JoAXQDDMIthap7FoN795lc/SHfIq2d416VufXpM8z/lD+WRm2gfOQ==",
+      "dev": true
+    },
     "unc-path-regex": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
@@ -5689,6 +6171,12 @@
         "vinyl-contents": "^2.0.0"
       }
     },
+    "webdriver-bidi-protocol": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.2.tgz",
+      "integrity": "sha512-VSV+fzfChirL3e7jay2yUC7B4HQCGtEWEg/MSSQbK+qWbqeGlRLlXTzPpYr3XGUvbpDHumWZBJxgesg4N7dbtA==",
+      "dev": true
+    },
     "which": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
@@ -5734,6 +6222,13 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+    },
+    "ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "dev": true,
+      "requires": {}
     },
     "y18n": {
       "version": "5.0.8",
@@ -5789,6 +6284,12 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true
+    },
+    "zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "dev": true
     }
   }

--- a/extensions/chromium/runet-censorship-bypass/package.json
+++ b/extensions/chromium/runet-censorship-bypass/package.json
@@ -12,6 +12,7 @@
     "test:legacy": "mocha --recursive ./src/extension-common/test/*",
     "test:mv3": "mocha --recursive ./src/extension-chromium-mv3/test/*",
     "test:pac": "mocha ./src/extension-chromium-mv3/test/pac-regression.js",
+    "test:browser:mv3": "node ./src/extension-chromium-mv3/test/chrome-stable-smoke.js",
     "verify:mv3": "npm run lint:mv3 && npm run test:mv3 && npm run build:mv3",
     "verify": "npm test && npm run lint:mv3 && npm run build:mv2 && npm run build:mv3",
     "subpages": "npm --prefix ./src/extension-common/pages/options run build",
@@ -27,7 +28,8 @@
     "eslint": "^10.8.1",
     "eslint-config-google": "^0.14.0",
     "globals": "^17.11.0",
-    "mocha": "^11.8.0"
+    "mocha": "^11.8.0",
+    "puppeteer-core": "^25.8.0"
   },
   "dependencies": {
     "gulp": "^5.0.1",

--- a/extensions/chromium/runet-censorship-bypass/src/extension-chromium-mv3/test/chrome-stable-smoke.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-chromium-mv3/test/chrome-stable-smoke.js
@@ -503,14 +503,14 @@ async function configureExtension(page, infrastructure) {
 
 async function assertRoute(session, infrastructure, scenario) {
 
-  const token = `${scenario.name}-${Date.now()}-${Math.random()}`;
+  const token = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
   const trafficStart = infrastructure.traffic.length;
   const page = await session.browser.newPage();
   try {
     await page.setCacheEnabled(false);
     const response = await page.goto(
         `http://${scenario.host}:${infrastructure.origin.port}/` +
-          `chrome-smoke?token=${encodeURIComponent(token)}`,
+          `chrome-smoke?token=${token}`,
         {
           timeout: CHROME_TIMEOUT_MS,
           waitUntil: 'domcontentloaded',

--- a/extensions/chromium/runet-censorship-bypass/src/extension-chromium-mv3/test/chrome-stable-smoke.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-chromium-mv3/test/chrome-stable-smoke.js
@@ -1,0 +1,652 @@
+'use strict';
+
+
+const Assert = require('assert');
+const Fs = require('fs');
+const Http = require('http');
+const Os = require('os');
+const Path = require('path');
+const Puppeteer = require('puppeteer-core');
+
+const PACKAGED_MV3_ROOT = Path.resolve(
+    __dirname,
+    '..',
+    '..',
+    '..',
+    'build',
+    'extension-chromium-mv3',
+);
+const SERVICE_WORKER_PATH = '/background/service-worker.js';
+const TEST_HOSTS = Object.freeze({
+  auto: 'auto.qa.test',
+  direct: 'direct.qa.test',
+  proxy: 'proxy.qa.test',
+});
+const CHROME_TIMEOUT_MS = 20 * 1000;
+
+function resolveChromeExecutable() {
+
+  const override = String(process.env.CHROME_BIN || '').trim();
+  if (override) {
+    Assert.ok(
+        Fs.existsSync(override) && Fs.statSync(override).isFile(),
+        `CHROME_BIN does not name an installed Chrome executable: ${override}`,
+    );
+    return override;
+  }
+
+  const candidates = process.platform === 'win32' ? [
+    process.env.PROGRAMFILES && Path.join(
+        process.env.PROGRAMFILES,
+        'Google',
+        'Chrome',
+        'Application',
+        'chrome.exe',
+    ),
+    process.env['PROGRAMFILES(X86)'] && Path.join(
+        process.env['PROGRAMFILES(X86)'],
+        'Google',
+        'Chrome',
+        'Application',
+        'chrome.exe',
+    ),
+    process.env.LOCALAPPDATA && Path.join(
+        process.env.LOCALAPPDATA,
+        'Google',
+        'Chrome',
+        'Application',
+        'chrome.exe',
+    ),
+  ] : process.platform === 'darwin' ? [
+    '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+  ] : [
+    '/usr/bin/google-chrome',
+    '/usr/bin/google-chrome-stable',
+  ];
+  const executable = candidates
+      .filter(Boolean)
+      .find((candidate) =>
+        Fs.existsSync(candidate) && Fs.statSync(candidate).isFile(),
+      );
+  Assert.ok(
+      executable,
+      'Google Chrome Stable was not found. Set CHROME_BIN explicitly; ' +
+      'this test never downloads a browser.',
+  );
+  return executable;
+
+}
+
+function assertBuiltExtension() {
+
+  const manifestPath = Path.join(PACKAGED_MV3_ROOT, 'manifest.json');
+  Assert.ok(
+      Fs.existsSync(manifestPath),
+      'Missing built MV3 extension. Run npm run build:mv3 first: ' +
+      PACKAGED_MV3_ROOT,
+  );
+  const manifest = JSON.parse(Fs.readFileSync(manifestPath, 'utf8'));
+  Assert.strictEqual(manifest.manifest_version, 3);
+  Assert.strictEqual(
+      manifest.background && manifest.background.service_worker,
+      SERVICE_WORKER_PATH.slice(1),
+  );
+
+}
+
+function delay(milliseconds) {
+
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+
+}
+
+function listen(server) {
+
+  return new Promise((resolve, reject) => {
+    const onError = (error) => {
+      server.off('listening', onListening);
+      reject(error);
+    };
+    const onListening = () => {
+      server.off('error', onError);
+      resolve(server.address().port);
+    };
+    server.once('error', onError);
+    server.once('listening', onListening);
+    server.listen(0, '127.0.0.1');
+  });
+
+}
+
+function closeServer(server) {
+
+  return new Promise((resolve, reject) => {
+    server.close((error) => error ? reject(error) : resolve());
+    if (typeof server.closeIdleConnections === 'function') {
+      server.closeIdleConnections();
+    }
+  });
+
+}
+
+function sendText(response, body, contentType = 'text/plain; charset=utf-8') {
+
+  response.writeHead(200, {
+    'Cache-Control': 'no-store',
+    'Connection': 'close',
+    'Content-Length': Buffer.byteLength(body),
+    'Content-Type': contentType,
+  });
+  response.end(body);
+
+}
+
+async function createReceiver(kind, traffic) {
+
+  const marker = `${kind}-receiver`;
+  const server = Http.createServer((request, response) => {
+    traffic.push({
+      kind,
+      method: request.method,
+      url: request.url,
+    });
+    request.resume();
+    sendText(response, marker);
+  });
+  server.on('connect', (request, socket) => {
+    traffic.push({
+      kind,
+      method: 'CONNECT',
+      url: request.url,
+    });
+    socket.end();
+  });
+  return {
+    kind,
+    marker,
+    port: await listen(server),
+    server,
+  };
+
+}
+
+async function createPacServer(providerProxyPort) {
+
+  const pacData = [
+    'function FindProxyForURL(url, host) {',
+    `  return "PROXY 127.0.0.1:${providerProxyPort}";`,
+    '}',
+  ].join('\n');
+  const server = Http.createServer((request, response) => {
+    if (request.url !== '/provider.pac') {
+      response.writeHead(404, {'Connection': 'close'});
+      response.end();
+      return;
+    }
+    request.resume();
+    sendText(response, pacData, 'application/x-ns-proxy-autoconfig');
+  });
+  return {
+    port: await listen(server),
+    server,
+  };
+
+}
+
+async function createInfrastructure() {
+
+  const traffic = [];
+  const origin = await createReceiver('origin', traffic);
+  const providerProxy = await createReceiver('provider-proxy', traffic);
+  const explicitProxy = await createReceiver('explicit-proxy', traffic);
+  const pac = await createPacServer(providerProxy.port);
+  return {
+    explicitProxy,
+    origin,
+    pac,
+    providerProxy,
+    traffic,
+  };
+
+}
+
+async function closeInfrastructure(infrastructure) {
+
+  if (!infrastructure) {
+    return;
+  }
+  await Promise.all([
+    infrastructure.pac,
+    infrastructure.explicitProxy,
+    infrastructure.providerProxy,
+    infrastructure.origin,
+  ].map((endpoint) => closeServer(endpoint.server)));
+
+}
+
+function attachWorkerDiagnostics(worker, diagnostics, monitoredWorkers) {
+
+  if (!worker || monitoredWorkers.has(worker)) {
+    return;
+  }
+  monitoredWorkers.add(worker);
+  worker.on('error', (error) => {
+    diagnostics.push(`service worker exception: ${error.message || error}`);
+  });
+  worker.on('console', (message) => {
+    const type = message.type();
+    const text = message.text();
+    if (
+      ['error', 'assert'].includes(type) ||
+      (type === 'warn' && /error|exception|failed/i.test(text))
+    ) {
+      diagnostics.push(`service worker console ${type}: ${text}`);
+    }
+  });
+
+}
+
+function attachPageDiagnostics(page, diagnostics) {
+
+  page.on('pageerror', (error) => {
+    diagnostics.push(`extension page exception: ${error.message || error}`);
+  });
+  page.on('console', (message) => {
+    if (['error', 'assert'].includes(message.type())) {
+      diagnostics.push(
+          `extension page console ${message.type()}: ${message.text()}`,
+      );
+    }
+  });
+
+}
+
+function isExtensionWorkerTarget(target) {
+
+  return target.type() === 'service_worker' &&
+    target.url().startsWith('chrome-extension://') &&
+    target.url().endsWith(SERVICE_WORKER_PATH);
+
+}
+
+async function launchExtension(chromeExecutable, profilePath) {
+
+  const diagnostics = [];
+  const monitoredWorkers = new WeakSet();
+  const browser = await Puppeteer.launch({
+    args: [
+      '--disable-background-networking',
+      '--disable-component-update',
+      '--disable-default-apps',
+      '--disable-features=HttpsFirstBalancedModeAutoEnable',
+      '--disable-gpu',
+      '--disable-sync',
+      '--metrics-recording-only',
+      '--no-default-browser-check',
+      '--no-first-run',
+      '--host-resolver-rules=' + [
+        `MAP ${TEST_HOSTS.auto} 127.0.0.1`,
+        `MAP ${TEST_HOSTS.proxy} 127.0.0.1`,
+        `MAP ${TEST_HOSTS.direct} 127.0.0.1`,
+      ].join(','),
+    ],
+    enableExtensions: true,
+    executablePath: chromeExecutable,
+    headless: true,
+    userDataDir: profilePath,
+  });
+  const monitorTarget = async (target) => {
+    if (!isExtensionWorkerTarget(target)) {
+      return;
+    }
+    try {
+      attachWorkerDiagnostics(
+          await target.worker(),
+          diagnostics,
+          monitoredWorkers,
+      );
+    } catch (error) {
+      diagnostics.push(
+          `service worker diagnostics failed: ${error.message || error}`,
+      );
+    }
+  };
+  browser.on('targetcreated', monitorTarget);
+  for (const target of browser.targets()) {
+    await monitorTarget(target);
+  }
+
+  const extensionId = await browser.installExtension(PACKAGED_MV3_ROOT);
+  const workerTarget = await browser.waitForTarget(
+      (target) => target.type() === 'service_worker' &&
+        target.url() ===
+          `chrome-extension://${extensionId}${SERVICE_WORKER_PATH}`,
+      {timeout: CHROME_TIMEOUT_MS},
+  );
+  const worker = await workerTarget.worker();
+  Assert.ok(worker, 'The MV3 service worker target is not attachable.');
+  attachWorkerDiagnostics(worker, diagnostics, monitoredWorkers);
+  return {
+    browser,
+    diagnostics,
+    extensionId,
+  };
+
+}
+
+async function openExtensionPage(session) {
+
+  const page = await session.browser.newPage();
+  attachPageDiagnostics(page, session.diagnostics);
+  await page.goto(
+      `chrome-extension://${session.extensionId}/pages/options/index.html`,
+      {waitUntil: 'domcontentloaded'},
+  );
+  await page.waitForFunction(
+      () => window.mv3Rpc &&
+        typeof window.mv3Rpc.callBackground === 'function',
+      {timeout: CHROME_TIMEOUT_MS},
+  );
+  return page;
+
+}
+
+async function callRpc(page, method, params = {}) {
+
+  const response = await page.evaluate(async (request) => {
+    try {
+      return {
+        ok: true,
+        result: await window.mv3Rpc.callBackground(
+            request.method,
+            request.params,
+        ),
+      };
+    } catch (error) {
+      return {
+        ok: false,
+        error: {
+          code: error && error.code || 'RPC_FAILED',
+          message: error && error.message || String(error),
+        },
+      };
+    }
+  }, {method, params});
+  if (!response.ok) {
+    const error = new Error(response.error.message);
+    error.code = response.error.code;
+    throw error;
+  }
+  return response.result;
+
+}
+
+async function readProxySettings(page) {
+
+  return page.evaluate(() => new Promise((resolve, reject) => {
+    chrome.proxy.settings.get({}, (details) => {
+      const runtimeError = chrome.runtime.lastError;
+      if (runtimeError) {
+        reject(new Error(runtimeError.message));
+        return;
+      }
+      const value = details && details.value || {};
+      const pacScript = value.pacScript || {};
+      resolve({
+        hasPacData: typeof pacScript.data === 'string' &&
+          pacScript.data.length > 0,
+        levelOfControl: details && details.levelOfControl,
+        mandatory: pacScript.mandatory,
+        mode: value.mode,
+      });
+    });
+  }));
+
+}
+
+function assertProxyControl(details) {
+
+  Assert.deepStrictEqual(details, {
+    hasPacData: true,
+    levelOfControl: 'controlled_by_this_extension',
+    mandatory: false,
+    mode: 'pac_script',
+  });
+
+}
+
+async function waitForProxyControl(page) {
+
+  const deadline = Date.now() + CHROME_TIMEOUT_MS;
+  let details = null;
+  while (Date.now() < deadline) {
+    details = await readProxySettings(page);
+    if (
+      details.hasPacData === true &&
+      details.levelOfControl === 'controlled_by_this_extension' &&
+      details.mandatory === false &&
+      details.mode === 'pac_script'
+    ) {
+      return details;
+    }
+    await delay(100);
+  }
+  assertProxyControl(details);
+  return details;
+
+}
+
+async function configureExtension(page, infrastructure) {
+
+  const reset = await callRpc(page, 'resetMv3State');
+  Assert.strictEqual(reset.ok, true);
+  const added = await callRpc(page, 'addCustomPacProvider', {
+    description: 'Chrome Stable MV3 browser smoke provider',
+    enabled: true,
+    label: 'Chrome Stable smoke',
+    urls: [`http://127.0.0.1:${infrastructure.pac.port}/provider.pac`],
+  });
+  Assert.strictEqual(added.ok, true);
+  const providerKey = added.provider.key;
+  const selected = await callRpc(page, 'setCurrentPacProvider', {providerKey});
+  Assert.strictEqual(selected.currentPacProviderKey, providerKey);
+
+  const pacMods = await callRpc(page, 'getPacMods');
+  pacMods.ownProxies = [{
+    enabled: true,
+    host: '127.0.0.1',
+    note: 'Chrome Stable MV3 browser smoke proxy',
+    password: '',
+    port: infrastructure.explicitProxy.port,
+    type: 'PROXY',
+    username: '',
+    useAsDirectReplacement: false,
+  }];
+  pacMods.localTor.enabled = false;
+  pacMods.torBrowser.enabled = false;
+  pacMods.warp.enabled = false;
+  pacMods.usePacScriptProxies = true;
+  pacMods.ownProxiesOnlyForOwnSites = true;
+  pacMods.replaceDirectWithProxy = false;
+  pacMods.noDirect = false;
+  pacMods.whitelist = [];
+  pacMods.exceptions = [];
+  pacMods.rules = [
+    {
+      action: 'PROXY',
+      enabled: true,
+      note: 'Chrome Stable MV3 browser smoke',
+      pattern: TEST_HOSTS.proxy,
+    },
+    {
+      action: 'DIRECT',
+      enabled: true,
+      note: 'Chrome Stable MV3 browser smoke',
+      pattern: TEST_HOSTS.direct,
+    },
+  ];
+  const saved = await callRpc(page, 'setPacMods', {pacMods});
+  Assert.strictEqual(saved.ok, true);
+
+  const downloaded = await callRpc(page, 'downloadPac', {providerKey});
+  Assert.strictEqual(downloaded.ok, true);
+  Assert.strictEqual(downloaded.status, 'success');
+  const cooked = await callRpc(page, 'cookPac', {providerKey});
+  Assert.strictEqual(cooked.ok, true);
+  Assert.strictEqual(cooked.status, 'success');
+  const applied = await callRpc(page, 'applyCookedPac');
+  Assert.strictEqual(applied.ok, true);
+  Assert.strictEqual(applied.status, 'applied');
+  assertProxyControl(await waitForProxyControl(page));
+
+}
+
+async function assertRoute(session, infrastructure, scenario) {
+
+  const token = `${scenario.name}-${Date.now()}-${Math.random()}`;
+  const trafficStart = infrastructure.traffic.length;
+  const page = await session.browser.newPage();
+  try {
+    await page.setCacheEnabled(false);
+    const response = await page.goto(
+        `http://${scenario.host}:${infrastructure.origin.port}/` +
+          `chrome-smoke?token=${encodeURIComponent(token)}`,
+        {
+          timeout: CHROME_TIMEOUT_MS,
+          waitUntil: 'domcontentloaded',
+        },
+    );
+    Assert.ok(response, `${scenario.name}: Chrome returned no response.`);
+    Assert.strictEqual(await response.text(), scenario.marker);
+    await delay(100);
+  } finally {
+    await page.close();
+  }
+  const hits = infrastructure.traffic
+      .slice(trafficStart)
+      .filter((entry) => entry.url.includes(token));
+  Assert.deepStrictEqual(
+      hits.map((entry) => entry.kind),
+      [scenario.expectedReceiver],
+      `${scenario.name}: request reached an unintended receiver: ` +
+        JSON.stringify(hits),
+  );
+
+}
+
+function assertNoSeriousDiagnostics(diagnostics) {
+
+  Assert.deepStrictEqual(
+      diagnostics,
+      [],
+      'Unexpected extension startup/runtime diagnostics: ' +
+        diagnostics.join('\n'),
+  );
+
+}
+
+function removeProfile(profilePath) {
+
+  const temporaryRoot = Path.resolve(Os.tmpdir());
+  const resolvedProfile = Path.resolve(profilePath);
+  Assert.strictEqual(Path.dirname(resolvedProfile), temporaryRoot);
+  Assert.ok(Path.basename(resolvedProfile).startsWith('rucb-mv3-smoke-'));
+  Fs.rmSync(resolvedProfile, {
+    force: true,
+    maxRetries: 3,
+    recursive: true,
+    retryDelay: 100,
+  });
+
+}
+
+async function runSmoke() {
+
+  assertBuiltExtension();
+  const chromeExecutable = resolveChromeExecutable();
+  const profilePath = Fs.mkdtempSync(
+      Path.join(Os.tmpdir(), 'rucb-mv3-smoke-'),
+  );
+  let browser = null;
+  let infrastructure = null;
+  let chromeVersion = '';
+  try {
+    infrastructure = await createInfrastructure();
+    let session = await launchExtension(chromeExecutable, profilePath);
+    browser = session.browser;
+    chromeVersion = await browser.version();
+    const optionsPage = await openExtensionPage(session);
+    await configureExtension(optionsPage, infrastructure);
+    await assertRoute(session, infrastructure, {
+      expectedReceiver: 'provider-proxy',
+      host: TEST_HOSTS.auto,
+      marker: infrastructure.providerProxy.marker,
+      name: 'Auto provider policy',
+    });
+    await assertRoute(session, infrastructure, {
+      expectedReceiver: 'explicit-proxy',
+      host: TEST_HOSTS.proxy,
+      marker: infrastructure.explicitProxy.marker,
+      name: 'explicit Proxy rule',
+    });
+    await assertRoute(session, infrastructure, {
+      expectedReceiver: 'origin',
+      host: TEST_HOSTS.direct,
+      marker: infrastructure.origin.marker,
+      name: 'explicit Direct rule',
+    });
+    assertNoSeriousDiagnostics(session.diagnostics);
+    const firstExtensionId = session.extensionId;
+    await optionsPage.close();
+    await browser.close();
+    browser = null;
+
+    session = await launchExtension(chromeExecutable, profilePath);
+    browser = session.browser;
+    Assert.strictEqual(
+        session.extensionId,
+        firstExtensionId,
+        'The unpacked extension ID changed across the profile restart.',
+    );
+    const restartedOptionsPage = await openExtensionPage(session);
+    assertProxyControl(await waitForProxyControl(restartedOptionsPage));
+    await assertRoute(session, infrastructure, {
+      expectedReceiver: 'explicit-proxy',
+      host: TEST_HOSTS.proxy,
+      marker: infrastructure.explicitProxy.marker,
+      name: 'restart recovery Proxy rule',
+    });
+    assertNoSeriousDiagnostics(session.diagnostics);
+    const cleared = await callRpc(restartedOptionsPage, 'clearProxy');
+    Assert.strictEqual(cleared.ok, true);
+    await restartedOptionsPage.close();
+    console.log(`Chrome Stable MV3 smoke passed with ${chromeVersion}.`);
+    console.log(
+        'Verified Auto -> provider proxy, Proxy -> explicit proxy, ' +
+        'Direct -> origin, and restart recovery -> explicit proxy.',
+    );
+  } finally {
+    if (browser) {
+      await browser.close().catch(() => undefined);
+    }
+    try {
+      await closeInfrastructure(infrastructure);
+    } finally {
+      removeProfile(profilePath);
+    }
+  }
+
+}
+
+if (require.main === module) {
+  runSmoke().catch((error) => {
+    console.error(error && error.stack || error);
+    process.exitCode = 1;
+  });
+}
+
+module.exports = {
+  PACKAGED_MV3_ROOT,
+  resolveChromeExecutable,
+  runSmoke,
+};


### PR DESCRIPTION
Adds a puppeteer-core smoke test that loads the real unpacked MV3 build in installed Google Chrome Stable, configures loopback PAC/proxies through production RPC, proves Auto/Proxy/Direct by receiver traffic, and verifies restart recovery. Wires the smoke into Verify MV3 after build and documents local use. Runtime/release impact: none; no runtime source, version, release metadata, or artifact-upload behavior changes, and the package remains 70 files with no test or instruction leakage. Validation: npm ci; test:pac; test:mv3; lint:mv3; build:mv2; build:mv3; verify:mv3; docs integrity; diff check; package integrity; production and full npm audits. The Chrome Stable smoke runs in PR CI via /usr/bin/google-chrome.