### PR TITLE
security: codify supply-chain policy

### DIFF
--- a/.agents/skills/dependency-review/SKILL.md
+++ b/.agents/skills/dependency-review/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: dependency-review
+description: Review package.json or package-lock changes, new or updated dependencies, vendored third-party code, GitHub Action additions or updates, or dependency-manager configuration in this repository.
+---
+
+# Dependency review
+
+Work from the repository root, read `AGENTS.md` and any scoped `AGENTS.md`, and establish the exact dependency, vendored-code, Action, or configuration delta before installing anything. Obey the legacy Options quarantine; do not install that package unless the user explicitly scopes a dedicated remediation task.
+
+1. Prefer browser/WebExtension APIs, Node APIs, and existing dependencies when they satisfy the requirement. State why a proposed dependency is preferable to platform, existing, or small auditable local code; do not locally reimplement complex security-sensitive primitives merely to avoid a mature dependency.
+2. Confirm the exact registry/package and source-repository identities and that the selected version exists before installation. Require the selected production or development dependency version to have been publicly available for at least 7 full days (168 hours), measured from registry publication to review. A younger version requires a concrete security or compatibility emergency, explicit user approval, and a prominent record of its version, age, reason, and extra review; an AI agent cannot approve the exception.
+3. Verify the selected version's publication metadata, license compatibility, public source/package correspondence, maintenance history, current maintainers or owners and their observable changes, advisories or malware reports, package/tarball contents, registry integrity/signature, and available provenance or attestations. Treat downloads, stars, activity, and Scorecard results as signals only, never proof.
+4. Inspect exactly what every newly introduced direct or transitive `preinstall`, `install`, or `postinstall` script executes. Record why it is needed and safe. Review transitive dependency and package-size growth for unexplained additions.
+5. Review the complete lockfile delta, including selected versions, resolved URLs, integrity hashes, source changes, lifecycle-script flags, and unexpected packages. Reject unexplained changes and explicitly review git, file, arbitrary-URL, or other non-registry sources. Prefer exact direct version pins.
+6. For a new or changed third-party GitHub Action, verify the full commit SHA belongs to the intended official repository/version, inspect its source and dependencies, require explicit least-privilege permissions, and keep `persist-credentials: false` unless write credentials are explicitly required.
+7. Run or evaluate the applicable deterministic install, audit, signature, build, and test commands from the authoritative package directory. For the Chromium package use:
+
+   ```powershell
+   $Project = '.\extensions\chromium\runet-censorship-bypass'
+   npm ci --prefix $Project
+   npm --prefix $Project run audit:prod
+   npm audit --prefix $Project
+   npm audit signatures --prefix $Project
+   ```
+
+   Record registry-signature and provenance results plus any CLI limitation. Run the relevant repository builds and tests for the affected scope.
+8. Review vendored third-party runtime code to the same standard, including origin, license, version, source correspondence, executable contents, and update provenance. Copying minified code does not bypass review.
+
+Never run `npm audit fix --force`, install a package before confirming its identity, judge safety only from popularity or Scorecard signals, or hide transitive and lifecycle-script changes.
+
+Return exactly one decision with the evidence and unresolved risks: `APPROVE`, `REJECT`, or `NEEDS USER APPROVAL`. Use `NEEDS USER APPROVAL` for a less-than-7-day emergency exception, a material unresolved trust issue, an unusual lifecycle script, or source/maintainer identity ambiguity that cannot be resolved safely.

--- a/.agents/skills/mv3-security-review/SKILL.md
+++ b/.agents/skills/mv3-security-review/SKILL.md
@@ -7,15 +7,18 @@ description: Perform a focused MV3 security review after changes to permissions,
 
 Work from the repository root. Set `$Project = '.\extensions\chromium\runet-censorship-bypass'` and read `AGENTS.md` plus `$Project\src\extension-chromium-mv3\background\AGENTS.md`. Review the complete relevant diff and enough callers to prove impact. Do not echo secrets, credential-bearing strings, full custom provider URLs, or browser-profile data; cite their locations and redact values.
 
+If the change also touches a package manifest or lock, vendored third-party code, dependency-manager configuration, or a GitHub Action, use `$dependency-review` as well. Where dependency changes intersect runtime security, review newly introduced lifecycle scripts and non-registry sources plus the code that actually enters service-worker or page execution; do not duplicate the general dependency review here.
+
 Review the affected boundary and any plausible adjacent effects. Use the following order for applicable items; do not add ceremonial `N/A` sections for unrelated categories:
 
 1. Permission or host-access expansion in `manifest.tmpl.json`, including whether `<all_urls>` use grew.
