### PR TITLE
release: prepare v0.0.3.0

### DIFF
--- a/extensions/chromium/runet-censorship-bypass/src/extension-chromium-mv3/test/options-ui.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-chromium-mv3/test/options-ui.js
@@ -659,7 +659,7 @@ async function createHarness(options = {}) {
       runtime: {
         getManifest() {
 
-          return {version: '0.0.2.3', version_name: '0.0.2.03'};
+          return {version: '0.0.3.0', version_name: '0.0.3.00'};
 
         },
       },
@@ -1035,7 +1035,7 @@ describe('MV3 options UI', function() {
         ]);
         expect(harness.root.textContent).to.include('Overview');
         expect(harness.root.textContent).to.include('Automatic routing');
-        expect(harness.root.textContent).to.include('0.0.2.03');
+        expect(harness.root.textContent).to.include('0.0.3.00');
         expect(harness.root.textContent).to.include('Stable release');
         expect(harness.root.textContent).not.to.include('MV3 migration:');
         const navigation = harness.root.querySelectorAll('.options-nav a');

--- a/extensions/chromium/runet-censorship-bypass/src/extension-chromium-mv3/test/verify-package-integrity.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-chromium-mv3/test/verify-package-integrity.js
@@ -22,8 +22,8 @@ const COMMON_SOURCE_ROOT = Path.resolve(
     'extension-common',
 );
 const MV3_LOCALES = Object.freeze(['en', 'ru']);
-const EXPECTED_MV3_VERSION = '0.0.2.3';
-const EXPECTED_MV3_VERSION_NAME = '0.0.2.03';
+const EXPECTED_MV3_VERSION = '0.0.3.0';
+const EXPECTED_MV3_VERSION_NAME = '0.0.3.00';
 
 const ALLOWED_RUNTIME_DIRECTORIES = new Set([
   'background/vendor/tldts/dist',

--- a/extensions/chromium/runet-censorship-bypass/src/templates-data.js
+++ b/extensions/chromium/runet-censorship-bypass/src/templates-data.js
@@ -41,8 +41,8 @@ exports.contexts.mini = Object.assign({}, commonContext, {
 });
 
 exports.contexts.chromiumMv3 = Object.assign({}, commonContext, {
-  version: '2.03',
-  storeVersion: '2.3',
+  version: '3.00',
+  storeVersion: '3.0',
   versionSuffix: '-mv3',
   nameSuffixEn: '',
   nameSuffixRu: '',


### PR DESCRIPTION
## Summary

- keep product code frozen;
- update only the authoritative Chromium MV3 version inputs and matching package/About test expectations;
- generate `version: 0.0.3.0` and `version_name: 0.0.3.00`;
- leave published `v0.0.2.3` README, current-release metadata, tag, release, and assets intentionally unchanged until publication.

## Release provenance

Trusted artifact `9607867100` remains the polished `0.0.2.3 / 0.0.2.03` baseline and cannot be the `v0.0.3.0` release payload. After this PR is squash-merged, the exact trusted-main artifact generated for the new versioned main SHA will be the sole release-candidate source.

The canonical package comparison contains 70 runtime files: missing 0, extra 0, changed only `manifest.json`; the other 69 files are byte-identical to artifact `9607867100`. The manifest diff changes only `version` and `version_name`.

## Validation

- production audit: 0 vulnerabilities;
- full audit: accepted Mocha dev-only baseline (`diff` low, `mocha` moderate, `serialize-javascript` high);
- documentation integrity: pass;
- PAC: 26 passing;
- MV3: 353 passing;
- aggregate: 369 passing;
- focused MV3 lint: pass;
- MV2 before MV3 builds: pass;
- Chrome Stable 151.0.7922.174 full browser smoke: pass;
- package integrity: 70 runtime files, no repository-only leakage;
- dependencies and lockfile unchanged.