### PR TITLE
release: prepare v0.0.2.3

### DIFF
--- a/extensions/chromium/runet-censorship-bypass/src/extension-chromium-mv3/test/options-ui.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-chromium-mv3/test/options-ui.js
@@ -577,7 +577,7 @@ async function createHarness(options = {}) {
       runtime: {
         getManifest() {
 
-          return {version: '0.0.2.2', version_name: '0.0.2.02'};
+          return {version: '0.0.2.3', version_name: '0.0.2.03'};
 
         },
       },
@@ -707,7 +707,7 @@ describe('MV3 options UI', function() {
         ]);
         expect(harness.root.textContent).to.include('Overview');
         expect(harness.root.textContent).to.include('Routing sources');
-        expect(harness.root.textContent).to.include('0.0.2.02');
+        expect(harness.root.textContent).to.include('0.0.2.03');
         expect(harness.root.textContent).to.include('Limited MV3 beta');
         expect(harness.root.textContent).not.to.include('MV3 migration:');
         const aboutLinks = harness.root.querySelectorAll('.about-links a');

--- a/extensions/chromium/runet-censorship-bypass/src/extension-chromium-mv3/test/verify-package-integrity.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-chromium-mv3/test/verify-package-integrity.js
@@ -22,8 +22,8 @@ const COMMON_SOURCE_ROOT = Path.resolve(
     'extension-common',
 );
 const MV3_LOCALES = Object.freeze(['en', 'ru']);
-const EXPECTED_MV3_VERSION = '0.0.2.2';
-const EXPECTED_MV3_VERSION_NAME = '0.0.2.02';
+const EXPECTED_MV3_VERSION = '0.0.2.3';
+const EXPECTED_MV3_VERSION_NAME = '0.0.2.03';
 
 const ALLOWED_RUNTIME_DIRECTORIES = new Set([
   'background/vendor/tldts/dist',

--- a/extensions/chromium/runet-censorship-bypass/src/templates-data.js
+++ b/extensions/chromium/runet-censorship-bypass/src/templates-data.js
@@ -41,8 +41,8 @@ exports.contexts.mini = Object.assign({}, commonContext, {
 });
 
 exports.contexts.chromiumMv3 = Object.assign({}, commonContext, {
-  version: '2.02',
-  storeVersion: '2.2',
+  version: '2.03',
+  storeVersion: '2.3',
   versionSuffix: '-mv3',
   nameSuffixEn: '',
   nameSuffixRu: '',


### PR DESCRIPTION
## Summary

- prepare stable MV3 manifest version `0.0.2.3`
- set display `version_name` to `0.0.2.03`
- update only the existing options and package-integrity version assertions

README and `docs/release-current.json` intentionally remain on published `v0.0.2.2`. No runtime behavior, dependency, workflow, tag, or release changes are included.

## Validation

- production audit: 0 vulnerabilities; full audit remains the accepted Mocha-only 1 low / 1 moderate / 1 high baseline
- PAC: 26 passing; MV3: 343 passing; aggregate: 359 passing
- MV3 lint, MV2/MV3 builds, `verify:mv3`, and `verify`
- Chrome Stable 151.0.7922.174 full browser smoke, including forced-worker 407 retry-limit recovery
- package: 70 files, no repository-only leakage, manifest `0.0.2.3` / `0.0.2.03`
- 70 matching paths versus trusted artifact `9506913946`; after Windows CRLF normalization only generated `manifest.json` differs

The eventual public payload must come from the exact trusted-main artifact produced after merge, never from this local build or a PR artifact.