### PR TITLE
fix: preserve proxy auth retry limits across worker restarts

### DIFF
--- a/docs/development/TESTING.md
+++ b/docs/development/TESTING.md
@@ -114,7 +114,10 @@ Windows. Сертификат и ключ создаются только во �
 
 Негативные browser cases подтверждают отказ передавать proxy credentials на
 обычный origin `401`, несовпадающий host/port и passwordless proxy, а также
-ограничение повторов при неверном пароле. Receiver logs хранят только безопасные
+ограничение повторов при неверном пароле. Отдельный синхронизированный case
+останавливает точную версию MV3 service worker через CDP между двумя `407` и
+подтверждает, что `storage.session` сохраняет общий лимит из двух credential
+responses для прежнего `requestId`. Receiver logs хранят только безопасные
 классы (`none`, `expected`, `known-wrong`, `unexpected`); password и reusable
 Basic token дополнительно ищутся в PAC, RPC responses, DOM, diagnostics и
 errors. Smoke сохраняет существующую проверку external-controller takeover,
@@ -123,11 +126,12 @@ deferred Turn off и restart persistence. Внешняя сеть не нужн�
 
 Smoke не заменяет ручные проверки upgrade существующего профиля и полного UI.
 Plain HTTP `407`, HTTPS destination `CONNECT` и TLS-to-proxy (`HTTPS` PAC
-scheme) теперь покрыты отдельно. Искусственное прерывание service worker
-посреди активного `407` остаётся отложенной задачей: счётчик auth retries
-хранится в памяти worker и не обещает durability при forced mid-request worker
-termination. Тест не изменяет machine policy, а детерминированные loopback DNS
-и receiver checks не доказывают отсутствие утечек в произвольной реальной
+scheme) покрыты отдельно; forced mid-request worker termination также покрыт
+receiver barrier без timing sleeps. Retry metadata живёт только в
+`chrome.storage.session`, не содержит credentials и очищается на границе
+browser session/extension reload. Тест не изменяет machine policy, а
+детерминированные loopback DNS и receiver checks не доказывают отсутствие
+утечек в произвольной реальной
 сети.
 
 ### Полная MV3 verification

--- a/docs/development/qa/RPC_CREDENTIAL_BROWSER_QA.md
+++ b/docs/development/qa/RPC_CREDENTIAL_BROWSER_QA.md
@@ -33,7 +33,11 @@ from the actual HTTP proxy receivers:
 - mismatched host/port and passwordless proxy challengers receive no credential
   from another configured endpoint and do not fall back to the origin;
 - wrong credentials produce bounded retries, the current `retry_limit` status,
-  no successful response, and no direct-origin hit; and
+  no successful response, and no direct-origin hit;
+- a receiver barrier holds the first credentialed wrong-password retry while
+  CDP stops the exact RUCB worker version; Chrome recreates the worker for the
+  next `407`, preserves the same request ID, and RUCB still supplies no more
+  than two credential responses in total; and
 - canary passwords and reusable Basic tokens remain absent from applied PAC,
   RPC responses, popup/options DOM and password inputs, auth diagnostics,
   extension console output, receiver logs, and test-visible errors.
@@ -52,9 +56,11 @@ certificate's base64 SHA-256 SPKI through
 override; global certificate-error suppression and trust-store changes are not
 used.
 
-The retry counter is worker memory: a full browser restart before a new proxy
-request is covered, but forced worker termination in the middle of one active
-`407` sequence is not. The automated run does not manipulate machine policy,
+Retry counters use `chrome.storage.session`: each entry contains only request
+ID, normalized challenger host/port identity, count, and update time. It
+survives MV3 worker termination but clears at browser-session or extension
+reload boundaries; no username, password, authorization value, URL, realm, or
+headers enter this store. The automated run does not manipulate machine policy,
 and its fake hostnames, loopback receivers, and direct traps do not claim
 arbitrary real-world DNS-leak coverage.
 
@@ -101,9 +107,9 @@ arbitrary real-world DNS-leak coverage.
   DevTools, screenshots, or exported diagnostics.
 - Restart or suspend the service worker, retry authentication, and confirm the
   durable credential still works without first opening an extension page. A
-  full Chrome restart before a previously unused proxy is automated; natural
-  suspension and forced mid-challenge termination remain manual/follow-up
-  boundaries.
+  full Chrome restart before a previously unused proxy and forced
+  mid-challenge worker termination are automated. Natural idle suspension timing
+  remains a browser-managed boundary rather than a timing-based test.
 
 ## DevTools inspection
 

--- a/extensions/chromium/runet-censorship-bypass/src/extension-chromium-mv3/background/proxy-auth.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-chromium-mv3/background/proxy-auth.js
@@ -6,7 +6,9 @@
 
   const MAX_ATTEMPTS_PER_CHALLENGER = 2;
   const ATTEMPT_TTL_MS = 10 * 60 * 1000;
-  const attempts = new Map();
+  const SESSION_STORAGE_KEY = 'mv3ProxyAuthAttempts';
+  let attemptOperationQueue = Promise.resolve();
+  let attemptsTracked = 0;
 
   function normalizeHost(host) {
 
@@ -197,19 +199,151 @@
 
   }
 
