### PR TITLE
ui: simplify Proxy connections configuration

### DIFF
--- a/extensions/chromium/runet-censorship-bypass/src/extension-chromium-mv3/_locales/en/messages.json
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-chromium-mv3/_locales/en/messages.json
@@ -620,7 +620,7 @@
     "message": "Proxy string"
   },
   "optionsAddProxyRow": {
-    "message": "Add proxy row"
+    "message": "Add custom proxy server"
   },
   "optionsUsername": {
     "message": "Username"
@@ -1377,10 +1377,10 @@
     "message": "Site rule removed. Apply the configuration to activate the change."
   },
   "optionsProxyMethodAvailability": {
-    "message": "Proxy connection availability"
+    "message": "Local and custom connection availability"
   },
   "optionsOneProxyMethod": {
-    "message": "$COUNT$ enabled connection",
+    "message": "$COUNT$ Proxy connection available",
     "placeholders": {
       "count": {
         "content": "$1"
@@ -1388,12 +1388,86 @@
     }
   },
   "optionsManyProxyMethods": {
-    "message": "$COUNT$ enabled connections",
+    "message": "$COUNT$ Proxy connections available",
     "placeholders": {
       "count": {
         "content": "$1"
       }
     }
+  },
+  "optionsProxyAvailabilityHelp": {
+    "message": "This count reflects enabled, configured connections for explicit Proxy rules; connection and authentication checks are in Maintenance. Automatic routing can use the selected source separately."
+  },
+  "optionsConfigureProxyConnections": {
+    "message": "Configure Proxy connections"
+  },
+  "optionsSourceProvidedProxies": {
+    "message": "Source-provided proxies"
+  },
+  "optionsSourceProvidedProxiesHelp": {
+    "message": "Keep proxy connections supplied by Automatic routing separate from local applications and custom servers."
+  },
+  "optionsAutomaticRoutingSourceProxies": {
+    "message": "Proxies from the Automatic routing source"
+  },
+  "optionsAutomaticRoutingSourceProxiesHelp": {
+    "message": "Allows the selected source to use the proxy connections it supplies."
+  },
+  "optionsUseSourceProvidedProxies": {
+    "message": "Use source-provided proxies"
+  },
+  "optionsLocalProxyApplications": {
+    "message": "Local proxy applications"
+  },
+  "optionsLocalProxyApplicationsHelp": {
+    "message": "Enable only applications that are installed and running on this computer."
+  },
+  "optionsTorRequirement": {
+    "message": "The local Tor service must be running."
+  },
+  "optionsTorBrowserRequirement": {
+    "message": "Tor Browser must be running."
+  },
+  "optionsWarpConnection": {
+    "message": "WARP"
+  },
+  "optionsWarpRequirement": {
+    "message": "The local proxy configured for WARP must be running; it is not discovered automatically."
+  },
+  "optionsEditConnection": {
+    "message": "Edit"
+  },
+  "optionsHideConnectionDetails": {
+    "message": "Hide details"
+  },
+  "optionsAdvancedProxyPolicies": {
+    "message": "Advanced proxy-routing policies"
+  },
+  "optionsAdvancedProxyPoliciesHelp": {
+    "message": "Scope custom proxy servers here. Direct replacement and Direct fallback policies remain in Advanced."
+  },
+  "optionsOpenAdvancedRouting": {
+    "message": "Open Advanced routing settings"
+  },
+  "optionsCustomProxyNumber": {
+    "message": "Custom proxy server $NUMBER$",
+    "placeholders": {
+      "number": {
+        "content": "$1"
+      }
+    }
+  },
+  "optionsEndpointNotConfigured": {
+    "message": "Endpoint not configured"
+  },
+  "optionsAuthenticationConfigured": {
+    "message": "Authentication configured"
+  },
+  "optionsNoAuthenticationConfigured": {
+    "message": "No authentication configured"
+  },
+  "optionsNeedsAttention": {
+    "message": "Needs attention"
   },
   "optionsProxyHealthAuthSeparateHelp": {
     "message": "Connection availability and successful proxy authentication are separate checks."

--- a/extensions/chromium/runet-censorship-bypass/src/extension-chromium-mv3/_locales/ru/messages.json
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-chromium-mv3/_locales/ru/messages.json
@@ -620,7 +620,7 @@
     "message": "Строка прокси"
   },
   "optionsAddProxyRow": {
-    "message": "Добавить строку прокси"
+    "message": "Добавить пользовательский прокси-сервер"
   },
   "optionsUsername": {
     "message": "Имя пользователя"
@@ -1377,10 +1377,10 @@
     "message": "Правило сайта удалено. Примените конфигурацию, чтобы активировать изменение."
   },
   "optionsProxyMethodAvailability": {
-    "message": "Доступность прокси-подключений"
+    "message": "Доступность локальных и пользовательских подключений"
   },
   "optionsOneProxyMethod": {
-    "message": "Включённых подключений: $COUNT$",
+    "message": "Доступных прокси-подключений: $COUNT$",
     "placeholders": {
       "count": {
         "content": "$1"
@@ -1388,12 +1388,86 @@
     }
   },
   "optionsManyProxyMethods": {
-    "message": "Включённых подключений: $COUNT$",
+    "message": "Доступных прокси-подключений: $COUNT$",
     "placeholders": {
       "count": {
         "content": "$1"
       }
     }
+  },
+  "optionsProxyAvailabilityHelp": {
+    "message": "Счётчик учитывает включённые настроенные подключения для явных правил «Через прокси»; проверка подключения и аутентификации находится в разделе «Обслуживание». Автоматическая маршрутизация может отдельно использовать выбранный источник."
+  },
+  "optionsConfigureProxyConnections": {
+    "message": "Настройка прокси-подключений"
+  },
+  "optionsSourceProvidedProxies": {
+    "message": "Прокси от источника"
+  },
+  "optionsSourceProvidedProxiesHelp": {
+    "message": "Прокси автоматической маршрутизации отделены от локальных приложений и пользовательских серверов."
+  },
+  "optionsAutomaticRoutingSourceProxies": {
+    "message": "Прокси от источника автоматической маршрутизации"
+  },
+  "optionsAutomaticRoutingSourceProxiesHelp": {
+    "message": "Разрешает выбранному источнику использовать предоставленные им прокси-подключения."
+  },
+  "optionsUseSourceProvidedProxies": {
+    "message": "Использовать прокси от источника"
+  },
+  "optionsLocalProxyApplications": {
+    "message": "Локальные прокси-приложения"
+  },
+  "optionsLocalProxyApplicationsHelp": {
+    "message": "Включайте только приложения, которые установлены и запущены на этом компьютере."
+  },
+  "optionsTorRequirement": {
+    "message": "Локальная служба Tor должна быть запущена."
+  },
+  "optionsTorBrowserRequirement": {
+    "message": "Tor Browser должен быть запущен."
+  },
+  "optionsWarpConnection": {
+    "message": "WARP"
+  },
+  "optionsWarpRequirement": {
+    "message": "Локальный прокси для WARP должен быть запущен; автоматического обнаружения нет."
+  },
+  "optionsEditConnection": {
+    "message": "Изменить"
+  },
+  "optionsHideConnectionDetails": {
+    "message": "Скрыть параметры"
+  },
+  "optionsAdvancedProxyPolicies": {
+    "message": "Расширенные политики прокси-маршрутизации"
+  },
+  "optionsAdvancedProxyPoliciesHelp": {
+    "message": "Здесь задаётся область пользовательских прокси-серверов. Замена Direct и fallback-политики Direct остаются в разделе «Расширенные»."
+  },
+  "optionsOpenAdvancedRouting": {
+    "message": "Открыть расширенные настройки маршрутизации"
+  },
+  "optionsCustomProxyNumber": {
+    "message": "Пользовательский прокси-сервер $NUMBER$",
+    "placeholders": {
+      "number": {
+        "content": "$1"
+      }
+    }
+  },
+  "optionsEndpointNotConfigured": {
+    "message": "Адрес подключения не настроен"
+  },
+  "optionsAuthenticationConfigured": {
+    "message": "Аутентификация настроена"
+  },
+  "optionsNoAuthenticationConfigured": {
+    "message": "Аутентификация не настроена"
+  },
+  "optionsNeedsAttention": {
+    "message": "Требует внимания"
   },
   "optionsProxyHealthAuthSeparateHelp": {
     "message": "Доступность подключения и успешная прокси-аутентификация проверяются отдельно."

--- a/extensions/chromium/runet-censorship-bypass/src/extension-chromium-mv3/pages/options/index.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-chromium-mv3/pages/options/index.js
@@ -50,6 +50,7 @@
     setupEligible: false,
   };
   let fieldId = 0;
+  let proxyEditorId = 0;
 
   function t(key, substitutions) {
 
@@ -688,6 +689,7 @@
       return;
     }
     fieldId = 0;
+    proxyEditorId = 0;
     root.replaceChildren();
     root.removeAttribute('aria-busy');
     document.title = t('optionsPageTitle');
@@ -2486,30 +2488,48 @@
         'optionsProxyMethodsDescription',
     );
     const pacMods = state.snapshot.state.pacMods;
+    const candidateCount = getProxyCandidateCount(pacMods);
     const summary = append(section, 'div', 'settings-card ui-card compact');
     const summaryHeader = append(summary, 'div', 'card-header');
     appendText(summaryHeader, 'h3', t('optionsProxyMethodAvailability'));
-    appendText(
+    const availability = appendText(
         summaryHeader,
         'span',
         formatCount(
-            getProxyCandidateCount(pacMods),
+            candidateCount,
             'optionsOneProxyMethod',
             'optionsManyProxyMethods',
         ),
-        getProxyCandidateCount(pacMods) ? 'ui-pill success' : 'ui-pill warning',
+        candidateCount ? 'ui-pill success' : 'ui-pill warning',
     );
+    availability.dataset.proxyAvailability = '';
     appendText(
         summary,
         'p',
-        t('optionsProxyHealthAuthSeparateHelp'),
+        t('optionsProxyAvailabilityHelp'),
         'section-description',
     );
     const card = append(section, 'div', 'settings-card ui-card');
-    const form = append(card, 'form');
+    const form = append(card, 'form', 'proxy-connections-form');
     form.onsubmit = (event) => event.preventDefault();
-    renderProxyPolicy(form, pacMods);
-    const methods = append(form, 'div', 'method-grid');
+    const formHeader = append(form, 'div', 'proxy-form-header');
+    appendText(formHeader, 'h3', t('optionsConfigureProxyConnections'));
+    const pending = appendText(
+        formHeader,
+        'span',
+        t('popupNotApplied'),
+        'ui-pill warning',
+    );
+    pending.dataset.proxyDraftStatus = '';
+    pending.hidden = true;
+    renderSourceProxyBlock(form, pacMods);
+    const localGroup = createProxyConnectionGroup(
+        form,
+        'local',
+        t('optionsLocalProxyApplications'),
+        t('optionsLocalProxyApplicationsHelp'),
+    );
+    const methods = append(localGroup, 'div', 'connection-list');
     renderTorMethod(
         methods,
         'localTor',
@@ -2526,6 +2546,7 @@
     );
     renderWarpMethod(methods, pacMods.warp || {});
     renderOwnProxyMethods(form, pacMods.ownProxies || []);
+    renderProxyPolicy(form, pacMods);
     const actions = append(form, 'div', 'split-actions');
     const save = createButton(
         actions,
@@ -2541,58 +2562,144 @@
     );
     discard.onclick = () => confirmDiscardAll();
     bindDraftForm(form, 'proxy-methods', {usesPacMods: true});
+    syncProxyFormPresentation(form);
+    const updateAvailability = () => updateProxyAvailabilitySummary(form);
+    form.addEventListener('input', updateAvailability);
+    form.addEventListener('change', updateAvailability);
     renderDraftConflict(form, 'proxy-methods');
+
+  }
+
+  function createProxyConnectionGroup(parent, key, title, description) {
+
+    const group = append(parent, 'section', 'proxy-connection-group');
+    group.dataset.proxyGroup = key;
+    const header = append(group, 'div', 'proxy-group-header');
+    appendText(header, 'h3', title);
+    if (description) {
+      appendText(header, 'p', description, 'section-description');
+    }
+    return group;
+
+  }
+
+  function renderSourceProxyBlock(parent, pacMods) {
+
+    const group = createProxyConnectionGroup(
+        parent,
+        'source',
+        t('optionsSourceProvidedProxies'),
+        t('optionsSourceProvidedProxiesHelp'),
+    );
+    const block = append(group, 'div', 'connection-card source-connection');
+    const header = append(block, 'div', 'connection-summary');
+    const copy = append(header, 'div', 'connection-summary-copy');
+    appendText(copy, 'h4', t('optionsAutomaticRoutingSourceProxies'));
+    appendText(
+        copy,
+        'p',
+        t('optionsAutomaticRoutingSourceProxiesHelp'),
+        'connection-requirement',
+    );
+    const controls = append(header, 'div', 'connection-summary-controls');
+    const enabled = pacMods.usePacScriptProxies !== false;
+    const status = appendText(
+        controls,
+        'span',
+        t(enabled ? 'optionsEnabled' : 'optionsDisabled'),
+        `ui-pill ${enabled ? 'success' : ''}`.trim(),
+    );
+    status.dataset.sourceConnectionStatus = '';
+    const input = appendCheckbox(
+        controls,
+        'usePacScriptProxies',
+        t('optionsUseSourceProvidedProxies'),
+        enabled,
+        '',
+        'connection-toggle',
+    );
+    input.onchange = () => updateEnabledStatus(status, input.checked);
 
   }
 
   function renderProxyPolicy(parent, pacMods) {
 
-    const group = append(parent, 'div', 'editor-panel');
-    appendText(group, 'h3', t('optionsProxyMethodPolicy'));
-    appendCheckbox(
-        group,
-        'usePacScriptProxies',
-        t('popupUsePacScriptProxies'),
-        pacMods.usePacScriptProxies !== false,
-        t('popupUsePacScriptProxiesHelp'),
+    const disclosure = createDetails(
+        parent,
+        'proxy-routing-policies',
+        t('optionsAdvancedProxyPolicies'),
+    );
+    disclosure.details.dataset.proxyGroup = 'advanced';
+    appendText(
+        disclosure.content,
+        'p',
+        t('optionsAdvancedProxyPoliciesHelp'),
+        'section-description',
     );
     appendCheckbox(
-        group,
+        disclosure.content,
         'ownProxiesOnlyForOwnSites',
         t('popupOwnProxiesOnlyForOwnSites'),
         pacMods.ownProxiesOnlyForOwnSites === true,
         t('popupOwnProxiesOnlyForOwnSitesHelp'),
     );
+    const advanced = createButton(
+        disclosure.content,
+        t('optionsOpenAdvancedRouting'),
+        'quiet compact-action',
+    );
+    advanced.onclick = () => {
+      state.openDisclosures.add('advanced-routing');
+      navigateTo('advanced');
+      const routing = root.querySelector(
+          '[data-disclosure-key="advanced-routing"]',
+      );
+      if (routing) {
+        routing.open = true;
+      }
+    };
 
   }
 
   function renderTorMethod(parent, key, title, config, defaultPort) {
 
-    const card = append(parent, 'fieldset', 'method-card');
-    appendText(card, 'legend', title, 'item-title');
-    const enabled = appendCheckbox(
-        card,
-        `${key}.enabled`,
-        t('optionsEnabled'),
-        config.enabled === true,
-        key === 'torBrowser' ?
-          t('optionsTorBrowserHelp') :
-          t('optionsLocalTorHelp'),
-    );
+    const healthError = getProxyConnectionHealthError(key);
+    const connection = createProxyConnectionCard(parent, {
+      key,
+      title,
+      enabled: config.enabled === true,
+      requirement: key === 'torBrowser' ?
+        t('optionsTorBrowserRequirement') :
+        t('optionsTorRequirement'),
+      endpoint: formatProxyEndpoint(
+          config.type || 'SOCKS5',
+          config.host || '127.0.0.1',
+          config.port || defaultPort,
+      ),
+      healthError,
+      forceOpen: Boolean(healthError),
+    });
+    const enabled = connection.enabled;
+    enabled.name = `${key}.enabled`;
     enabled.onchange = () => {
-      if (!enabled.checked) {
-        return;
-      }
+      updateEnabledStatus(connection.status, enabled.checked);
+      setConnectionEditorExpanded(connection.card, enabled.checked, true);
       const otherName = key === 'localTor' ?
         'torBrowser.enabled' :
         'localTor.enabled';
       const other = parent.querySelector(`[name="${otherName}"]`);
-      if (other) {
+      if (enabled.checked && other) {
         other.checked = false;
+        const otherCard = other.closest('[data-connection-key]');
+        updateEnabledStatus(
+            otherCard.querySelector('[data-connection-status]'),
+            false,
+        );
+        setConnectionEditorExpanded(otherCard, false, true);
       }
     };
     appendSelect(
-        card,
+        connection.editor,
         `${key}.type`,
         t('optionsType'),
         ['SOCKS5', 'SOCKS4', 'PROXY', 'HTTPS'],
@@ -2600,7 +2707,7 @@
         {full: true},
     );
     appendField(
-        card,
+        connection.editor,
         'text',
         `${key}.host`,
         t('optionsHost'),
@@ -2608,7 +2715,7 @@
         {full: true},
     );
     appendField(
-        card,
+        connection.editor,
         'number',
         `${key}.port`,
         t('optionsPort'),
@@ -2616,14 +2723,14 @@
         {full: true, min: 1, max: 65535},
     );
     appendCheckbox(
-        card,
+        connection.editor,
         `${key}.useForOnion`,
         t('optionsUseForOnion'),
         config.useForOnion !== false,
         '',
     );
     appendCheckbox(
-        card,
+        connection.editor,
         `${key}.useAsDirectReplacement`,
         t('optionsUseAsDirectReplacement'),
         config.useAsDirectReplacement === true,
@@ -2634,26 +2741,37 @@
 
   function renderWarpMethod(parent, warp) {
 
-    const card = append(parent, 'fieldset', 'method-card');
-    appendText(card, 'legend', t('popupWarpCustomProxy'), 'item-title');
-    appendCheckbox(
-        card,
-        'warp.enabled',
-        t('optionsEnabled'),
-        warp.enabled === true,
-        t('optionsWarpLocalProxyWarning'),
-    );
+    const proxyString = warp.proxyString ||
+      'SOCKS5 127.0.0.1:40000; HTTPS 127.0.0.1:40000';
+    const healthError = getProxyConnectionHealthError('warp');
+    const connection = createProxyConnectionCard(parent, {
+      key: 'warp',
+      title: t('optionsWarpConnection'),
+      enabled: warp.enabled === true,
+      requirement: t('optionsWarpRequirement'),
+      endpoint: proxyString,
+      healthError,
+      forceOpen: Boolean(healthError),
+    });
+    connection.enabled.name = 'warp.enabled';
+    connection.enabled.onchange = () => {
+      updateEnabledStatus(connection.status, connection.enabled.checked);
+      setConnectionEditorExpanded(
+          connection.card,
+          connection.enabled.checked,
+          true,
+      );
+    };
     appendField(
-        card,
+        connection.editor,
         'text',
         'warp.proxyString',
         t('optionsProxyString'),
-        warp.proxyString ||
-          'SOCKS5 127.0.0.1:40000; HTTPS 127.0.0.1:40000',
+        proxyString,
         {full: true, help: t('optionsProxyStringHelp')},
     );
     appendCheckbox(
-        card,
+        connection.editor,
         'warp.useAsDirectReplacement',
         t('optionsUseAsDirectReplacement'),
         warp.useAsDirectReplacement === true,
@@ -2662,18 +2780,189 @@
 
   }
 
+  function createProxyConnectionCard(parent, options) {
+
+    const card = append(parent, 'div', 'connection-card');
+    card.dataset.connectionKey = options.key;
+    card.mv3ExpandLabel = t('optionsEditConnection');
+    card.mv3CollapseLabel = t('optionsHideConnectionDetails');
+    const summary = append(card, 'div', 'connection-summary');
+    const copy = append(summary, 'div', 'connection-summary-copy');
+    appendText(copy, 'h4', options.title);
+    appendText(
+        copy,
+        'p',
+        options.requirement,
+        'connection-requirement',
+    );
+    appendText(
+        copy,
+        'p',
+        options.endpoint,
+        'connection-endpoint',
+    );
+    const controls = append(summary, 'div', 'connection-summary-controls');
+    const status = appendText(controls, 'span', '', 'ui-pill');
+    status.dataset.connectionStatus = '';
+    updateEnabledStatus(status, options.enabled);
+    const enabled = appendCheckbox(
+        controls,
+        '',
+        t('optionsEnabled'),
+        options.enabled,
+        '',
+        'connection-toggle',
+    );
+    const toggle = createButton(
+        controls,
+        card.mv3ExpandLabel,
+        'quiet compact-action',
+    );
+    toggle.dataset.connectionEdit = options.key;
+    toggle.dataset.focusKey = `proxy-connection-${options.key}`;
+    const editor = append(card, 'div', 'connection-editor field-grid');
+    editor.dataset.connectionEditor = '';
+    proxyEditorId += 1;
+    editor.id = `proxy-connection-editor-${proxyEditorId}`;
+    toggle.setAttribute('aria-controls', editor.id);
+    toggle.onclick = () => setConnectionEditorExpanded(
+        card,
+        toggle.getAttribute('aria-expanded') !== 'true',
+        true,
+    );
+    const expanded = options.enabled || options.forceOpen ||
+      state.openDisclosures.has(`connection:${options.key}`);
+    setConnectionEditorExpanded(card, expanded, false);
+    if (options.healthError) {
+      const warning = append(
+          card,
+          'div',
+          'connection-error status-banner error',
+      );
+      warning.setAttribute('role', 'status');
+      appendText(warning, 'p', options.healthError);
+      const maintenance = createButton(
+          warning,
+          t('popupOpenConnectionCheck'),
+          'quiet compact-action',
+      );
+      maintenance.onclick = () => navigateTo('maintenance');
+    }
+    return {card, editor, enabled, status, toggle};
+
+  }
+
+  function setConnectionEditorExpanded(card, expanded, remember) {
+
+    const editor = card.querySelector('[data-connection-editor]');
+    const toggle = card.querySelector('[data-connection-edit]');
+    if (!editor || !toggle) {
+      return;
+    }
+    editor.hidden = !expanded;
+    toggle.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+    toggle.textContent = expanded ?
+      card.mv3CollapseLabel :
+      card.mv3ExpandLabel;
+    if (remember) {
+      const key = `connection:${card.dataset.connectionKey}`;
+      if (expanded) {
+        state.openDisclosures.add(key);
+      } else {
+        state.openDisclosures.delete(key);
+      }
+    }
+
+  }
+
+  function updateEnabledStatus(status, enabled) {
+
+    status.textContent = t(enabled ? 'optionsEnabled' : 'optionsDisabled');
+    status.className = `ui-pill${enabled ? ' success' : ''}`;
+
+  }
+
+  function formatProxyEndpoint(type, host, port) {
+
+    const endpoint = `${String(host || '').trim()}:` +
+      String(port || '').trim();
+    return `${String(type || '').trim()} · ${endpoint}`;
+
+  }
+
+  function getProxyConnectionHealthError(key) {
+
+    const health = state.snapshot.reliability &&
+      state.snapshot.reliability.proxyHealth || {};
+    if (health.status !== 'error' || health.candidateType !== key) {
+      return '';
+    }
+    return getLocalizedProxyHealthError(health);
+
+  }
+
+  function updateProxyAvailabilitySummary(form) {
+
+    const own = Array.from(form.querySelectorAll('.proxy-row'))
+        .filter((row) => getChecked(row, 'proxy.enabled') &&
+          getValue(row, 'proxy.host') && getValue(row, 'proxy.port'))
+        .length;
+    const count = own +
+      (getChecked(form, 'localTor.enabled') ? 1 : 0) +
+      (getChecked(form, 'torBrowser.enabled') ? 1 : 0) +
+      (getChecked(form, 'warp.enabled') &&
+        getValue(form, 'warp.proxyString') ? 1 : 0);
+    const status = root.querySelector('[data-proxy-availability]');
+    if (!status) {
+      return;
+    }
+    status.textContent = formatCount(
+        count,
+        'optionsOneProxyMethod',
+        'optionsManyProxyMethods',
+    );
+    status.className = `ui-pill ${count ? 'success' : 'warning'}`;
+
+  }
+
+  function syncProxyFormPresentation(form) {
+
+    const sourceStatus = form.querySelector('[data-source-connection-status]');
+    if (sourceStatus) {
+      updateEnabledStatus(
+          sourceStatus,
+          getChecked(form, 'usePacScriptProxies'),
+      );
+    }
+    form.querySelectorAll('[data-connection-key]').forEach((card) => {
+      const enabled = card.querySelector('.connection-toggle input');
+      const status = card.querySelector('[data-connection-status]');
+      if (enabled && status) {
+        updateEnabledStatus(status, enabled.checked);
+        if (enabled.checked) {
+          setConnectionEditorExpanded(card, true, false);
+        }
+      }
+    });
+    form.querySelectorAll('.proxy-row').forEach(updateOwnProxySummary);
+    updateProxyAvailabilitySummary(form);
+
+  }
+
   function renderOwnProxyMethods(parent, proxies) {
 
-    const section = append(parent, 'fieldset', 'editor-panel');
-    appendText(section, 'legend', t('popupOwnProxies'), 'item-title');
-    appendText(
-        section,
-        'p',
+    const section = createProxyConnectionGroup(
+        parent,
+        'custom',
+        t('popupOwnProxies'),
         t('optionsOwnProxyEditorHelp'),
-        'section-description',
     );
     const rows = append(section, 'div', 'own-proxy-rows');
-    proxies.forEach((proxy) => renderOwnProxyRow(rows, proxy));
+    proxies.forEach((proxy, index) => renderOwnProxyRow(
+        rows,
+        proxy,
+        {index, open: false},
+    ));
     if (!proxies.length) {
       const empty = append(rows, 'div', 'empty-state proxy-empty-state');
       appendText(empty, 'p', t('optionsNoOwnProxies'), 'item-title');
@@ -2689,10 +2978,30 @@
       if (empty) {
         empty.remove();
       }
-      renderOwnProxyRow(rows, createEmptyProxy());
+      renderOwnProxyRow(
+          rows,
+          createEmptyProxy(),
+          {index: rows.querySelectorAll('.proxy-row').length, open: true},
+      );
       updateOwnProxyOrderButtons(rows);
       markDraftDirty(parent);
     };
+    const healthError = getProxyConnectionHealthError('ownProxy');
+    if (healthError) {
+      const warning = append(
+          section,
+          'div',
+          'connection-error status-banner error',
+      );
+      warning.setAttribute('role', 'status');
+      appendText(warning, 'p', healthError);
+      const maintenance = createButton(
+          warning,
+          t('popupOpenConnectionCheck'),
+          'quiet compact-action',
+      );
+      maintenance.onclick = () => navigateTo('maintenance');
+    }
 
   }
 
@@ -2711,38 +3020,76 @@
 
   }
 
-  function renderOwnProxyRow(parent, proxy) {
+  function renderOwnProxyRow(parent, proxy, options = {}) {
 
-    const row = append(parent, 'div', 'proxy-row');
+    const row = append(parent, 'div', 'proxy-row compact-proxy-row');
     row.mv3CredentialRef = proxy.credentialRef ?
       clone(proxy.credentialRef) :
       null;
     row.mv3HasPassword = proxy.hasPassword === true;
-    appendCheckbox(
-        row,
+    row.mv3ExpandLabel = t('optionsEditConnection');
+    row.mv3CollapseLabel = t('optionsHideConnectionDetails');
+    const summary = append(row, 'div', 'proxy-row-summary');
+    const copy = append(summary, 'div', 'proxy-summary-copy');
+    const title = appendText(
+        copy,
+        'h4',
+        t('optionsCustomProxyNumber', [String((options.index || 0) + 1)]),
+    );
+    title.dataset.proxyRowTitle = '';
+    const endpoint = appendText(copy, 'p', '', 'connection-endpoint');
+    endpoint.dataset.proxyEndpointSummary = '';
+    const authentication = appendText(
+        copy,
+        'p',
+        '',
+        'connection-authentication',
+    );
+    authentication.dataset.proxyAuthenticationSummary = '';
+    const controls = append(summary, 'div', 'connection-summary-controls');
+    const status = appendText(controls, 'span', '', 'ui-pill');
+    status.dataset.connectionStatus = '';
+    const enabled = appendCheckbox(
+        controls,
         'proxy.enabled',
         t('optionsEnabled'),
         proxy.enabled !== false,
         '',
-        'full',
+        'connection-toggle',
     );
-    appendSelect(
+    const edit = createButton(
+        controls,
+        row.mv3ExpandLabel,
+        'quiet compact-action',
+    );
+    edit.dataset.proxyEdit = '';
+    edit.dataset.focusKey = `proxy-row-edit-${proxyEditorId + 1}`;
+    const editor = append(row, 'div', 'proxy-editor field-grid');
+    editor.dataset.proxyEditor = '';
+    proxyEditorId += 1;
+    editor.id = `proxy-editor-${proxyEditorId}`;
+    edit.setAttribute('aria-controls', editor.id);
+    edit.onclick = () => setOwnProxyEditorExpanded(
         row,
+        edit.getAttribute('aria-expanded') !== 'true',
+    );
+    const type = appendSelect(
+        editor,
         'proxy.type',
         t('optionsType'),
         ['PROXY', 'HTTPS', 'SOCKS4', 'SOCKS5'],
         proxy.type || 'PROXY',
     );
-    appendField(
-        row,
+    const host = appendField(
+        editor,
         'text',
         'proxy.host',
         t('optionsHost'),
         proxy.host || '',
         {required: true},
     );
-    appendField(
-        row,
+    const port = appendField(
+        editor,
         'number',
         'proxy.port',
         t('optionsPort'),
@@ -2750,7 +3097,7 @@
         {min: 1, max: 65535, required: true},
     );
     appendField(
-        row,
+        editor,
         'text',
         'proxy.username',
         t('optionsUsername'),
@@ -2758,7 +3105,7 @@
         {autocomplete: 'username'},
     );
     const passwordMode = appendSelect(
-        row,
+        editor,
         'proxy.passwordMode',
         t('optionsPasswordAction'),
         proxy.hasPassword ? [
@@ -2773,7 +3120,7 @@
         {help: t('optionsPasswordIntentHelp')},
     );
     const password = appendField(
-        row,
+        editor,
         'password',
         'proxy.password',
         t('optionsNewPassword'),
@@ -2789,9 +3136,10 @@
       if (password.disabled) {
         password.value = '';
       }
+      updateOwnProxySummary(row);
     };
     appendCheckbox(
-        row,
+        editor,
         'proxy.useAsDirectReplacement',
         t('optionsDirectReplacement'),
         proxy.useAsDirectReplacement === true,
@@ -2799,14 +3147,14 @@
         'full',
     );
     appendField(
-        row,
+        editor,
         'text',
         'proxy.note',
         t('optionsNote'),
         proxy.note || '',
         {full: true},
     );
-    const actions = append(row, 'div', 'rule-actions full');
+    const actions = append(row, 'div', 'rule-actions proxy-row-actions');
     const moveUp = createButton(
         actions,
         t('optionsMoveUp'),
@@ -2834,7 +3182,62 @@
         markDraftDirty(form);
       }
     };
+    enabled.onchange = () => updateOwnProxySummary(row);
+    type.onchange = () => updateOwnProxySummary(row);
+    host.oninput = () => updateOwnProxySummary(row);
+    port.oninput = () => updateOwnProxySummary(row);
+    password.oninput = () => updateOwnProxySummary(row);
+    const invalid = !String(proxy.host || '').trim() ||
+      !Number.isInteger(Number(proxy.port)) || Number(proxy.port) < 1 ||
+      Number(proxy.port) > 65535;
+    setOwnProxyEditorExpanded(row, options.open === true || invalid);
+    updateOwnProxySummary(row);
     updateOwnProxyOrderButtons(parent);
+
+  }
+
+  function setOwnProxyEditorExpanded(row, expanded) {
+
+    const editor = row.querySelector('[data-proxy-editor]');
+    const edit = row.querySelector('[data-proxy-edit]');
+    if (!editor || !edit) {
+      return;
+    }
+    editor.hidden = !expanded;
+    edit.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+    edit.textContent = expanded ?
+      row.mv3CollapseLabel :
+      row.mv3ExpandLabel;
+
+  }
+
+  function updateOwnProxySummary(row) {
+
+    const type = getValue(row, 'proxy.type') || 'PROXY';
+    const host = getValue(row, 'proxy.host');
+    const port = getValue(row, 'proxy.port');
+    const endpoint = row.querySelector('[data-proxy-endpoint-summary]');
+    endpoint.textContent = host && port ?
+      formatProxyEndpoint(type, host, port) :
+      t('optionsEndpointNotConfigured');
+    const passwordMode = getValue(row, 'proxy.passwordMode');
+    const hasReplacement = passwordMode === 'replace' &&
+      Boolean(getRawValue(row, 'proxy.password'));
+    const hasAuthentication = (
+      row.mv3HasPassword && passwordMode === 'preserve'
+    ) || hasReplacement;
+    row.querySelector('[data-proxy-authentication-summary]').textContent =
+      t(hasAuthentication ?
+        'optionsAuthenticationConfigured' :
+        'optionsNoAuthenticationConfigured');
+    const invalid = Boolean(row.querySelector('[aria-invalid="true"]'));
+    const status = row.querySelector('[data-connection-status]');
+    if (invalid) {
+      status.textContent = t('optionsNeedsAttention');
+      status.className = 'ui-pill error';
+    } else {
+      updateEnabledStatus(status, getChecked(row, 'proxy.enabled'));
+    }
 
   }
 
@@ -2863,6 +3266,10 @@
 
     const rows = Array.from(parent.querySelectorAll('.proxy-row'));
     rows.forEach((row, index) => {
+      const title = row.querySelector('[data-proxy-row-title]');
+      if (title) {
+        title.textContent = t('optionsCustomProxyNumber', [String(index + 1)]);
+      }
       const up = row.querySelector('[data-proxy-move="up"]');
       const down = row.querySelector('[data-proxy-move="down"]');
       if (up) {
@@ -2928,6 +3335,7 @@
     clearValidation(form);
     let firstInvalid = null;
     form.querySelectorAll('.proxy-row').forEach((row) => {
+      let rowInvalid = false;
       const host = row.querySelector('[name="proxy.host"]');
       const port = row.querySelector('[name="proxy.port"]');
       const passwordMode = row.querySelector(
@@ -2938,15 +3346,18 @@
       if (!host.value.trim()) {
         showFieldError(host, t('optionsProxyHostRequired'));
         firstInvalid = firstInvalid || host;
+        rowInvalid = true;
       }
       const portValue = Number(port.value);
       if (!Number.isInteger(portValue) || portValue < 1 || portValue > 65535) {
         showFieldError(port, t('optionsProxyPortInvalid'));
         firstInvalid = firstInvalid || port;
+        rowInvalid = true;
       }
       if (passwordMode.value === 'replace' && !password.value) {
         showFieldError(password, t('optionsPasswordRequiredForReplace'));
         firstInvalid = firstInvalid || password;
+        rowInvalid = true;
       }
       const ref = row.mv3CredentialRef;
       const endpointChanged = ref && (
@@ -2960,7 +3371,12 @@
             t('optionsPasswordEndpointChanged'),
         );
         firstInvalid = firstInvalid || passwordMode;
+        rowInvalid = true;
       }
+      if (rowInvalid) {
+        setOwnProxyEditorExpanded(row, true);
+      }
+      updateOwnProxySummary(row);
     });
     if (firstInvalid) {
       firstInvalid.focus();
@@ -3207,7 +3623,7 @@
     const keys = {
       localTor: 'popupLocalTor',
       torBrowser: 'popupTorBrowser',
-      warp: 'popupWarpCustomProxy',
+      warp: 'optionsWarpConnection',
       ownProxy: 'popupOwnProxies',
     };
     return keys[type] ? t(keys[type]) : t('optionsNone');
@@ -4182,6 +4598,12 @@
       const draft = state.drafts.get(form.dataset.draftKey);
       form.dataset.dirty = draft && draft.dirty ? 'true' : 'false';
       form.dataset.conflict = draft && draft.conflict ? 'true' : 'false';
+      if (form.dataset.draftKey === 'proxy-methods') {
+        const pending = form.querySelector('[data-proxy-draft-status]');
+        if (pending) {
+          pending.hidden = !(draft && draft.dirty);
+        }
+      }
     });
     const bar = root.querySelector('#global-action-bar');
     if (bar && state.snapshot) {

--- a/extensions/chromium/runet-censorship-bypass/src/extension-chromium-mv3/pages/options/options.css
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-chromium-mv3/pages/options/options.css
@@ -267,6 +267,116 @@ ul:last-child {
   gap: var(--ui-space-1);
 }
 
+.proxy-connections-form,
+.proxy-connection-group,
+.connection-list,
+.own-proxy-rows {
+  display: grid;
+  gap: var(--ui-space-1-5);
+}
+
+.proxy-form-header,
+.connection-summary,
+.connection-summary-controls,
+.proxy-row-summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--ui-space-1);
+  align-items: center;
+}
+
+.proxy-form-header,
+.connection-summary,
+.proxy-row-summary {
+  justify-content: space-between;
+}
+
+.proxy-form-header {
+  padding-bottom: var(--ui-space-1);
+  border-bottom: 1px solid var(--ui-color-divider);
+}
+
+.proxy-group-header {
+  display: grid;
+  gap: var(--ui-space-0-5);
+}
+
+.connection-card,
+.compact-proxy-row {
+  padding: var(--ui-space-1-5);
+  border: 1px solid var(--ui-color-divider);
+  border-radius: var(--ui-radius-medium);
+  background: var(--ui-color-surface);
+}
+
+.connection-summary-copy,
+.proxy-summary-copy {
+  min-width: min(100%, 260px);
+  flex: 1 1 360px;
+}
+
+.connection-summary-copy h4,
+.proxy-summary-copy h4 {
+  margin-bottom: 2px;
+  font-size: var(--ui-font-size-body);
+  font-weight: var(--ui-font-weight-bold);
+}
+
+.connection-requirement,
+.connection-endpoint,
+.connection-authentication {
+  margin: 0;
+  overflow-wrap: anywhere;
+  color: var(--ui-color-text-muted);
+  font-size: var(--ui-font-size-caption);
+}
+
+.connection-endpoint {
+  margin-top: 2px;
+  color: var(--ui-color-text-secondary);
+}
+
+.connection-summary-controls {
+  flex: 0 1 auto;
+  justify-content: flex-end;
+}
+
+.connection-toggle {
+  min-height: var(--ui-control-height-compact);
+  align-items: center;
+}
+
+.connection-toggle input {
+  margin-top: 0;
+}
+
+.compact-action {
+  min-height: var(--ui-control-height-compact);
+  padding: var(--ui-space-0-5) var(--ui-space-1);
+}
+
+.connection-editor,
+.proxy-editor {
+  margin-top: var(--ui-space-1-5);
+  padding-top: var(--ui-space-1-5);
+  border-top: 1px solid var(--ui-color-divider);
+}
+
+.connection-error {
+  display: grid;
+  gap: var(--ui-space-1);
+  justify-items: start;
+  margin-top: var(--ui-space-1-5);
+}
+
+.connection-error p {
+  margin: 0;
+}
+
+.proxy-row-actions {
+  margin-top: var(--ui-space-1);
+}
+
 .summary-item {
   min-width: 0;
   padding: var(--ui-space-1-5);
@@ -615,7 +725,6 @@ details.disclosure[open] > summary {
   padding: var(--ui-space-2);
 }
 
-.proxy-row,
 .rule-row {
   position: relative;
   display: grid;
@@ -631,7 +740,7 @@ details.disclosure[open] > summary {
   margin-top: var(--ui-space-1);
 }
 
-.proxy-row .full,
+.proxy-editor .full,
 .rule-row .full {
   grid-column: 1 / -1;
 }
@@ -771,9 +880,14 @@ details.disclosure[open] > summary {
     grid-template-columns: 1fr;
   }
 
-  .proxy-row,
+  .proxy-editor,
   .rule-row {
     grid-template-columns: 1fr;
+  }
+
+  .connection-summary-controls {
+    width: 100%;
+    justify-content: flex-start;
   }
 
   .global-action-bar {
@@ -813,6 +927,8 @@ details.disclosure[open] > summary {
   .item-row,
   .editor-panel,
   .method-card,
+  .connection-card,
+  .compact-proxy-row,
   details.disclosure {
     border-color: CanvasText;
     box-shadow: none;

--- a/extensions/chromium/runet-censorship-bypass/src/extension-chromium-mv3/test/options-ui.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-chromium-mv3/test/options-ui.js
@@ -1176,6 +1176,210 @@ describe('MV3 options UI', function() {
 
       });
 
+  it('groups source, local, custom, and advanced Proxy connections once',
+      async function() {
+
+        const snapshot = createSnapshot();
+        snapshot.state.pacMods.localTor.enabled = false;
+        snapshot.state.pacMods.torBrowser.enabled = false;
+        snapshot.state.pacMods.warp.enabled = false;
+        snapshot.state.pacMods.ownProxies = [];
+        const harness = await createHarness({snapshot});
+        const proxies = getSection(harness.root, 'proxy-methods');
+        expect(proxies.querySelectorAll('[data-proxy-group]')
+            .map((group) => group.dataset.proxyGroup)).to.deep.equal([
+          'source',
+          'local',
+          'custom',
+          'advanced',
+        ]);
+        expect(proxies.textContent).to.include('Source-provided proxies');
+        expect(proxies.textContent).to.include('Local proxy applications');
+        expect(proxies.textContent).to.include('Custom proxy servers');
+        expect(proxies.textContent).to.include(
+            'Advanced proxy-routing policies',
+        );
+        expect(getInput(proxies, 'usePacScriptProxies').checked)
+            .to.equal(true);
+        expect(proxies.querySelectorAll(
+            '[name="ownProxiesOnlyForOwnSites"]',
+        )).to.have.length(1);
+        expect(harness.root.querySelectorAll(
+            '[name="replaceDirectWithProxy"]',
+        )).to.have.length(1);
+        expect(harness.root.querySelectorAll('[name="noDirect"]'))
+            .to.have.length(1);
+        const policies = proxies.querySelector(
+            '[data-proxy-group="advanced"]',
+        );
+        expect(policies.tagName).to.equal('DETAILS');
+        findButton(policies, 'Open Advanced routing settings').onclick();
+        expect(getSection(harness.root, 'advanced').hidden).to.equal(false);
+        expect(harness.root.querySelector(
+            '[data-disclosure-key="advanced-routing"]',
+        ).open).to.equal(true);
+
+      });
+
+  it('keeps disabled local applications compact and exposes exact endpoints',
+      async function() {
+
+        const snapshot = createSnapshot();
+        snapshot.state.pacMods.localTor.enabled = false;
+        snapshot.state.pacMods.torBrowser.enabled = false;
+        snapshot.state.pacMods.warp.enabled = false;
+        const harness = await createHarness({snapshot});
+        const proxies = getSection(harness.root, 'proxy-methods');
+        const tor = proxies.querySelector('[data-connection-key="localTor"]');
+        const browser = proxies.querySelector(
+            '[data-connection-key="torBrowser"]',
+        );
+        const warp = proxies.querySelector('[data-connection-key="warp"]');
+        [tor, browser, warp].forEach((card) => {
+          expect(card.querySelector('[data-connection-editor]').hidden)
+              .to.equal(true);
+          expect(card.querySelector('[data-connection-edit]')
+              .getAttribute('aria-expanded')).to.equal('false');
+          expect(card.textContent).to.include('Disabled');
+        });
+        expect(tor.textContent).to.include('127.0.0.1:9050');
+        expect(tor.textContent).to.include(
+            'The local Tor service must be running.',
+        );
+        expect(browser.textContent).to.include('127.0.0.1:9150');
+        expect(browser.textContent).to.include('Tor Browser must be running.');
+        expect(warp.textContent).to.include('WARP');
+        expect(warp.textContent).to.not.include('WARP/custom proxy');
+        expect(getInput(warp, 'warp.proxyString').value)
+            .to.equal('SOCKS5 127.0.0.1:40000');
+
+        getInput(tor, 'localTor.enabled').checked = true;
+        getInput(tor, 'localTor.enabled').dispatch('change');
+        expect(tor.querySelector('[data-connection-editor]').hidden)
+            .to.equal(false);
+        expect(getInput(tor, 'localTor.host').value).to.equal('127.0.0.1');
+        expect(getInput(tor, 'localTor.port').value).to.equal('9050');
+        expect(harness.calls.map((call) => call.method))
+            .to.deep.equal(['getState']);
+        expect(proxies.querySelector('[data-proxy-draft-status]').hidden)
+            .to.equal(false);
+
+        getInput(browser, 'torBrowser.enabled').checked = true;
+        getInput(browser, 'torBrowser.enabled').dispatch('change');
+        expect(getInput(tor, 'localTor.enabled').checked).to.equal(false);
+        expect(browser.querySelector('[data-connection-editor]').hidden)
+            .to.equal(false);
+        expect(getInput(browser, 'torBrowser.port').value).to.equal('9150');
+
+        getInput(warp, 'warp.enabled').checked = true;
+        getInput(warp, 'warp.enabled').dispatch('change');
+        expect(warp.querySelector('[data-connection-editor]').hidden)
+            .to.equal(false);
+        expect(proxies.querySelector('[data-proxy-availability]').textContent)
+            .to.include('2 Proxy connections available');
+
+        harness.dispatchProxyChange();
+        await flush();
+        const refreshed = getSection(harness.root, 'proxy-methods');
+        const refreshedBrowser = refreshed.querySelector(
+            '[data-connection-key="torBrowser"]',
+        );
+        expect(getInput(refreshedBrowser, 'torBrowser.enabled').checked)
+            .to.equal(true);
+        expect(refreshedBrowser.querySelector(
+            '[data-connection-editor]',
+        ).hidden).to.equal(false);
+        expect(refreshedBrowser.textContent).to.include('Enabled');
+        expect(refreshed.querySelector('[data-proxy-availability]').textContent)
+            .to.include('2 Proxy connections available');
+
+      });
+
+  it('never substitutes the Tor and Tor Browser endpoint values',
+      async function() {
+
+        const snapshot = createSnapshot();
+        snapshot.state.pacMods.localTor = Object.assign(
+            {},
+            snapshot.state.pacMods.localTor,
+            {enabled: false, port: 9150},
+        );
+        snapshot.state.pacMods.torBrowser = Object.assign(
+            {},
+            snapshot.state.pacMods.torBrowser,
+            {enabled: false, port: 9050},
+        );
+        const harness = await createHarness({snapshot});
+        expect(getInput(harness.root, 'localTor.port').value).to.equal('9150');
+        expect(getInput(harness.root, 'torBrowser.port').value).to.equal('9050');
+
+      });
+
+  it('renders compact custom summaries and opens new or invalid editors',
+      async function() {
+
+        const snapshot = createSnapshot();
+        snapshot.state.pacMods.ownProxies = [{
+          enabled: true,
+          type: 'HTTPS',
+          host: 'first.example',
+          port: 443,
+          username: 'stored-user',
+          hasPassword: true,
+          credentialRef: {
+            index: 0,
+            revision: 4,
+            type: 'HTTPS',
+            host: 'first.example',
+            port: 443,
+            username: 'stored-user',
+          },
+          note: '',
+        }, {
+          enabled: false,
+          type: 'SOCKS5',
+          host: 'second.example',
+          port: 1080,
+          username: '',
+          hasPassword: false,
+          note: '',
+        }];
+        const harness = await createHarness({snapshot});
+        const proxies = getSection(harness.root, 'proxy-methods');
+        let rows = proxies.querySelectorAll('.proxy-row');
+        expect(rows).to.have.length(2);
+        expect(rows.every((row) => row.querySelector(
+            '[data-proxy-editor]',
+        ).hidden)).to.equal(true);
+        expect(rows[0].textContent).to.include('HTTPS · first.example:443');
+        expect(rows[0].textContent).to.include('Authentication configured');
+        expect(rows[0].textContent).to.not.include('stored-user');
+        expect(getInput(rows[0], 'proxy.password').value).to.equal('');
+
+        rows[0].querySelector('[data-proxy-edit]').onclick();
+        expect(rows[0].querySelector('[data-proxy-editor]').hidden)
+            .to.equal(false);
+        expect(rows[0].querySelector('[data-proxy-edit]')
+            .getAttribute('aria-expanded')).to.equal('true');
+
+        findButton(proxies, 'Add custom proxy server').onclick();
+        rows = proxies.querySelectorAll('.proxy-row');
+        expect(rows).to.have.length(3);
+        expect(rows[2].querySelector('[data-proxy-editor]').hidden)
+            .to.equal(false);
+        expect(getInput(rows[2], 'proxy.type').value).to.equal('PROXY');
+        expect(getInput(rows[2], 'proxy.port').value).to.equal('8080');
+        await findButton(proxies, 'Save proxy settings').onclick();
+        const invalidHost = getInput(rows[2], 'proxy.host');
+        expect(invalidHost.getAttribute('aria-invalid')).to.equal('true');
+        expect(harness.document.activeElement).to.equal(invalidHost);
+        expect(rows[2].textContent).to.include('Needs attention');
+        expect(harness.calls.some((call) =>
+          call.method === 'applyPopupChanges',
+        )).to.equal(false);
+
+      });
+
   it('separates applied, cleared, and external ownership actions',
       async function() {
 


### PR DESCRIPTION
## Summary

- reorganize Proxy connections as source-provided proxies → compact local applications → custom proxy servers → advanced proxy-routing policies
- keep Tor, Tor Browser, and WARP endpoint controls behind accessible inline disclosure while preserving their exact defaults and values
- render custom proxies as credential-safe summaries with inline editing, explicit reorder/remove controls, and invalid-row focus
- keep source-proxy inclusion and custom-proxy scope in one place; Direct replacement and fallback remain in the established Advanced section
- show local Not applied feedback for Proxy-connection drafts while preserving the existing Save and global Apply workflow

No PAC, routing, candidate-order, authentication, credential-storage, state-schema, service-worker, health, ownership, permission, dependency, workflow, version, or release semantics changed.

## Validation

- PAC: 26 passing
- MV3: 353 passing
- aggregate: 369 passing
- Chrome Stable 151.0.7922.174 full browser smoke: PASS
- production audit: 0 vulnerabilities
- full audit: accepted Mocha dev-only baseline (3 advisories)
- MV3 package: exactly 70 runtime files, version 0.0.2.3 / 0.0.2.03
- EN/RU Chrome matrix: 36 desktop/narrow cases, no horizontal overflow, console errors, or password exposure
- docs integrity and git diff --check: PASS

README screenshots are intentionally deferred to the next focused documentation PR.