-2. CSP/script execution and the PAC trust boundary: downloaded PAC stays data until Chromium receives it; flag dynamic extension execution.
-3. URL scheme, redirect/final-URL, size, fallback, and external-request validation.
+2. CSP/script execution and the PAC trust boundary: downloaded PAC stays data until Chromium receives it; flag dynamic extension execution. Distinguish proving that extension code does not evaluate remote code from proving Chrome or Firefox store remote-code-policy compliance.
+3. URL scheme, redirect/final-URL, size, fallback, credential mode, referrer policy, and external-request validation for PAC and other fetches.
 4. Credential path from structured state to `onAuthRequired`; generated PAC, UI, event, error, log, diagnostic, health, and migration redaction.
-5. IndexedDB artifacts versus `mv3State`, service-worker restart recovery, alarm reconstruction, concurrent whole-state writes, and destructive cleanup.
+5. IndexedDB artifacts versus `mv3State`, service-worker restart recovery, alarm reconstruction, concurrent whole-state writes, and destructive cleanup. When content scripts or externally reachable contexts are introduced, verify `storage.local` and `storage.session` access levels.
 6. Routing fail-open/fail-closed effects, `DIRECT` or direct-IP leak paths, live proxy-control checks, proxy-error coverage, and custom-provider disable/delete behavior.
 7. Migration confirmation, field selection, idempotence, old-data retention, proxy-apply side effects, and active refresh-interval mapping.
+8. Packaged-code allowlists, unreferenced executable code, and source correspondence for vendored runtime code where relevant.
 
 Run:
 

--- a/.agents/skills/release-candidate/SKILL.md
+++ b/.agents/skills/release-candidate/SKILL.md
@@ -10,7 +10,14 @@ This workflow produces a local preflight artifact only. Its locally built and pa
 Work from the repository root, set `$Project = '.\extensions\chromium\runet-censorship-bypass'`, and read `AGENTS.md`. Do not commit, publish, upload, clean user changes, overwrite an existing archive, or reveal matched secret/private URL values.
 
 1. Inspect `git status --short`, staged paths, and the complete release-relevant diff. A normal RC requires a clean tree; package a dirty tree only when the user explicitly accepts its exact contents.
-2. Run the existing deterministic checks and builds. MV2 must precede MV3 because `build:mv2` deletes all of `build`:
+2. Check the release supply chain. Run the production audit and `npm audit signatures`; record tool limitations rather than weakening the check. Confirm that package/lock, vendored-code, dependency-manager, and GitHub Action changes received `$dependency-review`. Inspect newly introduced lifecycle scripts, reject unexpected non-registry dependency sources, and confirm source/package correspondence for vendored runtime dependencies where applicable.
+
+   ```powershell
+   npm --prefix $Project run audit:prod
+   npm audit signatures --prefix $Project
+   ```
+
+3. Run the existing deterministic checks and builds. MV2 must precede MV3 because `build:mv2` deletes all of `build`:
 
    ```powershell
    npm --prefix $Project test
@@ -19,7 +26,7 @@ Work from the repository root, set `$Project = '.\extensions\chromium\runet-cens
    npm --prefix $Project run build:mv3
    ```
 
-3. Validate `$Project\build\extension-chromium-mv3\manifest.json`, derive a new local archive name from its version, and package the contents of that build directory at archive root with PowerShell `Compress-Archive`. Confirm `manifest.json` is at archive root and calculate SHA-256 with `Get-FileHash`.
-4. If the ignored legacy options bundle is unavailable, report that the MV2 result was copy/template sanity only; do not call it a functional legacy UI build. Rebuild that bundle with its existing nested lockfile when legacy/shared changes require it.
-5. Scan staged paths, generated output, and the archive without printing matched values. Reject dependency, cache, profile, log, environment, key, coverage, nested build/dist, secret, credential, or private-URL material.
-6. Return version/version-name, local preflight archive path relative to the project, SHA-256, commands and results, dirty-tree state, legacy-build scope, a concise change/security summary, and remaining browser QA. Label the archive as local preflight output, not a public release source. Browser QA includes load-unpacked startup/restart, provider refresh without auto-enable, Proxy/Auto/Direct, real Tor and authenticated proxy behavior, proxy errors/takeover, IndexedDB persistence, and upgraded-profile migration.
+4. Validate `$Project\build\extension-chromium-mv3\manifest.json`, derive a new local archive name from its version, and package the contents of that build directory at archive root with PowerShell `Compress-Archive`. Confirm `manifest.json` is at archive root and calculate SHA-256 with `Get-FileHash`.
+5. Treat the legacy Options toolchain under `$Project\src\extension-common\pages\options` as security-quarantined. Do not install or build it merely to obtain a functional legacy UI bundle. Report that functional build as unavailable/quarantined and state the MV2 copy/template scope actually checked. Any future need to run it requires a dedicated remediation task after `$dependency-review`.
+6. Scan staged paths, generated output, and the archive without printing matched values. Reject dependency, cache, profile, log, environment, key, coverage, nested build/dist, secret, credential, or private-URL material.
+7. Return version/version-name, local preflight archive path relative to the project, SHA-256, commands and results, dirty-tree state, legacy-build scope, supply-chain checks, a concise change/security summary, and remaining browser QA. Label the archive as local preflight output, not a public release source. Browser QA includes load-unpacked startup/restart, provider refresh without auto-enable, Proxy/Auto/Direct, real Tor and authenticated proxy behavior, proxy errors/takeover, IndexedDB persistence, and upgraded-profile migration.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ npm --prefix $Project run build:mv2
 npm --prefix $Project run verify:mv3
 ```
 