-  function cleanupAttempts(now = Date.now()) {
+  function getAttemptRequestId(details) {
 
-    attempts.forEach((value, key) => {
-      if (now - value.updatedAt > ATTEMPT_TTL_MS) {
-        attempts.delete(key);
+    return String(details && details.requestId || 'unknown');
+
+  }
+
+  function normalizeAttemptEntry(value) {
+
+    if (!value || typeof value !== 'object') {
+      return null;
+    }
+    const requestId = typeof value.requestId === 'string' ? value.requestId : '';
+    const challengerKey = typeof value.challengerKey === 'string' ?
+      value.challengerKey :
+      '';
+    const count = Number(value.count);
+    const updatedAt = Number(value.updatedAt);
+    if (
+      !requestId ||
+      !challengerKey ||
+      !Number.isInteger(count) ||
+      count < 1 ||
+      !Number.isFinite(updatedAt) ||
+      updatedAt <= 0
+    ) {
+      return null;
+    }
+    return {
+      requestId,
+      challengerKey,
+      count: Math.min(count, MAX_ATTEMPTS_PER_CHALLENGER),
+      updatedAt,
+    };
+
+  }
+
+  function normalizeAttemptEntries(value) {
+
+    if (!Array.isArray(value)) {
+      return [];
+    }
+    const normalized = [];
+    value.forEach((candidate) => {
+      const entry = normalizeAttemptEntry(candidate);
+      if (!entry) {
+        return;
+      }
+      const duplicate = normalized.find((current) =>
+        current.requestId === entry.requestId &&
+        current.challengerKey === entry.challengerKey,
+      );
+      if (!duplicate) {
+        normalized.push(entry);
+        return;
+      }
+      duplicate.count = Math.max(duplicate.count, entry.count);
+      duplicate.updatedAt = Math.max(duplicate.updatedAt, entry.updatedAt);
+    });
+    return normalized;
+
+  }
+
+  function cleanupAttemptEntries(entries, now = Date.now()) {
+
+    return entries.filter((entry) => now - entry.updatedAt <= ATTEMPT_TTL_MS);
+
+  }
+
+  function createRetryStateError() {
+
+    const error = new Error('Proxy auth retry state is unavailable.');
+    error.code = 'PROXY_AUTH_RETRY_STATE_FAILED';
+    return error;
+
+  }
+
+  function getSessionStorageArea() {
+
+    const area = typeof chrome !== 'undefined' &&
+      chrome.storage && chrome.storage.session;
+    if (!area || typeof area.get !== 'function' || typeof area.set !== 'function') {
+      throw createRetryStateError();
+    }
+    return area;
+
+  }
+
+  function getRuntimeLastError() {
+
+    return typeof chrome !== 'undefined' &&
+      chrome.runtime && chrome.runtime.lastError || null;
+
+  }
+
+  function readAttemptEntries() {
+
+    return new Promise((resolve, reject) => {
+      let area;
+      try {
+        area = getSessionStorageArea();
+        area.get({[SESSION_STORAGE_KEY]: []}, (items) => {
+          if (getRuntimeLastError()) {
+            reject(createRetryStateError());
+            return;
+          }
+          const entries = normalizeAttemptEntries(
+              items && items[SESSION_STORAGE_KEY],
+          );
+          attemptsTracked = entries.length;
+          resolve(entries);
+        });
+      } catch (error) {
+        reject(createRetryStateError());
       }
     });
 
   }
 
-  function getAttemptKey(details, challengerKey) {
+  function writeAttemptEntries(entries) {
 
-    return `${details.requestId || 'unknown'}|${challengerKey}`;
+    const normalized = normalizeAttemptEntries(entries);
+    return new Promise((resolve, reject) => {
+      let area;
+      try {
+        area = getSessionStorageArea();
+        area.set({[SESSION_STORAGE_KEY]: normalized}, () => {
+          if (getRuntimeLastError()) {
+            reject(createRetryStateError());
+            return;
+          }
+          attemptsTracked = normalized.length;
+          resolve(normalized);
+        });
+      } catch (error) {
+        reject(createRetryStateError());
+      }
+    });
+
+  }
+
+  function runAttemptOperation(operation) {
+
+    const result = attemptOperationQueue.then(operation, operation);
+    attemptOperationQueue = result.then(() => undefined, () => undefined);
+    return result;
 
   }
 
@@ -239,26 +373,23 @@
 
   }
 
-  function handleProxyAuthRequired(details, state) {
+  function prepareProxyAuthRequest(details, state) {
 
-    cleanupAttempts();
     const config = buildProxyAuthConfig(state);
     if (!config.enabled) {
-      return createResult(
-          {},
-          createEvent('disabled', details, {
-            message: 'Proxy auth is disabled.',
-          }),
-      );
+      return {
+        result: createResult({}, createEvent('disabled', details, {
+          message: 'Proxy auth is disabled.',
+        })),
+      };
     }
 
     if (!details || details.isProxy !== true) {
-      return createResult(
-          {},
-          createEvent('non_proxy_ignored', details, {
-            message: 'Non-proxy auth challenge ignored.',
-          }),
-      );
+      return {
+        result: createResult({}, createEvent('non_proxy_ignored', details, {
+          message: 'Non-proxy auth challenge ignored.',
+        })),
+      };
     }
 
     const challenger = details.challenger || {};
@@ -267,20 +398,73 @@
       config.credentialsByChallenger[challengerKey] :
       null;
     if (!credentials || !credentials.length) {
+      return {
+        result: createResult({}, createEvent('missing_credentials', details, {
+          message: 'No credentials configured for proxy challenger.',
+        })),
+      };
+    }
+    return {challengerKey, credentials};
+
+  }
+
+  async function reserveProxyAuthAttempt(details, challengerKey, credentials) {
+
+    return runAttemptOperation(async () => {
+      const now = Date.now();
+      const requestId = getAttemptRequestId(details);
+      const entries = cleanupAttemptEntries(await readAttemptEntries(), now);
+      const currentAttempt = entries.find((entry) =>
+        entry.requestId === requestId &&
+        entry.challengerKey === challengerKey,
+      );
+      const count = currentAttempt ? currentAttempt.count : 0;
+      if (count >= MAX_ATTEMPTS_PER_CHALLENGER) {
+        await writeAttemptEntries(entries);
+        return {allowed: false};
+      }
+
+      const credential = credentials[count % credentials.length];
+      const updatedEntries = entries.filter((entry) =>
+        entry.requestId !== requestId ||
+        entry.challengerKey !== challengerKey,
+      );
+      updatedEntries.push({
+        requestId,
+        challengerKey,
+        count: count + 1,
+        updatedAt: now,
+      });
+      await writeAttemptEntries(updatedEntries);
+      return {allowed: true, credential};
+    });
+
+  }
+
+  async function handleProxyAuthRequired(details, state) {
+
+    const prepared = prepareProxyAuthRequest(details, state);
+    if (prepared.result) {
+      return prepared.result;
+    }
+
+    let reservation;
+    try {
+      reservation = await reserveProxyAuthAttempt(
+          details,
+          prepared.challengerKey,
+          prepared.credentials,
+      );
+    } catch (error) {
       return createResult(
-          {},
-          createEvent('missing_credentials', details, {
-            message: 'No credentials configured for proxy challenger.',
+          {cancel: true},
+          createEvent('error', details, {
+            hasCredentials: true,
+            message: 'Proxy auth retry state is unavailable.',
           }),
       );
     }
-
-    const attemptKey = getAttemptKey(details, challengerKey);
-    const currentAttempt = attempts.get(attemptKey) || {
-      count: 0,
-      updatedAt: Date.now(),
-    };
-    if (currentAttempt.count >= MAX_ATTEMPTS_PER_CHALLENGER) {
+    if (!reservation.allowed) {
       return createResult(
           {cancel: true},
           createEvent('retry_limit', details, {
@@ -290,11 +474,7 @@
       );
     }
 
-    const credential = credentials[currentAttempt.count % credentials.length];
-    attempts.set(attemptKey, {
-      count: currentAttempt.count + 1,
-      updatedAt: Date.now(),
-    });
+    const credential = reservation.credential;
     return createResult(
         {
           authCredentials: {
@@ -313,15 +493,32 @@
 
   function clearProxyAuthAttempts(details = {}) {
 
-    if (!details.requestId) {
-      attempts.clear();
-      return;
-    }
-    const requestPrefix = `${details.requestId}|`;
-    Array.from(attempts.keys()).forEach((key) => {
-      if (key.startsWith(requestPrefix)) {
-        attempts.delete(key);
+    return runAttemptOperation(async () => {
+      const storedEntries = await readAttemptEntries();
+      const entries = cleanupAttemptEntries(storedEntries);
+      if (!details.requestId) {
+        if (!storedEntries.length) {
+          return;
+        }
+        await writeAttemptEntries([]);
+        return;
       }
+      const requestId = getAttemptRequestId(details);
+      const challenger = details.challenger || {};
+      const challengerKey = getChallengerKey(challenger.host, challenger.port);
+      const retained = entries.filter((entry) => {
+        if (entry.requestId !== requestId) {
+          return true;
+        }
+        return challengerKey && entry.challengerKey !== challengerKey;
+      });
+      if (
+        retained.length === storedEntries.length &&
+        entries.length === storedEntries.length
+      ) {
+        return;
+      }
+      await writeAttemptEntries(retained);
     });
 
   }
@@ -344,7 +541,7 @@
         proxies: config.summary,
       },
       retryLimit: config.retryLimit,
-      attemptsTracked: attempts.size,
+      attemptsTracked,
     };
 
   }
@@ -359,7 +556,6 @@
 
   function selfTest() {
 
-    clearProxyAuthAttempts();
     const samplePassword = ['sec', 'ret'].join('');
     const state = {
       proxyAuth: {enabled: true},
@@ -375,56 +571,56 @@
       requestId: '1',
       challenger: {host: 'proxy.example', port: 8443},
     };
-    const nonProxy = handleProxyAuthRequired({
+    const nonProxy = prepareProxyAuthRequest({
       isProxy: false,
       requestId: '2',
       challenger: {host: 'proxy.example', port: 8443},
     }, state);
-    const unknown = handleProxyAuthRequired({
+    const unknown = prepareProxyAuthRequest({
       isProxy: true,
       requestId: '3',
       challenger: {host: 'proxy.example', port: 8444},
     }, state);
-    const first = handleProxyAuthRequired(known, state);
-    const second = handleProxyAuthRequired(known, state);
-    const third = handleProxyAuthRequired(known, state);
-    const disabled = handleProxyAuthRequired({
+    const prepared = prepareProxyAuthRequest(known, state);
+    const disabled = prepareProxyAuthRequest({
       isProxy: true,
       requestId: '4',
       challenger: {host: 'proxy.example', port: 8443},
     }, {proxyAuth: {enabled: false}, pacMods: state.pacMods});
     const status = getProxyAuthStatus(state);
+    const providedEvent = createEvent('provided', known, {
+      hasCredentials: true,
+      username: prepared.credentials[0].username,
+      message: 'Proxy credentials provided.',
+    });
     const eventText = JSON.stringify([
-      nonProxy.event,
-      unknown.event,
-      first.event,
-      third.event,
+      nonProxy.result.event,
+      unknown.result.event,
+      providedEvent,
       status,
     ]);
     return {
-      nonProxyIgnored: nonProxy.event.type === 'non_proxy_ignored' &&
-        !nonProxy.response.authCredentials,
-      unknownProxyIgnored: unknown.event.type === 'missing_credentials' &&
-        !unknown.response.authCredentials,
-      knownProxyReturnsCredentials: first.response.authCredentials &&
-        first.response.authCredentials.username === 'user' &&
-        first.response.authCredentials.password === samplePassword,
-      retryLimitCancels: third.event.type === 'retry_limit' &&
-        third.response.cancel === true,
-      disabledReturnsNoCredentials: disabled.event.type === 'disabled' &&
-        !disabled.response.authCredentials,
+      nonProxyIgnored: nonProxy.result.event.type === 'non_proxy_ignored' &&
+        !nonProxy.result.response.authCredentials,
+      unknownProxyIgnored: unknown.result.event.type === 'missing_credentials' &&
+        !unknown.result.response.authCredentials,
+      knownProxyFindsCredentials: prepared.credentials.length === 1 &&
+        prepared.credentials[0].username === 'user' &&
+        prepared.credentials[0].password === samplePassword,
+      disabledReturnsNoCredentials: disabled.result.event.type === 'disabled' &&
+        !disabled.result.response.authCredentials,
       exactHostPortMatching: status.configuredCredentials.count === 1,
       passwordRedactedFromEvents: !eventText.includes(samplePassword),
       usernameRedactedInStatus: status.configuredCredentials.proxies[0].username ===
         'u***r',
-      secondAttemptAllowed: second.response.authCredentials &&
-        second.event.type === 'provided',
     };
 
   }
 
   exports.mv3ProxyAuth = Object.freeze({
+    ATTEMPT_TTL_MS,
     MAX_ATTEMPTS_PER_CHALLENGER,
+    SESSION_STORAGE_KEY,
     buildProxyAuthConfig,
     handleProxyAuthRequired,
     getProxyAuthStatus,

--- a/extensions/chromium/runet-censorship-bypass/src/extension-chromium-mv3/background/service-worker.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-chromium-mv3/background/service-worker.js
@@ -1140,8 +1140,8 @@ const RPC_METHODS = Object.freeze({
 
   async clearProxyAuthEvents() {
 
+    await mv3ProxyAuth.clearProxyAuthAttempts();
     await mv3State.resetProxyAuthState();
-    mv3ProxyAuth.clearProxyAuthAttempts();
     const state = await mv3State.loadState();
     return getProxyAuthStatusFromState(state);
 
@@ -1366,8 +1366,8 @@ function handleWebRequestAuthRequired(details, asyncCallback) {
         respond(result.response);
         return mv3State.recordProxyAuthEvent(result.event);
       })
-      .catch((err) => {
-        respond({});
+      .catch(() => {
+        respond(details && details.isProxy === true ? {cancel: true} : {});
         return mv3State.recordProxyAuthEvent({
           type: 'error',
           at: Date.now(),
@@ -1375,7 +1375,7 @@ function handleWebRequestAuthRequired(details, asyncCallback) {
           isProxy: details && details.isProxy === true,
           host: details && details.challenger && details.challenger.host || null,
           port: details && details.challenger && details.challenger.port || null,
-          message: err && err.message || 'Proxy auth handler failed.',
+          message: 'Proxy auth handler failed safely.',
         });
       })
       .catch(() => {});
@@ -1384,7 +1384,8 @@ function handleWebRequestAuthRequired(details, asyncCallback) {
 
 function clearWebRequestAuthAttempt(details) {
 
-  mv3ProxyAuth.clearProxyAuthAttempts(details);
+  mv3ProxyAuth.clearProxyAuthAttempts(details)
+      .catch(() => console.warn('Failed to clear proxy-auth retry state.'));
 
 }
 

--- a/extensions/chromium/runet-censorship-bypass/src/extension-chromium-mv3/test/chrome-stable-smoke.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-chromium-mv3/test/chrome-stable-smoke.js
@@ -29,6 +29,7 @@ const TEST_HOSTS = Object.freeze({
   authHttpsProxy: 'auth-https-proxy.qa.test',
   authMismatch: 'auth-mismatch.qa.test',
   authPasswordless: 'auth-passwordless.qa.test',
+  authWorkerRestart: 'auth-worker-restart.qa.test',
   authWrong: 'auth-wrong.qa.test',
   direct: 'direct.qa.test',
   origin401: 'origin-401.qa.test',
@@ -110,6 +111,40 @@ function assertBuiltExtension() {
 function delay(milliseconds) {
 
   return new Promise((resolve) => setTimeout(resolve, milliseconds));
+
+}
+
+function createBarrier() {
+
+  let ifReleased = false;
+  let releasePromise;
+  const promise = new Promise((resolve) => {
+    releasePromise = resolve;
+  });
+  return {
+    promise,
+    release(value) {
+
+      if (ifReleased) {
+        return;
+      }
+      ifReleased = true;
+      releasePromise(value);
+
+    },
+  };
+
+}
+
+function waitForBarrier(promise, message, timeout = CHROME_TIMEOUT_MS) {
+
+  let timeoutId;
+  return Promise.race([
+    promise,
+    new Promise((resolve, reject) => {
+      timeoutId = setTimeout(() => reject(new Error(message)), timeout);
+    }),
+  ]).finally(() => clearTimeout(timeoutId));
 
 }
 
@@ -276,6 +311,9 @@ function trackSocket(sockets, socket) {
 
 async function closeEndpoint(endpoint) {
 
+  if (typeof endpoint.releaseNextChallenge === 'function') {
+    endpoint.releaseNextChallenge();
+  }
   if (endpoint.sockets) {
     endpoint.sockets.forEach((socket) => socket.destroy());
   }
@@ -477,6 +515,63 @@ async function createAuthenticatedProxy(options) {
     marker,
     port: await listen(server),
     server,
+  };
+
+}
+
+async function createInterruptedAuthenticatedProxy(options) {
+
+  const marker = `${options.kind}-authenticated-receiver`;
+  const realm = `rucb-${options.kind}`;
+  const firstCredentialReceived = createBarrier();
+  const releaseNextChallenge = createBarrier();
+  const sockets = new Set();
+  let credentialedRequests = 0;
+  const sendChallenge = (response) => {
+    if (response.destroyed || response.headersSent) {
+      return;
+    }
+    response.writeHead(407, {
+      'Connection': 'close',
+      'Content-Length': '0',
+      'Proxy-Authenticate': `Basic realm="${realm}"`,
+    });
+    response.end();
+  };
+  const server = Http.createServer((request, response) => {
+    const auth = classifyAuthorization(
+        request.headers['proxy-authorization'],
+        options.expectedAuthorization,
+        options.knownAuthorizations,
+    );
+    options.traffic.push({
+      auth,
+      kind: options.kind,
+      method: request.method,
+      url: request.url,
+    });
+    request.resume();
+    if (auth !== 'known-wrong') {
+      sendChallenge(response);
+      return;
+    }
+    ++credentialedRequests;
+    if (credentialedRequests !== 1) {
+      sendChallenge(response);
+      return;
+    }
+    firstCredentialReceived.release();
+    releaseNextChallenge.promise.then(() => sendChallenge(response));
+  });
+  server.on('connection', (socket) => trackSocket(sockets, socket));
+  return {
+    firstCredentialReceived: firstCredentialReceived.promise,
+    kind: options.kind,
+    marker,
+    port: await listen(server),
+    releaseNextChallenge: () => releaseNextChallenge.release(),
+    server,
+    sockets,
   };
 
 }
@@ -700,6 +795,10 @@ async function createInfrastructure() {
     proxyB: createCredentialCanary('proxy-b'),
     proxyConnect: createCredentialCanary('proxy-connect'),
     proxyHttps: createCredentialCanary('proxy-https'),
+    workerRestartConfigured: createCredentialCanary(
+        'worker-restart-configured',
+    ),
+    workerRestartExpected: createCredentialCanary('worker-restart-expected'),
     wrongConfigured: createCredentialCanary('wrong-configured'),
     wrongExpected: createCredentialCanary('wrong-expected'),
   });
@@ -765,6 +864,12 @@ async function createInfrastructure() {
     knownAuthorizations,
     traffic,
   });
+  const authWorkerRestart = await createInterruptedAuthenticatedProxy({
+    expectedAuthorization: credentials.workerRestartExpected.authorization,
+    kind: 'auth-worker-restart',
+    knownAuthorizations: [credentials.workerRestartConfigured.authorization],
+    traffic,
+  });
   const authWrong = await createAuthenticatedProxy({
     acceptExpected: true,
     expectedAuthorization: credentials.wrongExpected.authorization,
@@ -795,6 +900,10 @@ async function createInfrastructure() {
       host: TEST_HOSTS.authPasswordless,
       result: `PROXY 127.0.0.1:${authPasswordless.port}`,
     },
+    {
+      host: TEST_HOSTS.authWorkerRestart,
+      result: `PROXY 127.0.0.1:${authWorkerRestart.port}`,
+    },
     {host: TEST_HOSTS.authWrong, result: `PROXY 127.0.0.1:${authWrong.port}`},
     {host: TEST_HOSTS.origin401, result: 'DIRECT'},
   ]);
@@ -805,6 +914,7 @@ async function createInfrastructure() {
     authPasswordless,
     authProxyA,
     authProxyB,
+    authWorkerRestart,
     authWrong,
     connectDirectTrap,
     connectTlsOrigin,
@@ -836,6 +946,7 @@ async function closeInfrastructure(infrastructure) {
       infrastructure.authPasswordless,
       infrastructure.authProxyA,
       infrastructure.authProxyB,
+      infrastructure.authWorkerRestart,
       infrastructure.authWrong,
       infrastructure.connectDirectTrap,
       infrastructure.connectTlsOrigin,
@@ -982,6 +1093,7 @@ async function launchExtension(
         `MAP ${TEST_HOSTS.authHttpsProxy} 127.0.0.1`,
         `MAP ${TEST_HOSTS.authMismatch} 127.0.0.1`,
         `MAP ${TEST_HOSTS.authPasswordless} 127.0.0.1`,
+        `MAP ${TEST_HOSTS.authWorkerRestart} 127.0.0.1`,
         `MAP ${TEST_HOSTS.authWrong} 127.0.0.1`,
         `MAP ${TEST_HOSTS.proxy} 127.0.0.1`,
         `MAP ${TEST_HOSTS.direct} 127.0.0.1`,
@@ -1038,6 +1150,121 @@ async function launchExtension(
     diagnostics,
     extensionId,
   };
+
+}
+
+function waitForEmitterEvent(emitter, eventName, predicate, message) {
+
+  return new Promise((resolve, reject) => {
+    const cleanup = () => {
+      clearTimeout(timeoutId);
+      emitter.off(eventName, listener);
+    };
+    const listener = (value) => {
+      if (!predicate(value)) {
+        return;
+      }
+      cleanup();
+      resolve(value);
+    };
+    const timeoutId = setTimeout(() => {
+      cleanup();
+      reject(new Error(message));
+    }, CHROME_TIMEOUT_MS);
+    emitter.on(eventName, listener);
+  });
+
+}
+
+async function stopExtensionWorkerWithCdp(session, observerPage) {
+
+  const scriptUrl =
+    `chrome-extension://${session.extensionId}${SERVICE_WORKER_PATH}`;
+  const workerTarget = session.browser.targets().find((target) =>
+    target.type() === 'service_worker' && target.url() === scriptUrl,
+  );
+  Assert.ok(workerTarget, 'RUCB worker-stop unsupported: target was not found.');
+
+  const protocol = await observerPage.createCDPSession();
+  const targetInfos = await protocol.send('Target.getTargets');
+  const workerTargetInfo = targetInfos.targetInfos.find((targetInfo) =>
+    targetInfo.type === 'service_worker' && targetInfo.url === scriptUrl,
+  );
+  Assert.ok(
+      workerTargetInfo,
+      'RUCB worker-stop unsupported: CDP target was not found.',
+  );
+  const runningVersion = createBarrier();
+  const stoppedVersion = createBarrier();
+  let versionId = null;
+  const observeVersions = (event) => {
+    (event.versions || []).forEach((version) => {
+      if (version.scriptURL !== scriptUrl) {
+        return;
+      }
+      if (
+        version.targetId === workerTargetInfo.targetId &&
+        version.runningStatus === 'running'
+      ) {
+        runningVersion.release(version);
+      }
+      if (
+        versionId &&
+        version.versionId === versionId &&
+        version.runningStatus === 'stopped'
+      ) {
+        stoppedVersion.release(version);
+      }
+    });
+  };
+  protocol.on('ServiceWorker.workerVersionUpdated', observeVersions);
+  try {
+    try {
+      await protocol.send('ServiceWorker.enable');
+    } catch (error) {
+      throw new Error('RUCB worker-stop unsupported: CDP ServiceWorker.enable failed.');
+    }
+    const running = await waitForBarrier(
+        runningVersion.promise,
+        'RUCB worker-stop unsupported: running version was not reported.',
+    );
+    versionId = running.versionId;
+    const destroyed = waitForEmitterEvent(
+        session.browser,
+        'targetdestroyed',
+        (target) => isExtensionWorkerTarget(target) &&
+          target.url() === scriptUrl,
+        'RUCB worker-stop unsupported: target was not destroyed.',
+    );
+    const attachedWorker = await workerTarget.worker();
+    Assert.ok(
+        attachedWorker && attachedWorker.client,
+        'RUCB worker-stop unsupported: diagnostics session was not found.',
+    );
+    try {
+      await attachedWorker.client.detach();
+    } catch (error) {
+      throw new Error(
+          'RUCB worker-stop unsupported: diagnostics detach failed.',
+      );
+    }
+    try {
+      await protocol.send('ServiceWorker.stopWorker', {versionId});
+    } catch (error) {
+      throw new Error('RUCB worker-stop unsupported: CDP stopWorker failed.');
+    }
+    await Promise.all([
+      destroyed,
+      waitForBarrier(
+          stoppedVersion.promise,
+          'RUCB worker-stop unsupported: stopped version was not reported.',
+      ),
+    ]);
+    return {scriptUrl, versionId};
+  } finally {
+    protocol.off('ServiceWorker.workerVersionUpdated', observeVersions);
+    await protocol.detach().catch(() => undefined);
+  }
 
 }
 
@@ -1404,6 +1631,11 @@ async function configureExtension(page, infrastructure) {
         'Chrome Stable passwordless proxy',
     ),
     createOwnProxy(
+        infrastructure.authWorkerRestart,
+        'Chrome Stable worker-restart wrong-credential proxy',
+        infrastructure.credentials.workerRestartConfigured,
+    ),
+    createOwnProxy(
         infrastructure.authWrong,
         'Chrome Stable wrong-credential proxy',
         infrastructure.credentials.wrongConfigured,
@@ -1508,6 +1740,27 @@ async function waitForProxyAuthEvent(page, type, port) {
     await delay(100);
   }
   Assert.fail(`Proxy auth event ${type} was not observed for the test endpoint.`);
+
+}
+
+async function waitForProxyAuthRetrySequence(page, port, requestId) {
+
+  const deadline = Date.now() + CHROME_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    const status = await callRpc(page, 'getProxyAuthStatus');
+    const events = status.lastEvents.filter((event) =>
+      String(event.port) === String(port) && event.requestId === requestId,
+    );
+    const provided = events.filter((event) => event.type === 'provided');
+    const retryLimit = events.find((event) => event.type === 'retry_limit');
+    if (provided.length === 2 && retryLimit) {
+      return {events, provided, retryLimit, status};
+    }
+    await delay(100);
+  }
+  Assert.fail(
+      'Worker-restart proxy auth did not reach its original retry limit.',
+  );
 
 }
 
@@ -1984,6 +2237,148 @@ async function assertWrongCredentialsStop(
 
 }
 
+async function assertWorkerRestartRetryLimit(
+    session,
+    optionsPage,
+    infrastructure,
+) {
+
+  const scenarioName = 'wrong credentials across worker restart';
+  await clearProxyAuthEvents(optionsPage);
+  const endpoint = infrastructure.authWorkerRestart;
+  const token = `${Date.now()}-${Crypto.randomBytes(8).toString('hex')}`;
+  const trafficStart = infrastructure.traffic.length;
+  const page = await session.browser.newPage();
+  attachCredentialLeakGuard(
+      page,
+      session.diagnostics,
+      session.credentialCanaries,
+  );
+  await page.setCacheEnabled(false);
+  const navigationPromise = (async () => {
+    let errorMessage = null;
+    let responseBody = null;
+    let responseStatus = null;
+    try {
+      const response = await page.goto(
+          `http://${TEST_HOSTS.authWorkerRestart}:` +
+            `${infrastructure.origin.port}/chrome-auth-smoke?token=${token}`,
+          {
+            timeout: CHROME_TIMEOUT_MS,
+            waitUntil: 'domcontentloaded',
+          },
+      );
+      if (response) {
+        responseStatus = response.status();
+        responseBody = await response.text().catch(() => null);
+      }
+    } catch (error) {
+      assertNoCredentialCanary(
+          error && error.stack || error,
+          session.credentialCanaries,
+          `${scenarioName} thrown error`,
+      );
+      errorMessage = redactCredentialCanaries(
+          error && error.message || error,
+          session.credentialCanaries,
+      );
+    }
+    return {errorMessage, responseBody, responseStatus};
+  })();
+
+  let scenarioError = null;
+  let requestId = null;
+  let workerStop = null;
+  try {
+    await waitForBarrier(
+        endpoint.firstCredentialReceived,
+        'Worker-restart proxy never received the first credentialed retry.',
+    );
+    const beforeRestartHits = getTrafficForToken(
+        infrastructure,
+        trafficStart,
+        token,
+    );
+    Assert.deepStrictEqual(
+        beforeRestartHits.map((entry) => entry.auth),
+        ['none', 'known-wrong'],
+        'Worker-restart proxy reached an unexpected pre-stop auth sequence.',
+    );
+    const firstProvided = await waitForProxyAuthEvent(
+        optionsPage,
+        'provided',
+        endpoint.port,
+    );
+    assertExactProxyAuthEvent(firstProvided, endpoint, scenarioName);
+    requestId = firstProvided.event.requestId;
+    Assert.ok(requestId, 'Worker-restart auth event had no requestId.');
+
+    workerStop = await stopExtensionWorkerWithCdp(session, optionsPage);
+    const recreatedWorker = waitForEmitterEvent(
+        session.browser,
+        'targetcreated',
+        (target) => isExtensionWorkerTarget(target) &&
+          target.url() === workerStop.scriptUrl,
+        'Worker interruption-not-redispatched: RUCB worker was not recreated.',
+    );
+    endpoint.releaseNextChallenge();
+    await recreatedWorker;
+  } catch (error) {
+    scenarioError = error;
+  } finally {
+    endpoint.releaseNextChallenge();
+  }
+
+  const navigation = await navigationPromise;
+  await page.close();
+  if (scenarioError) {
+    throw scenarioError;
+  }
+  Assert.notStrictEqual(
+      navigation.responseStatus,
+      200,
+      'Worker-restart wrong credentials unexpectedly succeeded.',
+  );
+  const observed = await waitForProxyAuthRetrySequence(
+      optionsPage,
+      endpoint.port,
+      requestId,
+  );
+  const hits = getTrafficForToken(
+      infrastructure,
+      trafficStart,
+      token,
+  );
+  Assert.deepStrictEqual(
+      hits.map((entry) => entry.kind),
+      [endpoint.kind, endpoint.kind, endpoint.kind],
+      'Worker-restart auth reached an unintended receiver or DIRECT.',
+  );
+  Assert.deepStrictEqual(
+      hits.map((entry) => entry.auth),
+      ['none', 'known-wrong', 'known-wrong'],
+      'Worker restart bypassed the original credential retry budget.',
+  );
+  Assert.strictEqual(observed.provided.length, 2);
+  Assert.ok(
+      observed.events.every((event) => event.requestId === requestId),
+      'Chrome changed requestId during the restarted auth sequence.',
+  );
+  assertNoCredentialCanary(
+      [navigation, observed, hits, session.diagnostics],
+      session.credentialCanaries,
+      'worker-restart auth observations',
+  );
+  return {
+    credentialResponsesAfterRestart: hits.slice(1).length,
+    credentialResponsesBeforeRestart: 1,
+    errorMessage: navigation.errorMessage,
+    requestIdPreserved: true,
+    workerStopped: Boolean(workerStop && workerStop.versionId),
+  };
+
+}
+
 async function assertCredentialRedaction(
     session,
     optionsPage,
@@ -2249,11 +2644,17 @@ async function runSmoke() {
         restartedOptionsPage,
         infrastructure,
     );
+    const workerRestartEvidence = await assertWorkerRestartRetryLimit(
+        session,
+        restartedOptionsPage,
+        infrastructure,
+    );
     observedErrors.push(
         origin401Evidence.errorMessage,
         mismatchEvidence.errorMessage,
         passwordlessEvidence.errorMessage,
         wrongEvidence.errorMessage,
+        workerRestartEvidence.errorMessage,
     );
     await assertCredentialRedaction(
         session,
@@ -2289,6 +2690,12 @@ async function runSmoke() {
     console.log(
         `Chrome smoke 407: wrong credentials ` +
           `${wrongEvidence.receiverEvidence.join(' -> ')} then retry limit.`,
+    );
+    console.log(
+        'Chrome smoke 407 worker restart: ' +
+          `${workerRestartEvidence.credentialResponsesBeforeRestart} before, ` +
+          `${workerRestartEvidence.credentialResponsesAfterRestart} total; ` +
+          'same requestId and retry limit preserved.',
     );
     assertNoSeriousDiagnostics(session.diagnostics);
 
@@ -2366,7 +2773,8 @@ async function runSmoke() {
         'Direct -> origin, restart recovery -> explicit proxy, and ' +
         'external takeover -> deferred Clear -> direct after release/restart. ' +
         'Verified real HTTP 407 auth, durable credentials, 401/mismatch/' +
-        'passwordless rejection, retry limiting, and credential redaction. ' +
+        'passwordless rejection, retry limiting across a forced worker stop, ' +
+        'and credential redaction. ' +
         'Verified authenticated CONNECT to an HTTPS origin and authenticated ' +
         'HTTP/1.1 traffic over an HTTPS proxy transport.',
     );

--- a/extensions/chromium/runet-censorship-bypass/src/extension-chromium-mv3/test/proxy-auth-worker-recovery.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-chromium-mv3/test/proxy-auth-worker-recovery.js
@@ -1,0 +1,383 @@
+'use strict';
+
+
+const Chai = require('chai');
+const Crypto = require('crypto');
+const Mocha = require('mocha');
+const {createRuntimeHarness} = require('./runtime-performance-harness');
+
+const AUTH_HOST = 'proxy.example';
+const AUTH_PORT = 8443;
+const SESSION_STORAGE_KEY = 'mv3ProxyAuthAttempts';
+
+function createSecret(label) {
+
+  return `${label}-${Crypto.randomBytes(24).toString('base64url')}`;
+
+}
+
+function createProxy(host, port, username, password) {
+
+  return {
+    enabled: true,
+    host,
+    note: 'Proxy auth retry test',
+    password,
+    port,
+    type: 'PROXY',
+    username,
+    useAsDirectReplacement: false,
+  };
+
+}
+
+function createAuthState(harness, proxies, enabled = true) {
+
+  return {
+    proxyAuth: {enabled},
+    pacMods: harness.context.mv3PacMods.normalizePacMods({ownProxies: proxies}),
+  };
+
+}
+
+function createDetails(requestId, host = AUTH_HOST, port = AUTH_PORT) {
+
+  return {
+    challenger: {host, port},
+    isProxy: true,
+    requestId,
+  };
+
+}
+
+function getAuthEntries(harness) {
+
+  const session = harness.getSessionStorage();
+  return session[SESSION_STORAGE_KEY] || [];
+
+}
+
+function hasCredentials(result) {
+
+  return Boolean(result && result.response && result.response.authCredentials);
+
+}
+
+async function authorize(harness, state, details) {
+
+  return harness.context.mv3ProxyAuth.handleProxyAuthRequired(details, state);
+
+}
+
+Mocha.describe('MV3 proxy-auth worker retry recovery', function() {
+
+  Mocha.it('allows two matching responses and rejects the third',
+      async function() {
+
+        const secret = createSecret('normal-limit');
+        const harness = await createRuntimeHarness();
+        const state = createAuthState(harness, [
+          createProxy(AUTH_HOST, AUTH_PORT, 'retry-user', secret),
+        ]);
+        const details = createDetails('normal-limit-request');
+
+        const first = await authorize(harness, state, details);
+        const second = await authorize(harness, state, details);
+        const third = await authorize(harness, state, details);
+
+        Chai.expect(hasCredentials(first)).to.equal(true);
+        Chai.expect(hasCredentials(second)).to.equal(true);
+        Chai.expect(hasCredentials(third)).to.equal(false);
+        Chai.expect(third.response.cancel).to.equal(true);
+        Chai.expect(third.event.type).to.equal('retry_limit');
+        Chai.expect(getAuthEntries(harness)).to.deep.equal([{
+          challengerKey: `${AUTH_HOST}:${AUTH_PORT}`,
+          count: 2,
+          requestId: details.requestId,
+          updatedAt: getAuthEntries(harness)[0].updatedAt,
+        }]);
+
+      });
+
+  Mocha.it('preserves the count across worker recreation but not a new session',
+      async function() {
+
+        const secret = createSecret('worker-restart');
+        const firstHarness = await createRuntimeHarness();
+        const firstState = createAuthState(firstHarness, [
+          createProxy(AUTH_HOST, AUTH_PORT, 'restart-user', secret),
+        ]);
+        const details = createDetails('worker-restart-request');
+        Chai.expect(hasCredentials(
+            await authorize(firstHarness, firstState, details),
+        )).to.equal(true);
+
+        const restartedHarness = await createRuntimeHarness({
+          initialSessionStorage: firstHarness.getSessionStorage(),
+        });
+        const restartedState = createAuthState(restartedHarness, [
+          createProxy(AUTH_HOST, AUTH_PORT, 'restart-user', secret),
+        ]);
+        const second = await authorize(restartedHarness, restartedState, details);
+        const third = await authorize(restartedHarness, restartedState, details);
+        Chai.expect(hasCredentials(second)).to.equal(true);
+        Chai.expect(hasCredentials(third)).to.equal(false);
+        Chai.expect(third.event.type).to.equal('retry_limit');
+
+        const newSessionHarness = await createRuntimeHarness();
+        const newSessionState = createAuthState(newSessionHarness, [
+          createProxy(AUTH_HOST, AUTH_PORT, 'restart-user', secret),
+        ]);
+        Chai.expect(hasCredentials(
+            await authorize(newSessionHarness, newSessionState, details),
+        )).to.equal(true);
+
+      });
+
+  Mocha.it('completion clears only the completed request', async function() {
+
+    const secret = createSecret('completion');
+    const harness = await createRuntimeHarness();
+    const state = createAuthState(harness, [
+      createProxy(AUTH_HOST, AUTH_PORT, 'completion-user', secret),
+    ]);
+    await authorize(harness, state, createDetails('completed-request'));
+    await authorize(harness, state, createDetails('concurrent-request'));
+
+    harness.events.webCompleted.dispatch({requestId: 'completed-request'});
+    await harness.waitForAsyncWork();
+
+    Chai.expect(getAuthEntries(harness).map((entry) => entry.requestId))
+        .to.deep.equal(['concurrent-request']);
+    const writesAfterCleanup = harness.counts.storageSets;
+    harness.events.webCompleted.dispatch({requestId: 'untracked-request'});
+    await harness.waitForAsyncWork();
+    Chai.expect(harness.counts.storageSets).to.equal(writesAfterCleanup);
+
+  });
+
+  Mocha.it('error completion clears only the failed request', async function() {
+
+    const secret = createSecret('error-completion');
+    const harness = await createRuntimeHarness();
+    const state = createAuthState(harness, [
+      createProxy(AUTH_HOST, AUTH_PORT, 'error-user', secret),
+    ]);
+    await authorize(harness, state, createDetails('failed-request'));
+    await authorize(harness, state, createDetails('surviving-request'));
+
+    harness.events.webError.dispatch({
+      error: 'net::ERR_ABORTED',
+      requestId: 'failed-request',
+    });
+    await harness.waitForAsyncWork();
+
+    Chai.expect(getAuthEntries(harness).map((entry) => entry.requestId))
+        .to.deep.equal(['surviving-request']);
+
+  });
+
+  Mocha.it('expires stale retry state before evaluating a new attempt',
+      async function() {
+
+        const clock = {now: 2000000};
+        const harness = await createRuntimeHarness({
+          clock,
+          initialSessionStorage: {
+            [SESSION_STORAGE_KEY]: [{
+              challengerKey: `${AUTH_HOST}:${AUTH_PORT}`,
+              count: 2,
+              requestId: 'expired-request',
+              updatedAt: clock.now - 10 * 60 * 1000 - 1,
+            }],
+          },
+        });
+        const state = createAuthState(harness, [
+          createProxy(
+              AUTH_HOST,
+              AUTH_PORT,
+              'expiry-user',
+              createSecret('expiry'),
+          ),
+        ]);
+
+        const result = await authorize(
+            harness,
+            state,
+            createDetails('expired-request'),
+        );
+        Chai.expect(hasCredentials(result)).to.equal(true);
+        Chai.expect(getAuthEntries(harness)[0].count).to.equal(1);
+        Chai.expect(getAuthEntries(harness)[0].updatedAt).to.equal(clock.now);
+
+      });
+
+  Mocha.it('isolates request IDs and normalized challenger endpoints',
+      async function() {
+
+        const secret = createSecret('isolation');
+        const harness = await createRuntimeHarness();
+        const state = createAuthState(harness, [
+          createProxy(AUTH_HOST, AUTH_PORT, 'isolation-user', secret),
+          createProxy('other-proxy.example', 9443, 'other-user', secret),
+        ]);
+        const firstRequest = createDetails('first-request');
+        const secondRequest = createDetails('second-request');
+        const otherEndpoint = createDetails(
+            'first-request',
+            'OTHER-PROXY.EXAMPLE',
+            9443,
+        );
+
+        await authorize(harness, state, firstRequest);
+        await authorize(harness, state, secondRequest);
+        await authorize(harness, state, otherEndpoint);
+
+        const entries = getAuthEntries(harness);
+        Chai.expect(entries).to.have.length(3);
+        Chai.expect(entries.map((entry) =>
+          `${entry.requestId}|${entry.challengerKey}`,
+        ).sort()).to.deep.equal([
+          'first-request|other-proxy.example:9443',
+          `first-request|${AUTH_HOST}:${AUTH_PORT}`,
+          `second-request|${AUTH_HOST}:${AUTH_PORT}`,
+        ]);
+
+      });
+
+  Mocha.it('serializes concurrent challenges so only two receive credentials',
+      async function() {
+
+        const harness = await createRuntimeHarness();
+        const state = createAuthState(harness, [
+          createProxy(
+              AUTH_HOST,
+              AUTH_PORT,
+              'concurrent-user',
+              createSecret('concurrent'),
+          ),
+        ]);
+        const details = createDetails('concurrent-limit-request');
+        const results = await Promise.all([
+          authorize(harness, state, details),
+          authorize(harness, state, details),
+          authorize(harness, state, details),
+        ]);
+
+        Chai.expect(results.filter(hasCredentials)).to.have.length(2);
+        Chai.expect(results.filter((result) => result.response.cancel))
+            .to.have.length(1);
+        Chai.expect(getAuthEntries(harness)[0].count).to.equal(2);
+
+      });
+
+  Mocha.it('cancels safely on session reads or writes without leaking errors',
+      async function() {
+
+        const secret = createSecret('storage-failure');
+        const username = 'storage-failure-user';
+        const harness = await createRuntimeHarness();
+        const state = createAuthState(harness, [
+          createProxy(AUTH_HOST, AUTH_PORT, username, secret),
+        ]);
+        const details = createDetails('storage-failure-request');
+
+        harness.failNextSessionStorageGet(`read-${secret}`);
+        const readFailure = await authorize(harness, state, details);
+        harness.failNextSessionStorageSet(`write-${secret}`);
+        const writeFailure = await authorize(harness, state, details);
+        const serialized = JSON.stringify([readFailure.event, writeFailure.event]);
+
+        Chai.expect(hasCredentials(readFailure)).to.equal(false);
+        Chai.expect(readFailure.response.cancel).to.equal(true);
+        Chai.expect(readFailure.event.type).to.equal('error');
+        Chai.expect(hasCredentials(writeFailure)).to.equal(false);
+        Chai.expect(writeFailure.response.cancel).to.equal(true);
+        Chai.expect(writeFailure.event.type).to.equal('error');
+        Chai.expect(serialized.includes(secret)).to.equal(false);
+        Chai.expect(serialized.includes(username)).to.equal(false);
+        Chai.expect(getAuthEntries(harness)).to.deep.equal([]);
+
+      });
+
+  Mocha.it('clears retry state through the explicit auth reset RPC',
+      async function() {
+
+        const harness = await createRuntimeHarness();
+        const state = createAuthState(harness, [
+          createProxy(
+              AUTH_HOST,
+              AUTH_PORT,
+              'reset-user',
+              createSecret('reset'),
+          ),
+        ]);
+        await authorize(harness, state, createDetails('reset-request'));
+        Chai.expect(getAuthEntries(harness)).to.have.length(1);
+
+        await harness.callRpc('clearProxyAuthEvents');
+        Chai.expect(getAuthEntries(harness)).to.deep.equal([]);
+
+      });
+
+  Mocha.it('stores only minimal retry metadata and preserves rejection behavior',
+      async function() {
+
+        const secret = createSecret('metadata');
+        const username = 'metadata-user';
+        const basicToken = Buffer.from(`${username}:${secret}`).toString('base64');
+        const harness = await createRuntimeHarness();
+        const state = createAuthState(harness, [
+          createProxy(AUTH_HOST, AUTH_PORT, username, secret),
+          createProxy('passwordless.example', 8080, '', ''),
+        ]);
+        const matching = await authorize(
+            harness,
+            state,
+            createDetails('metadata-request'),
+        );
+        const nonProxy = await authorize(harness, state, {
+          challenger: {host: AUTH_HOST, port: AUTH_PORT},
+          isProxy: false,
+          requestId: 'origin-auth',
+        });
+        const mismatch = await authorize(
+            harness,
+            state,
+            createDetails('mismatch', AUTH_HOST, 9444),
+        );
+        const passwordless = await authorize(
+            harness,
+            state,
+            createDetails('passwordless', 'passwordless.example', 8080),
+        );
+        const entries = getAuthEntries(harness);
+        const serializedSession = JSON.stringify(entries);
+        const serializedEvents = JSON.stringify([
+          matching.event,
+          nonProxy.event,
+          mismatch.event,
+          passwordless.event,
+        ]);
+
+        Chai.expect(entries).to.have.length(1);
+        Chai.expect(Object.keys(entries[0]).sort()).to.deep.equal([
+          'challengerKey',
+          'count',
+          'requestId',
+          'updatedAt',
+        ]);
+        Chai.expect(serializedSession.includes(secret)).to.equal(false);
+        Chai.expect(serializedSession.includes(username)).to.equal(false);
+        Chai.expect(serializedSession.includes(basicToken)).to.equal(false);
+        Chai.expect(serializedEvents.includes(secret)).to.equal(false);
+        Chai.expect(nonProxy.event.type).to.equal('non_proxy_ignored');
+        Chai.expect(mismatch.event.type).to.equal('missing_credentials');
+        Chai.expect(passwordless.event.type).to.equal('missing_credentials');
+        Chai.expect(hasCredentials(nonProxy)).to.equal(false);
+        Chai.expect(hasCredentials(mismatch)).to.equal(false);
+        Chai.expect(hasCredentials(passwordless)).to.equal(false);
+
+      });
+
+});

--- a/extensions/chromium/runet-censorship-bypass/src/extension-chromium-mv3/test/rpc-credential-redaction.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-chromium-mv3/test/rpc-credential-redaction.js
@@ -82,14 +82,14 @@ function setExplicitPassword(proxy, password) {
 
 }
 
-function lookupProxyAuth(harness, state, requestId, host, port) {
+async function lookupProxyAuth(harness, state, requestId, host, port) {
 
-  harness.context.mv3ProxyAuth.clearProxyAuthAttempts();
-  return harness.context.mv3ProxyAuth.handleProxyAuthRequired({
+  await harness.context.mv3ProxyAuth.clearProxyAuthAttempts();
+  return (await harness.context.mv3ProxyAuth.handleProxyAuthRequired({
     isProxy: true,
     requestId,
     challenger: {host, port},
-  }, state).response;
+  }, state)).response;
 
 }
 
@@ -405,7 +405,7 @@ Mocha.describe('MV3 RPC credential redaction', function() {
         });
         const afterUnrelatedState = harness.getState();
         const afterUnrelated = afterUnrelatedState.pacMods.ownProxies[0];
-        const authAfterUnrelated = lookupProxyAuth(
+        const authAfterUnrelated = await lookupProxyAuth(
             harness,
             afterUnrelatedState,
             'preserved-unrelated',
@@ -422,7 +422,7 @@ Mocha.describe('MV3 RPC credential redaction', function() {
         });
         const afterUsernameState = harness.getState();
         const afterUsername = afterUsernameState.pacMods.ownProxies[0];
-        const authAfterUsername = lookupProxyAuth(
+        const authAfterUsername = await lookupProxyAuth(
             harness,
             afterUsernameState,
             'preserved-username',
@@ -437,7 +437,7 @@ Mocha.describe('MV3 RPC credential redaction', function() {
         });
         const afterReplacementState = harness.getState();
         const afterReplacement = afterReplacementState.pacMods.ownProxies[0];
-        const authAfterReplacement = lookupProxyAuth(
+        const authAfterReplacement = await lookupProxyAuth(
             harness,
             afterReplacementState,
             'replaced-password',
@@ -455,7 +455,7 @@ Mocha.describe('MV3 RPC credential redaction', function() {
         const afterRemoval = afterRemovalState.pacMods.ownProxies[0];
         const authAfterRemoval = harness.context.mv3ProxyAuth
             .buildProxyAuthConfig(afterRemovalState);
-        const authLookupAfterRemoval = lookupProxyAuth(
+        const authLookupAfterRemoval = await lookupProxyAuth(
             harness,
             afterRemovalState,
             'removed-password',
@@ -536,8 +536,8 @@ Mocha.describe('MV3 RPC credential redaction', function() {
           tabUrl: 'https://audit.example/',
         });
 
-        harness.context.mv3ProxyAuth.clearProxyAuthAttempts();
-        const result = harness.context.mv3ProxyAuth.handleProxyAuthRequired({
+        await harness.context.mv3ProxyAuth.clearProxyAuthAttempts();
+        const result = await harness.context.mv3ProxyAuth.handleProxyAuthRequired({
           isProxy: true,
           requestId: 'rpc-credential-test',
           challenger: {host: 'proxy.example', port: 8443},
@@ -795,14 +795,14 @@ Mocha.describe('MV3 RPC credential redaction', function() {
           pacMods: explicit,
         });
         const replacedState = harness.getState();
-        const oldEndpointAuth = lookupProxyAuth(
+        const oldEndpointAuth = await lookupProxyAuth(
             harness,
             replacedState,
             'old-endpoint',
             'proxy.example',
             8443,
         );
-        const newEndpointAuth = lookupProxyAuth(
+        const newEndpointAuth = await lookupProxyAuth(
             harness,
             replacedState,
             'new-endpoint',
@@ -871,7 +871,7 @@ Mocha.describe('MV3 RPC credential redaction', function() {
           pacMods: clearedUsername,
         });
         const preservedState = harness.getState();
-        const preservedAuth = lookupProxyAuth(
+        const preservedAuth = await lookupProxyAuth(
             harness,
             preservedState,
             'blank-username',

--- a/extensions/chromium/runet-censorship-bypass/src/extension-chromium-mv3/test/runtime-performance-harness.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-chromium-mv3/test/runtime-performance-harness.js
@@ -170,6 +170,8 @@ async function createRuntimeHarness(options = {}) {
   let nextProxySettingsReadError = null;
   let nextProxySettingsSetError = options.initialProxySettingsSetError || null;
   let nextProxySettingsClearError = null;
+  let nextSessionStorageGetError = null;
+  let nextSessionStorageSetError = null;
   const proxySettingsSetValues = [];
   let proxyDetails = clone(options.initialProxyDetails || {
     levelOfControl: 'controlled_by_this_extension',
@@ -436,6 +438,15 @@ async function createRuntimeHarness(options = {}) {
         get(keysOrDefaults, callback) {
 
           ++counts.storageGets;
+          if (nextSessionStorageGetError) {
+            chromeApi.runtime.lastError = {
+              message: nextSessionStorageGetError,
+            };
+            nextSessionStorageGetError = null;
+            callback({});
+            chromeApi.runtime.lastError = null;
+            return;
+          }
           const result = {};
           Object.keys(keysOrDefaults || {}).forEach((key) => {
             result[key] = Object.prototype.hasOwnProperty.call(
@@ -449,6 +460,15 @@ async function createRuntimeHarness(options = {}) {
         set(values, callback) {
 
           ++counts.storageSets;
+          if (nextSessionStorageSetError) {
+            chromeApi.runtime.lastError = {
+              message: nextSessionStorageSetError,
+            };
+            nextSessionStorageSetError = null;
+            callback();
+            chromeApi.runtime.lastError = null;
+            return;
+          }
           Object.assign(sessionStorageData, clone(values));
           callback();
 
@@ -998,6 +1018,16 @@ async function createRuntimeHarness(options = {}) {
     getSessionStorage() {
 
       return clone(sessionStorageData);
+
+    },
+    failNextSessionStorageGet(message) {
+
+      nextSessionStorageGetError = message;
+
+    },
+    failNextSessionStorageSet(message) {
+
+      nextSessionStorageSetError = message;
 
     },
     getActionState() {


### PR DESCRIPTION
## Summary

- keep proxy-auth retry counts in `chrome.storage.session` so the two-response cap survives MV3 worker termination
- serialize read/update/write reservations, persist counts before returning credentials, and fail closed on session-storage errors
- clean request-scoped retry metadata on terminal events and explicit auth reset without persisting secrets
- add unit regressions plus a barrier-driven real Chrome 407 case that stops the exact RUCB worker version

## Validation

- `npm --prefix .\extensions\chromium\runet-censorship-bypass run audit:prod` (0 vulnerabilities)
- PAC: 26 passing
- MV3: 343 passing
- aggregate: 359 passing
- lint, MV2/MV3 builds, `verify:mv3`, and `verify`
- Chrome Stable 151.0.7922.174 browser smoke, including 1 credential response before worker stop / 2 total with the same request ID and terminal retry limit
- docs integrity and `git diff --check`
- MV3 package: 70 files, zero test/docs/instruction leakage