### PR TITLE
release: prepare v0.0.2.2

### DIFF
--- a/extensions/chromium/runet-censorship-bypass/src/extension-chromium-mv3/test/options-ui.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-chromium-mv3/test/options-ui.js
@@ -577,7 +577,7 @@ async function createHarness(options = {}) {
       runtime: {
         getManifest() {
 
-          return {version: '0.0.2.1', version_name: '0.0.2.01'};
+          return {version: '0.0.2.2', version_name: '0.0.2.02'};
 
         },
       },
@@ -707,7 +707,7 @@ describe('MV3 options UI', function() {
         ]);
         expect(harness.root.textContent).to.include('Overview');
         expect(harness.root.textContent).to.include('Routing sources');
-        expect(harness.root.textContent).to.include('0.0.2.01');
+        expect(harness.root.textContent).to.include('0.0.2.02');
         expect(harness.root.textContent).to.include('Limited MV3 beta');
         expect(harness.root.textContent).not.to.include('MV3 migration:');
         const aboutLinks = harness.root.querySelectorAll('.about-links a');

--- a/extensions/chromium/runet-censorship-bypass/src/extension-chromium-mv3/test/verify-package-integrity.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-chromium-mv3/test/verify-package-integrity.js
@@ -22,8 +22,8 @@ const COMMON_SOURCE_ROOT = Path.resolve(
     'extension-common',
 );
 const MV3_LOCALES = Object.freeze(['en', 'ru']);
-const EXPECTED_MV3_VERSION = '0.0.2.1';
-const EXPECTED_MV3_VERSION_NAME = '0.0.2.01';
+const EXPECTED_MV3_VERSION = '0.0.2.2';
+const EXPECTED_MV3_VERSION_NAME = '0.0.2.02';
 
 const ALLOWED_RUNTIME_DIRECTORIES = new Set([
   'background/vendor/tldts/dist',

--- a/extensions/chromium/runet-censorship-bypass/src/templates-data.js
+++ b/extensions/chromium/runet-censorship-bypass/src/templates-data.js
@@ -41,8 +41,8 @@ exports.contexts.mini = Object.assign({}, commonContext, {
 });
 
 exports.contexts.chromiumMv3 = Object.assign({}, commonContext, {
-  version: '2.01',
-  storeVersion: '2.1',
+  version: '2.02',
+  storeVersion: '2.2',
   versionSuffix: '-mv3',
   nameSuffixEn: '',
   nameSuffixRu: '',


### PR DESCRIPTION
## Scope

- bump Chromium MV3 manifest `version` from `0.0.2.1` to `0.0.2.2`
- bump `version_name` from `0.0.2.01` to `0.0.2.02`
- update the options/package-integrity tests that pin those generated values

No runtime logic, PAC/routing/auth/state behavior, dependency, workflow, public-release metadata, tag, or release changes. README and `docs/release-current.json` continue to describe published `v0.0.2.1-beta3`.

## Validation

- documentation integrity passed
- PAC tests: 26 passing
- MV3 tests: 333 passing
- aggregate tests: 349 passing
- focused MV3 lint passed
- MV2 then MV3 builds passed
- Chrome Stable browser smoke passed on `151.0.7922.174`
- generated manifest: `0.0.2.2` / `0.0.2.02`
- package integrity: 70 runtime files, no test/docs/instruction leakage
- trusted-artifact comparison: same 70 paths; no non-manifest content changes after accounting for the established Windows checkout EOL boundary; manifest reverts byte-for-byte when only the two version strings are restored
- production audit: 0 vulnerabilities
- full audit: unchanged Mocha baseline of 1 low / 1 moderate / 1 high
- `git diff --check origin/main...HEAD`

The eventual stable public artifact must come from the exact successful trusted-main CI artifact after this PR is merged. This PR does not publish or tag a release.