-Use Windows PowerShell-compatible commands. Use `npm ci --prefix $Project` only when extension dependencies are missing. A functional legacy options bundle additionally needs `npm ci --prefix "$Project\src\extension-common\pages\options"` followed by `npm --prefix "$Project\src\extension-common\pages\options" run build`. `build:mv2` deletes the complete `build` directory, so always build MV2 before the final MV3 build. Whole-tree `npm run lint` has pre-existing legacy failures; use the focused `lint:mv3` check for MV3 work and report the legacy baseline rather than reformatting it.
+Use Windows PowerShell-compatible commands. Use `npm ci --prefix $Project` only when extension dependencies are missing. The obsolete dependency tree under `$Project\src\extension-common\pages\options` is security-quarantined: do not install or build it during ordinary work, reuse it for Firefox, or add it to normal CI. Any task that genuinely requires that toolchain must first be scoped as dedicated dependency/toolchain remediation using `$dependency-review`. `build:mv2` deletes the complete `build` directory, so always build MV2 before the final MV3 build. Whole-tree `npm run lint` has pre-existing legacy failures; use the focused `lint:mv3` check for MV3 work and report the legacy baseline rather than reformatting it.
 
 ## Coding approach
 
@@ -30,6 +30,18 @@ Use Windows PowerShell-compatible commands. Use `npm ci --prefix $Project` only 
 - For non-trivial work, use observable success criteria to guide implementation and verification. State them only when they help align scope or explain the evidence.
 - Prefer the simplest solution that fully meets the requirement and fits the existing architecture. Add features, configuration, flexibility, or abstractions only for a demonstrated requirement or design need.
 - Make focused changes and preserve unrelated behavior and user work. Do not reformat legacy files, regenerate lockfiles unnecessarily, or alter production behavior as cleanup.
+
+## Dependency, Actions, and supply-chain policy
+
+- Adding a dependency is not the default solution. Check browser/WebExtension APIs, Node APIs, and existing dependencies first. Prefer a small auditable local implementation for simple functionality when it avoids a large dependency tree, but do not reimplement mature security-sensitive primitives merely to avoid a legitimate established dependency.
+- A package version must have been publicly available for at least 7 full days (168 hours), measured from its registry publication timestamp to review time, before it may be newly added or selected by an update. This applies to direct production and development dependencies; do not reduce it to 24, 48, or 72 hours or an unspecified few days. An exception requires a concrete security or compatibility emergency, explicit user approval, and a prominent PR record of the package/version, publication age, reason, and additional review. An AI agent cannot approve its own exception.
+- Before adding a new direct dependency, use `$dependency-review` and verify its exact registry identity and selected version, publication date, public source repository and source/package correspondence, compatible license, maintenance history, observable maintainers/owners, advisories or malware reports, package/tarball contents, lifecycle scripts, transitive delta, registry integrity/signature, available provenance/attestation, and unexplained dependency or package-size growth. Downloads, stars, repository activity, OpenSSF Scorecard, and similar metrics are signals only, never proof of safety; there is no `npm reviews` requirement.
+- Re-review a previously accepted package when there is evidence of an unexpected maintainer or repository-ownership change, source-repository change, dormant-project release, new lifecycle script, dramatic package-size or unusual transitive growth, public-source/package mismatch, or unusual registry, source, or integrity change.
+- Manually inspect exactly what every newly introduced direct or transitive `preinstall`, `install`, or `postinstall` script executes. The dependency review must record why the script is needed and safe; never dismiss it as normal package behavior.
+- Commit package locks, use `npm ci` for deterministic installation and CI, and review lockfile deltas for the versions actually installed. Reject unexplained registry/source or integrity changes and require explicit review for git, file, or arbitrary-URL dependencies. Never run `npm audit fix --force` automatically. Prefer exact direct version pins because this project has no library-consumer semver flexibility requirement; convert existing ranges only in a separately reviewed change.
+- Pin third-party GitHub Actions to full immutable commit SHAs, verify each SHA belongs to the intended official repository/version, declare explicit least-privilege workflow permissions, and set `persist-credentials: false` unless a task explicitly requires write credentials. Review new or changed third-party Actions like dependencies.
+- An AI/Codex agent must not propose or install a package merely because it remembers the name, finds it convenient, sees it in generated output, or thinks the name looks right. It must first prove that the package exists, its registry and source-repository identities are correct, the requested version exists, and the same age, trust, and security policy was applied. This guards against hallucinated, dependency-confusion, and slopsquatted package names.
+- Apply the same trust and security review to new vendored runtime libraries or code. Copying a minified library into the repository does not bypass dependency review.
 
 ## Documentation and release ownership
 
