### PR TITLE
ci: enforce production npm audit

### DIFF
--- a/.github/workflows/mv3.yml
+++ b/.github/workflows/mv3.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Install extension dependencies
         run: npm ci --prefix ./extensions/chromium/runet-censorship-bypass
 
+      - name: Audit production dependencies
+        run: npm --prefix ./extensions/chromium/runet-censorship-bypass run audit:prod
+
       - name: Run PAC regression tests
         run: npm --prefix ./extensions/chromium/runet-censorship-bypass run test:pac
 

--- a/docs/development/TESTING.md
+++ b/docs/development/TESTING.md
@@ -21,6 +21,17 @@ anchors, запрещает developer-machine paths и stale current-release/def
 branch/install metadata. Она не делает CI зависимым от доступности внешних
 сайтов; отдельный bounded аудит можно запустить с `--audit-external`.
 
+### Production npm audit
+
+```powershell
+npm --prefix $Project run audit:prod
+```
+
+CI запускает этот gate сразу после `npm ci`. Команда использует
+`npm audit --omit=dev` и блокирует любую advisory в production dependency tree.
+Полный `npm audit` остаётся диагностическим: принятые dev-only findings дерева
+Mocha не входят в production gate и не блокируют CI.
+
 ### PAC semantics
 
 ```powershell

--- a/extensions/chromium/runet-censorship-bypass/package.json
+++ b/extensions/chromium/runet-censorship-bypass/package.json
@@ -8,6 +8,7 @@
     "gulp": "gulp",
     "build:mv2": "node ./node_modules/gulp/bin/gulp.js buildAll",
     "build:mv3": "node ./node_modules/gulp/bin/gulp.js buildChromiumMv3 && node ./src/extension-chromium-mv3/test/verify-runtime-icons.js && node ./src/extension-chromium-mv3/test/verify-package-integrity.js",
+    "audit:prod": "npm audit --omit=dev",
     "test": "mocha --recursive ./src/**/test/*",
     "test:legacy": "mocha --recursive ./src/extension-common/test/*",
     "test:mv3": "mocha --recursive ./src/extension-chromium-mv3/test/*",


### PR DESCRIPTION
## Scope

- add `audit:prod` as `npm audit --omit=dev` in the authoritative extension tooling package
- run the production-only audit immediately after `npm ci` in `Verify MV3`
- document the authoritative command and keep full dev audit findings non-blocking

No dependency, lockfile, runtime, version, release metadata, or MV2 behavior changes.

## Validation

- production audit: 0 vulnerabilities
- full audit: accepted Mocha tree only (1 low, 1 moderate, 1 high)
- `verify:mv3`: 333 passing; 70 runtime files
- aggregate `verify`: 349 passing; 70 runtime files
- base/head runtime builds: 0 missing, 0 extra, 0 byte-changed
- dependency graph and package-lock: identical
- documentation integrity and `git diff --check origin/main...HEAD`: passed