@@ -54,10 +66,12 @@ Use Windows PowerShell-compatible commands. Use `npm ci --prefix $Project` only 
 
 ## Change rules and required checks
 
+- Dependency manifests, lockfiles, vendored third-party libraries, dependency-manager configuration, or GitHub Action additions/updates: use `$dependency-review`. If the change also crosses an MV3 security boundary, use `$mv3-security-review` as well.
 - PAC/routing/candidate changes: use `$pac-regression`, run `test:pac` and `test:mv3`, and add semantic cases when behavior changes.
 - MV3 permissions, service worker, downloads, storage, auth, migration, external requests, or proxy errors: use `$mv3-security-review`, run `lint:mv3`, `test:mv3`, and `build:mv3`; identify real-browser QA.
-- Shared/template/gulp/MV2 changes: run the full tests and `build:mv2`, then rebuild MV3. Report when the legacy options bundle could not be rebuilt.
+- Shared/template/gulp/MV2 changes: run the full tests and `build:mv2`, then rebuild MV3. Report the quarantined legacy Options functional build as unavailable and describe only the copy/template scope actually validated.
 - MV3 UI/localization changes: update both `en` and `ru`, build MV3, and manually check affected controls. Never render stored values with HTML injection sinks.
+- Release preparation, provenance, packaging, or audit work: use `$release-candidate`.
 - Agent/docs-only changes: run `node ./scripts/verify-docs.mjs`, validate skill frontmatter/paths when relevant, and run `git diff --check`; do not claim product checks were necessary if no runtime file changed.
 
 Before calling work complete, review the complete relevant diff and run the checks required above. If a required check cannot run, report the work as incomplete and explain why. Confirm that generated/profile/secret material is neither staged nor packaged, preserve unrelated changes, and name browser-dependent gaps. Report changed files and checks with pass/fail results; mention security/routing impact, unresolved product issues, generated artifacts, and browser QA only when relevant. Include final `git status --short`. Never commit, push, publish, or upload unless separately authorized.

--- a/extensions/chromium/runet-censorship-bypass/src/extension-common/pages/options/AGENTS.md
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-common/pages/options/AGENTS.md
@@ -1,0 +1,9 @@
+# SECURITY QUARANTINE
+
+These instructions apply to the legacy Options source and toolchain in this directory. A security audit on 2026-08-26 found its obsolete dependency tree had 37 advisories, including 11 Critical, and obsolete dependencies with install scripts.
+
+- Do not run `npm install`, `npm ci`, or package builds here during ordinary development, and do not add this toolchain to normal CI.
+- Do not reuse this implementation or toolchain for Firefox support.
+- Do not attempt remediation with `npm audit fix --force`.
+- Any dedicated remediation must use `$dependency-review` and explicitly review the complete dependency/toolchain delta before installation.
+- Preserve these legacy sources and their history unless the remediation task explicitly decides otherwise.


### PR DESCRIPTION
## Summary

- codify dependency minimization, a hard 7-day/168-hour package-version age gate, trust review, lifecycle-script inspection, lockfile controls, full-SHA GitHub Actions policy, and AI/slopsquatting protections
- add the focused `dependency-review` skill and integrate it with MV3 security and release reviews
- quarantine the dormant legacy Options toolchain found with 37 advisories, including 11 Critical, without installing or modifying its dependencies

This is an instructions/policy/skills-only change. Runtime, dependencies, lockfiles, workflows, versions, and releases are unchanged.

## Validation

- `node .\scripts\verify-docs.mjs`
- skill frontmatter/name/description/path/command validation for all changed/new skills
- `git diff --check`