### PR TITLE
security: enforce supply-chain checks

### DIFF
--- a/.agents/skills/dependency-review/SKILL.md
+++ b/.agents/skills/dependency-review/SKILL.md
@@ -17,6 +17,8 @@ Work from the repository root, read `AGENTS.md` and any scoped `AGENTS.md`, and 
 
    ```powershell
    $Project = '.\extensions\chromium\runet-censorship-bypass'
+   node .\scripts\verify-supply-chain.mjs
+   node --test .\scripts\verify-supply-chain.test.mjs
    npm ci --prefix $Project
    npm --prefix $Project run audit:prod
    npm audit --prefix $Project

--- a/.agents/skills/release-candidate/SKILL.md
+++ b/.agents/skills/release-candidate/SKILL.md
@@ -5,7 +5,7 @@ description: Prepare or audit a local Chromium MV3 release preflight for this re
 
 # Local release preflight
 
-This workflow produces a local preflight artifact only. Its locally built and packaged archive is not the canonical public release artifact and must not be published as one. Every public beta or release must follow `docs/development/RELEASE_PROCESS.md` and use the exact artifact from successful trusted-main CI for the validated `main` commit.
+This workflow produces a local preflight artifact only. Its locally built and packaged archive is not the canonical public release artifact and must not be published as one. Every public beta or release must follow `docs/development/RELEASE_PROCESS.md` and use the exact artifact from successful trusted-main CI for the validated `main` commit. Normally that is the push-to-main run. If GitHub creates no push run, do not rewrite or synthesize a commit: manually dispatch `Verify MV3` on `main` and accept it only when the event is `workflow_dispatch`, the ref is `refs/heads/main`, its head SHA equals current `origin/main`, the complete normal job succeeds, and that run uploads the canonical artifact.
 
 Work from the repository root, set `$Project = '.\extensions\chromium\runet-censorship-bypass'`, and read `AGENTS.md`. Do not commit, publish, upload, clean user changes, overwrite an existing archive, or reveal matched secret/private URL values.
 
@@ -13,6 +13,8 @@ Work from the repository root, set `$Project = '.\extensions\chromium\runet-cens
 2. Check the release supply chain. Run the production audit and `npm audit signatures`; record tool limitations rather than weakening the check. Confirm that package/lock, vendored-code, dependency-manager, and GitHub Action changes received `$dependency-review`. Inspect newly introduced lifecycle scripts, reject unexpected non-registry dependency sources, and confirm source/package correspondence for vendored runtime dependencies where applicable.
 
    ```powershell
+   node .\scripts\verify-supply-chain.mjs
+   node --test .\scripts\verify-supply-chain.test.mjs
    npm --prefix $Project run audit:prod
    npm audit signatures --prefix $Project
    ```

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+* text=auto eol=lf
+
+*.gif -text
+*.ico -text
+*.jpeg -text
+*.jpg -text
+*.pdf -text
+*.png -text
+*.webp -text
+*.woff -text
+*.woff2 -text
+*.zip -text

--- a/.github/workflows/mv3.yml
+++ b/.github/workflows/mv3.yml
@@ -1,6 +1,7 @@
 name: Verify MV3
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
@@ -29,6 +30,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Set up Node.js
@@ -41,8 +43,25 @@ jobs:
       - name: Verify documentation integrity
         run: node ./scripts/verify-docs.mjs
 
+      - name: Verify supply-chain policy
+        env:
+          SUPPLY_CHAIN_BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || '' }}
+        run: node ./scripts/verify-supply-chain.mjs
+
+      - name: Test supply-chain verifier
+        run: node --test ./scripts/verify-supply-chain.test.mjs
+
+      - name: Review dependency changes
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+        with:
+          show-openssf-scorecard: false
+
       - name: Install extension dependencies
         run: npm ci --prefix ./extensions/chromium/runet-censorship-bypass
+
+      - name: Verify registry signatures
+        run: npm audit signatures --prefix ./extensions/chromium/runet-censorship-bypass
 
       - name: Audit production dependencies
         run: npm --prefix ./extensions/chromium/runet-censorship-bypass run audit:prod
@@ -75,7 +94,7 @@ jobs:
         run: git diff --exit-code
 
       - name: Upload unpacked MV3 build
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        if: ${{ github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: runet-censorship-bypass-mv3-${{ github.sha }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,8 @@ When required by the change rules below, run these commands from the repository 
 
 ```powershell
 $Project = '.\extensions\chromium\runet-censorship-bypass'
+node .\scripts\verify-supply-chain.mjs
+node --test .\scripts\verify-supply-chain.test.mjs
 npm --prefix $Project test
 npm --prefix $Project run test:pac
 npm --prefix $Project run build:mv2
@@ -66,7 +68,7 @@ Use Windows PowerShell-compatible commands. Use `npm ci --prefix $Project` only 
 
 ## Change rules and required checks
 
-- Dependency manifests, lockfiles, vendored third-party libraries, dependency-manager configuration, or GitHub Action additions/updates: use `$dependency-review`. If the change also crosses an MV3 security boundary, use `$mv3-security-review` as well.
+- Dependency manifests, lockfiles, vendored third-party libraries, dependency-manager configuration, or GitHub Action additions/updates: use `$dependency-review`, run `node .\scripts\verify-supply-chain.mjs` and its focused Node test, and run the applicable audit/build/test gates. If the change also crosses an MV3 security boundary, use `$mv3-security-review` as well.
 - PAC/routing/candidate changes: use `$pac-regression`, run `test:pac` and `test:mv3`, and add semantic cases when behavior changes.
 - MV3 permissions, service worker, downloads, storage, auth, migration, external requests, or proxy errors: use `$mv3-security-review`, run `lint:mv3`, `test:mv3`, and `build:mv3`; identify real-browser QA.
 - Shared/template/gulp/MV2 changes: run the full tests and `build:mv2`, then rebuild MV3. Report the quarantined legacy Options functional build as unavailable and describe only the copy/template scope actually validated.

--- a/docs/development/RELEASE_PROCESS.md
+++ b/docs/development/RELEASE_PROCESS.md
@@ -30,7 +30,10 @@ trusted-main CI и проверки того же артефакта, котор
 ```powershell
 $Project = '.\extensions\chromium\runet-censorship-bypass'
 node .\scripts\verify-docs.mjs
+node .\scripts\verify-supply-chain.mjs
+node --test .\scripts\verify-supply-chain.test.mjs
 npm ci --prefix $Project
+npm audit signatures --prefix $Project
 npm --prefix $Project run test:pac
 npm --prefix $Project run test:mv3
 npm --prefix $Project run lint:mv3
@@ -46,10 +49,16 @@ MV3 build. После всех команд tracked tree должен остат
 ## 3. Подтвердить trusted-main CI
 
 Для exact main SHA workflow **Verify MV3** должен завершиться успешно как
-trusted push в `main`. Проверьте не только общий зелёный статус, но наличие и
-успех обязательных gates:
+trusted push в `main`. Если GitHub не создал ожидаемый push run, не переписывайте
+и не дополняйте `main`: вручную запустите тот же workflow на `main`. Такой run
+допустим только при `event = workflow_dispatch`, `ref = refs/heads/main`,
+`head_sha = origin/main`, полном успехе обычного job и наличии canonical
+artifact этого run. Dispatch другой ветки не является trusted source и не
+загружает canonical artifact. Проверьте не только общий зелёный статус, но
+наличие и успех обязательных gates:
 
 - documentation integrity;
+- static supply-chain policy, focused verifier tests и registry signatures;
 - PAC и MV3 tests;
 - focused MV3 lint и build;
 - aggregate `verify`;

--- a/docs/development/TESTING.md
+++ b/docs/development/TESTING.md
@@ -21,6 +21,34 @@ anchors, запрещает developer-machine paths и stale current-release/def
 branch/install metadata. Она не делает CI зависимым от доступности внешних
 сайтов; отдельный bounded аудит можно запустить с `--audit-external`.
 
+### Supply-chain gates
+
+```powershell
+node .\scripts\verify-supply-chain.mjs
+node --test .\scripts\verify-supply-chain.test.mjs
+npm audit signatures --prefix $Project
+```
+
+Статический verifier разрешает только два известных npm-root: основной tooling
+package и явно quarantined legacy Options package. Для основного lockfile он
+проверяет exact direct pins, официальный npm registry source, integrity и
+минимальный lifecycle baseline (`fsevents@2.3.3`, optional). Legacy Options
+dependency tree не устанавливается и не становится допустимым baseline. На PR
+registry publication time запрашивается только для новых выбранных direct
+versions; граница равна 168 часам и ошибка registry/metadata блокирует change.
+Эти gates дают defense in depth, но не доказывают безопасность package.
+
+Pull request дополнительно использует официальный
+`actions/dependency-review-action` v5.0.0, pinned на signed commit
+`a1d282b36b6f3519aa1f3fc636f609c47dddb294`. Release опубликован
+2026-05-08T20:23:50Z и на review 2026-08-26 был старше 2619 часов; repository
+принадлежит GitHub `actions`, license — MIT, consumer запускает committed Node
+24 bundle и не устанавливает source dependencies. Проверенный source lock имел
+753 package entries, без non-registry sources или missing integrity; его
+build-time install metadata (`esbuild` и optional `fsevents`) не исполняется в
+этом workflow. Action получает только `contents: read`; custom license/severity
+policy не включена, Scorecard display отключён как необязательный сигнал.
+
 ### Production npm audit
 
 ```powershell

--- a/extensions/chromium/runet-censorship-bypass/package.json
+++ b/extensions/chromium/runet-censorship-bypass/package.json
@@ -24,18 +24,18 @@
   "author": "Ilya Ig. Petrov",
   "license": "GPLv3",
   "devDependencies": {
-    "@eslint/js": "^10.0.1",
-    "chai": "^4.5.0",
-    "eslint": "^10.8.1",
-    "eslint-config-google": "^0.14.0",
-    "globals": "^17.11.0",
-    "mocha": "^11.8.0",
-    "puppeteer-core": "^25.8.0"
+    "@eslint/js": "10.0.1",
+    "chai": "4.5.0",
+    "eslint": "10.8.1",
+    "eslint-config-google": "0.14.0",
+    "globals": "17.11.0",
+    "mocha": "11.8.0",
+    "puppeteer-core": "25.8.0"
   },
   "dependencies": {
-    "gulp": "^5.0.1",
-    "plugin-error": "^1.0.1",
-    "through2": "^4.0.2",
+    "gulp": "5.0.1",
+    "plugin-error": "1.0.1",
+    "through2": "4.0.2",
     "tldts": "7.4.8"
   }
 }

--- a/scripts/verify-supply-chain.mjs
+++ b/scripts/verify-supply-chain.mjs
@@ -1,0 +1,465 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+export const MIN_VERSION_AGE_MS = 168 * 60 * 60 * 1000;
+export const AUTHORITATIVE_PACKAGE = 'extensions/chromium/runet-censorship-bypass';
+export const QUARANTINED_PACKAGE = 'extensions/chromium/runet-censorship-bypass/src/extension-common/pages/options';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const expectedPackageRoots = new Map([
+  [AUTHORITATIVE_PACKAGE, { quarantined: false }],
+  [QUARANTINED_PACKAGE, { quarantined: true }],
+]);
+const ignoredDirectories = new Set([
+  '.git',
+  '.local',
+  '.tmp',
+  'build',
+  'coverage',
+  'dist',
+  'node_modules',
+]);
+const directSections = ['dependencies', 'devDependencies', 'optionalDependencies'];
+const exactVersionPattern = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/u;
+const packageNamePattern = /^(?:@[a-z0-9][a-z0-9._-]*\/)?[a-z0-9][a-z0-9._-]*$/u;
+const integrityPattern = /^(?:sha512|sha384|sha256|sha1)-[A-Za-z0-9+/]+={0,2}$/u;
+const acceptedLifecyclePackages = new Map([
+  ['node_modules/fsevents', { name: 'fsevents', version: '2.3.3', optional: true }],
+]);
+
+export class SupplyChainVerificationError extends Error {
+  constructor(errors) {
+    super(errors.join(os.EOL));
+    this.name = 'SupplyChainVerificationError';
+    this.errors = errors;
+  }
+}
+
+function toPosix(value) {
+  return value.split(path.sep).join('/');
+}
+
+function readJson(absolutePath, relativePath, errors) {
+  try {
+    return JSON.parse(fs.readFileSync(absolutePath, 'utf8'));
+  } catch (error) {
+    errors.push(`${relativePath}: invalid JSON (${error.message})`);
+    return null;
+  }
+}
+
+function inventoryPackageRoots(rootDirectory) {
+  const inventory = new Map();
+
+  function walk(directory) {
+    for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+      if (entry.isDirectory()) {
+        if (!ignoredDirectories.has(entry.name)) {
+          walk(path.join(directory, entry.name));
+        }
+        continue;
+      }
+      if (!entry.isFile() || (entry.name !== 'package.json' && entry.name !== 'package-lock.json')) {
+        continue;
+      }
+      const relativeDirectory = toPosix(path.relative(rootDirectory, directory)) || '.';
+      const record = inventory.get(relativeDirectory) ?? { manifest: false, lockfile: false };
+      record[entry.name === 'package.json' ? 'manifest' : 'lockfile'] = true;
+      inventory.set(relativeDirectory, record);
+    }
+  }
+
+  walk(rootDirectory);
+  return inventory;
+}
+
+function packageNameFromLockPath(lockPath) {
+  const segments = lockPath.split('/');
+  const marker = segments.lastIndexOf('node_modules');
+  if (marker < 0 || marker + 1 >= segments.length) {
+    return null;
+  }
+  const first = segments[marker + 1];
+  if (!first.startsWith('@')) {
+    return first;
+  }
+  const second = segments[marker + 2];
+  return second ? `${first}/${second}` : null;
+}
+
+function validRegistryTarballPath(pathname, version) {
+  const segments = decodeURIComponent(pathname).split('/').filter(Boolean);
+  let packageName;
+  let separator;
+  let filename;
+  if (segments.length === 3) {
+    [packageName, separator, filename] = segments;
+  } else if (segments.length === 4 && segments[0].startsWith('@')) {
+    packageName = `${segments[0]}/${segments[1]}`;
+    [, , separator, filename] = segments;
+  } else {
+    return false;
+  }
+  const basename = packageName.split('/').at(-1);
+  return packageNamePattern.test(packageName)
+    && separator === '-'
+    && filename === `${basename}-${version}.tgz`;
+}
+
+function validIntegrity(value) {
+  return typeof value === 'string'
+    && value.trim() !== ''
+    && value.trim().split(/\s+/u).every((token) => integrityPattern.test(token));
+}
+
+function sectionObject(document, section) {
+  const value = document?.[section];
+  return value && typeof value === 'object' && !Array.isArray(value) ? value : {};
+}
+
+function sortedKeys(value) {
+  return Object.keys(value).sort((left, right) => left.localeCompare(right));
+}
+
+function sameKeys(left, right) {
+  const leftKeys = sortedKeys(left);
+  const rightKeys = sortedKeys(right);
+  return leftKeys.length === rightKeys.length
+    && leftKeys.every((value, index) => value === rightKeys[index]);
+}
+
+export function directSelectionsFromDocuments(manifest, lockfile, { requireExactPins = true } = {}) {
+  const errors = [];
+  const selections = new Map();
+  const lockPackages = lockfile?.packages;
+  const lockRoot = lockPackages?.[''];
+  if (!lockRoot || typeof lockRoot !== 'object') {
+    throw new SupplyChainVerificationError(['package-lock.json: packages[""] is required']);
+  }
+
+  for (const section of directSections) {
+    const manifestDependencies = sectionObject(manifest, section);
+    const lockDependencies = sectionObject(lockRoot, section);
+    if (!sameKeys(manifestDependencies, lockDependencies)) {
+      errors.push(`package-lock.json: root ${section} package set does not match package.json`);
+    }
+    for (const [name, specifier] of Object.entries(manifestDependencies)) {
+      if (!packageNamePattern.test(name)) {
+        errors.push(`package.json: unsupported package identity in ${section}`);
+        continue;
+      }
+      if (requireExactPins && !exactVersionPattern.test(specifier)) {
+        errors.push(`package.json: ${name} in ${section} must use an exact version pin`);
+        continue;
+      }
+      if (selections.has(name)) {
+        errors.push(`package.json: ${name} appears in more than one direct dependency section`);
+        continue;
+      }
+      const selected = lockPackages[`node_modules/${name}`];
+      if (!selected || typeof selected.version !== 'string') {
+        errors.push(`package-lock.json: selected version for ${name} is required`);
+        continue;
+      }
+      if (requireExactPins && selected.version !== specifier) {
+        errors.push(`package-lock.json: selected version for ${name} must equal package.json ${specifier}`);
+        continue;
+      }
+      selections.set(name, { name, version: selected.version, section });
+    }
+  }
+
+  if (errors.length > 0) {
+    throw new SupplyChainVerificationError(errors);
+  }
+  return selections;
+}
+
+function validateAuthoritativeDocuments(manifest, lockfile, errors) {
+  if (!Number.isInteger(lockfile?.lockfileVersion) || lockfile.lockfileVersion < 2) {
+    errors.push(`${AUTHORITATIVE_PACKAGE}/package-lock.json: lockfileVersion 2 or newer is required`);
+    return { selections: new Map(), packageCount: 0, lifecyclePackages: [] };
+  }
+  if (!lockfile.packages || typeof lockfile.packages !== 'object') {
+    errors.push(`${AUTHORITATIVE_PACKAGE}/package-lock.json: packages map is required`);
+    return { selections: new Map(), packageCount: 0, lifecyclePackages: [] };
+  }
+
+  let selections = new Map();
+  try {
+    selections = directSelectionsFromDocuments(manifest, lockfile);
+  } catch (error) {
+    if (error instanceof SupplyChainVerificationError) {
+      errors.push(...error.errors.map((message) => `${AUTHORITATIVE_PACKAGE}/${message}`));
+    } else {
+      throw error;
+    }
+  }
+
+  const lifecyclePackages = [];
+  for (const [lockPath, entry] of Object.entries(lockfile.packages)) {
+    if (lockPath === '') {
+      continue;
+    }
+    const name = packageNameFromLockPath(lockPath);
+    const identity = name && entry?.version ? `${name}@${entry.version}` : lockPath;
+    if (!name || !packageNamePattern.test(name) || typeof entry?.version !== 'string') {
+      errors.push(`${AUTHORITATIVE_PACKAGE}/package-lock.json: invalid package entry ${lockPath}`);
+      continue;
+    }
+    if (entry.link === true) {
+      errors.push(`${AUTHORITATIVE_PACKAGE}/package-lock.json: link source is not allowed for ${identity}`);
+    }
+    if (typeof entry.resolved !== 'string' || entry.resolved === '') {
+      errors.push(`${AUTHORITATIVE_PACKAGE}/package-lock.json: resolved registry source is required for ${identity}`);
+    } else {
+      try {
+        const resolved = new URL(entry.resolved);
+        if (resolved.protocol !== 'https:'
+          || resolved.origin !== 'https://registry.npmjs.org'
+          || resolved.username
+          || resolved.password
+          || resolved.search
+          || resolved.hash
+          || !validRegistryTarballPath(resolved.pathname, entry.version)) {
+          errors.push(`${AUTHORITATIVE_PACKAGE}/package-lock.json: unexpected registry source for ${identity}`);
+        }
+      } catch {
+        errors.push(`${AUTHORITATIVE_PACKAGE}/package-lock.json: malformed registry source for ${identity}`);
+      }
+    }
+    if (!validIntegrity(entry.integrity)) {
+      errors.push(`${AUTHORITATIVE_PACKAGE}/package-lock.json: valid integrity is required for ${identity}`);
+    }
+    if (entry.hasInstallScript !== undefined && typeof entry.hasInstallScript !== 'boolean') {
+      errors.push(`${AUTHORITATIVE_PACKAGE}/package-lock.json: malformed lifecycle metadata for ${identity}`);
+    }
+    if (entry.hasInstallScript === true) {
+      const accepted = acceptedLifecyclePackages.get(lockPath);
+      if (!accepted
+        || accepted.name !== name
+        || accepted.version !== entry.version
+        || entry.optional !== accepted.optional) {
+        errors.push(`${AUTHORITATIVE_PACKAGE}/package-lock.json: unexpected lifecycle-install metadata for ${identity}`);
+      } else {
+        lifecyclePackages.push(identity);
+      }
+    }
+  }
+
+  return {
+    selections,
+    packageCount: Math.max(0, Object.keys(lockfile.packages).length - 1),
+    lifecyclePackages: lifecyclePackages.sort(),
+  };
+}
+
+export function inspectRepository(rootDirectory = repoRoot) {
+  const errors = [];
+  const inventory = inventoryPackageRoots(rootDirectory);
+
+  for (const [directory, record] of inventory) {
+    if (!expectedPackageRoots.has(directory)) {
+      errors.push(`${directory}: unexpected package manifest or lockfile; dependency review is required`);
+    }
+    if (record.manifest !== record.lockfile) {
+      errors.push(`${directory}: package.json and package-lock.json must both be present`);
+    }
+  }
+  for (const directory of expectedPackageRoots.keys()) {
+    const record = inventory.get(directory);
+    if (!record?.manifest || !record?.lockfile) {
+      errors.push(`${directory}: expected package.json and package-lock.json are missing`);
+    }
+  }
+
+  const documents = new Map();
+  for (const [directory, policy] of expectedPackageRoots) {
+    const manifestPath = path.join(rootDirectory, directory, 'package.json');
+    const lockfilePath = path.join(rootDirectory, directory, 'package-lock.json');
+    if (!fs.existsSync(manifestPath) || !fs.existsSync(lockfilePath)) {
+      continue;
+    }
+    const manifest = readJson(manifestPath, `${directory}/package.json`, errors);
+    const lockfile = readJson(lockfilePath, `${directory}/package-lock.json`, errors);
+    if (manifest && lockfile) {
+      documents.set(directory, { manifest, lockfile, ...policy });
+    }
+  }
+
+  const authoritative = documents.get(AUTHORITATIVE_PACKAGE);
+  let authoritativeSummary = { selections: new Map(), packageCount: 0, lifecyclePackages: [] };
+  if (authoritative) {
+    authoritativeSummary = validateAuthoritativeDocuments(
+      authoritative.manifest,
+      authoritative.lockfile,
+      errors,
+    );
+  }
+
+  if (errors.length > 0) {
+    throw new SupplyChainVerificationError(errors);
+  }
+  return {
+    inventory: [...inventory.keys()].sort(),
+    documents,
+    directSelections: authoritativeSummary.selections,
+    packageCount: authoritativeSummary.packageCount,
+    lifecyclePackages: authoritativeSummary.lifecyclePackages,
+    quarantinedPackages: [QUARANTINED_PACKAGE],
+  };
+}
+
+export function changedDirectSelections(currentManifest, currentLockfile, baseManifest, baseLockfile) {
+  const current = directSelectionsFromDocuments(currentManifest, currentLockfile);
+  const base = directSelectionsFromDocuments(baseManifest, baseLockfile, { requireExactPins: false });
+  return [...current.values()]
+    .filter((selection) => base.get(selection.name)?.version !== selection.version)
+    .sort((left, right) => left.name.localeCompare(right.name));
+}
+
+async function registryPublicationTime(name, version) {
+  const endpoint = `https://registry.npmjs.org/${encodeURIComponent(name)}`;
+  let response;
+  try {
+    response = await fetch(endpoint, {
+      redirect: 'error',
+      signal: AbortSignal.timeout(15_000),
+      headers: {
+        Accept: 'application/json',
+        'User-Agent': 'runet-censorship-bypass-supply-chain-verifier',
+      },
+    });
+  } catch (error) {
+    throw new Error(`registry request failed (${error.name})`);
+  }
+  if (!response.ok) {
+    throw new Error(`registry request failed (HTTP ${response.status})`);
+  }
+  let packument;
+  try {
+    packument = await response.json();
+  } catch {
+    throw new Error('registry returned malformed JSON');
+  }
+  return packument?.time?.[version];
+}
+
+export async function verifyPublicationAges(selections, {
+  reviewTime = new Date(),
+  getPublicationTime = registryPublicationTime,
+} = {}) {
+  const reviewTimestamp = reviewTime instanceof Date
+    ? reviewTime.getTime()
+    : Date.parse(reviewTime);
+  if (!Number.isFinite(reviewTimestamp)) {
+    throw new SupplyChainVerificationError(['review time is invalid']);
+  }
+
+  const errors = [];
+  const results = [];
+  for (const selection of [...selections].sort((left, right) => left.name.localeCompare(right.name))) {
+    let publicationValue;
+    try {
+      publicationValue = await getPublicationTime(selection.name, selection.version);
+    } catch (error) {
+      errors.push(`${selection.name}@${selection.version}: publication metadata unavailable (${error.message})`);
+      continue;
+    }
+    if (typeof publicationValue !== 'string' || !Number.isFinite(Date.parse(publicationValue))) {
+      errors.push(`${selection.name}@${selection.version}: publication timestamp is missing or malformed`);
+      continue;
+    }
+    const publicationTimestamp = Date.parse(publicationValue);
+    const ageMilliseconds = reviewTimestamp - publicationTimestamp;
+    if (ageMilliseconds < MIN_VERSION_AGE_MS) {
+      const ageHours = Math.floor(ageMilliseconds / (60 * 60 * 1000));
+      errors.push(`${selection.name}@${selection.version}: selected version is ${ageHours} hours old; 168 full hours are required`);
+      continue;
+    }
+    results.push({
+      ...selection,
+      publicationTime: publicationValue,
+      ageHours: Math.floor(ageMilliseconds / (60 * 60 * 1000)),
+    });
+  }
+
+  if (errors.length > 0) {
+    throw new SupplyChainVerificationError(errors);
+  }
+  return results;
+}
+
+function gitJson(baseSha, relativePath) {
+  try {
+    const content = execFileSync('git', ['show', `${baseSha}:${relativePath}`], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      maxBuffer: 20 * 1024 * 1024,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    return JSON.parse(content);
+  } catch {
+    throw new SupplyChainVerificationError([
+      `${relativePath}: unable to read the PR base version; dependency age review cannot continue`,
+    ]);
+  }
+}
+
+async function main() {
+  if (process.argv.length > 2) {
+    throw new SupplyChainVerificationError(['verify-supply-chain.mjs accepts no command-line bypasses']);
+  }
+  const summary = inspectRepository(repoRoot);
+  console.log(`Supply-chain static verification passed: ${summary.packageCount} authoritative lock packages, ${summary.directSelections.size} exact direct pins.`);
+  console.log(`Accepted authoritative lifecycle baseline: ${summary.lifecyclePackages.join(', ') || 'none present'}.`);
+  console.log(`Quarantined package root (not installed or trusted as baseline): ${QUARANTINED_PACKAGE}.`);
+
+  const baseSha = (process.env.SUPPLY_CHAIN_BASE_SHA ?? '').trim();
+  if (process.env.GITHUB_EVENT_NAME === 'pull_request' && !baseSha) {
+    throw new SupplyChainVerificationError(['pull_request verification requires SUPPLY_CHAIN_BASE_SHA']);
+  }
+  if (baseSha) {
+    if (!/^[0-9a-f]{40}$/u.test(baseSha)) {
+      throw new SupplyChainVerificationError(['SUPPLY_CHAIN_BASE_SHA must be a lowercase 40-character Git SHA']);
+    }
+    const authoritative = summary.documents.get(AUTHORITATIVE_PACKAGE);
+    const baseManifest = gitJson(baseSha, `${AUTHORITATIVE_PACKAGE}/package.json`);
+    const baseLockfile = gitJson(baseSha, `${AUTHORITATIVE_PACKAGE}/package-lock.json`);
+    const changedSelections = changedDirectSelections(
+      authoritative.manifest,
+      authoritative.lockfile,
+      baseManifest,
+      baseLockfile,
+    );
+    if (changedSelections.length === 0) {
+      console.log('Dependency age verification passed: no newly selected direct versions; registry was not queried.');
+    } else {
+      const ages = await verifyPublicationAges(changedSelections);
+      console.log(`Dependency age verification passed for ${ages.length} newly selected direct version(s): ${ages.map((item) => `${item.name}@${item.version} (${item.ageHours}h)`).join(', ')}.`);
+    }
+  } else {
+    console.log('Dependency age verification not requested: no PR base SHA was supplied.');
+  }
+  console.log('These checks are defense-in-depth gates, not proof that a dependency is safe.');
+}
+
+const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : '';
+if (invokedPath === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    if (error instanceof SupplyChainVerificationError) {
+      console.error(`Supply-chain verification failed with ${error.errors.length} error(s):`);
+      for (const message of error.errors) {
+        console.error(`- ${message}`);
+      }
+    } else {
+      console.error(`Supply-chain verification failed: ${error.message}`);
+    }
+    process.exitCode = 1;
+  });
+}

--- a/scripts/verify-supply-chain.test.mjs
+++ b/scripts/verify-supply-chain.test.mjs
@@ -1,0 +1,216 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import {
+  AUTHORITATIVE_PACKAGE,
+  MIN_VERSION_AGE_MS,
+  QUARANTINED_PACKAGE,
+  SupplyChainVerificationError,
+  changedDirectSelections,
+  inspectRepository,
+  verifyPublicationAges,
+} from './verify-supply-chain.mjs';
+
+const integrity = `sha512-${Buffer.from('fixture-integrity').toString('base64')}`;
+
+function packageDocuments({
+  directSpecifier = '1.2.3',
+  selectedVersion = '1.2.3',
+  resolved = 'https://registry.npmjs.org/safe-package/-/safe-package-1.2.3.tgz',
+  selectedIntegrity = integrity,
+  extraPackages = {},
+} = {}) {
+  return {
+    manifest: {
+      name: 'fixture',
+      version: '1.0.0',
+      private: true,
+      dependencies: {
+        'safe-package': directSpecifier,
+      },
+    },
+    lockfile: {
+      name: 'fixture',
+      version: '1.0.0',
+      lockfileVersion: 2,
+      requires: true,
+      packages: {
+        '': {
+          name: 'fixture',
+          version: '1.0.0',
+          dependencies: {
+            'safe-package': directSpecifier,
+          },
+        },
+        'node_modules/safe-package': {
+          version: selectedVersion,
+          resolved,
+          integrity: selectedIntegrity,
+        },
+        'node_modules/fsevents': {
+          version: '2.3.3',
+          resolved: 'https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz',
+          integrity,
+          hasInstallScript: true,
+          optional: true,
+        },
+        ...extraPackages,
+      },
+    },
+  };
+}
+
+function writeJson(root, relativePath, value) {
+  const target = path.join(root, ...relativePath.split('/'));
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  fs.writeFileSync(target, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+}
+
+function fixtureRepository(authoritative = packageDocuments(), configure) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'rucb-supply-chain-'));
+  writeJson(root, `${AUTHORITATIVE_PACKAGE}/package.json`, authoritative.manifest);
+  writeJson(root, `${AUTHORITATIVE_PACKAGE}/package-lock.json`, authoritative.lockfile);
+  writeJson(root, `${QUARANTINED_PACKAGE}/package.json`, {
+    name: 'quarantined-options',
+    version: '0.0.0',
+    dependencies: { fsevents: '^1.0.0' },
+  });
+  writeJson(root, `${QUARANTINED_PACKAGE}/package-lock.json`, {
+    name: 'quarantined-options',
+    lockfileVersion: 1,
+    dependencies: {
+      fsevents: {
+        version: '1.2.13',
+        hasInstallScript: true,
+      },
+    },
+  });
+  configure?.(root);
+  return root;
+}
+
+function withFixture(authoritative, assertion, configure) {
+  const root = fixtureRepository(authoritative, configure);
+  try {
+    assertion(root);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+function assertSupplyChainFailure(callback, pattern) {
+  assert.throws(callback, (error) => {
+    assert.ok(error instanceof SupplyChainVerificationError);
+    assert.match(error.message, pattern);
+    return true;
+  });
+}
+
+test('accepts official registry sources, integrity, the lifecycle baseline, and quarantine', () => {
+  withFixture(packageDocuments(), (root) => {
+    const summary = inspectRepository(root);
+    assert.equal(summary.packageCount, 2);
+    assert.deepEqual(summary.lifecyclePackages, ['fsevents@2.3.3']);
+    assert.deepEqual(summary.quarantinedPackages, [QUARANTINED_PACKAGE]);
+  });
+});
+
+test('an unchanged direct selection does not require an age lookup', () => {
+  const current = packageDocuments();
+  const base = structuredClone(current);
+  base.manifest.dependencies['safe-package'] = '^1.2.3';
+  base.lockfile.packages[''].dependencies['safe-package'] = '^1.2.3';
+  assert.deepEqual(
+    changedDirectSelections(current.manifest, current.lockfile, base.manifest, base.lockfile),
+    [],
+  );
+});
+
+for (const [label, resolved] of [
+  ['git dependency', 'git+https://github.com/example/safe-package.git'],
+  ['file dependency', 'file:../safe-package'],
+  ['arbitrary tarball source', 'https://example.test/safe-package-1.2.3.tgz'],
+]) {
+  test(`rejects a ${label}`, () => {
+    withFixture(packageDocuments({ resolved }), (root) => {
+      assertSupplyChainFailure(() => inspectRepository(root), /registry source/u);
+    });
+  });
+}
+
+test('rejects missing integrity metadata', () => {
+  withFixture(packageDocuments({ selectedIntegrity: null }), (root) => {
+    assertSupplyChainFailure(() => inspectRepository(root), /valid integrity/u);
+  });
+});
+
+test('rejects newly introduced lifecycle-install metadata', () => {
+  withFixture(packageDocuments({
+    extraPackages: {
+      'node_modules/new-installer': {
+        version: '4.5.6',
+        resolved: 'https://registry.npmjs.org/new-installer/-/new-installer-4.5.6.tgz',
+        integrity,
+        hasInstallScript: true,
+      },
+    },
+  }), (root) => {
+    assertSupplyChainFailure(() => inspectRepository(root), /unexpected lifecycle-install metadata/u);
+  });
+});
+
+test('rejects an unexpected package manifest and lockfile', () => {
+  withFixture(packageDocuments(), (root) => {
+    writeJson(root, 'unexpected/package.json', { name: 'unexpected', version: '1.0.0' });
+    writeJson(root, 'unexpected/package-lock.json', {
+      name: 'unexpected',
+      version: '1.0.0',
+      lockfileVersion: 3,
+      packages: {},
+    });
+    assertSupplyChainFailure(() => inspectRepository(root), /unexpected package manifest or lockfile/u);
+  });
+});
+
+test('accepts a selected version exactly 168 hours old', async () => {
+  const reviewTime = new Date('2026-08-26T12:00:00Z');
+  const publicationTime = new Date(reviewTime.getTime() - MIN_VERSION_AGE_MS).toISOString();
+  const result = await verifyPublicationAges(
+    [{ name: 'safe-package', version: '1.2.3', section: 'dependencies' }],
+    { reviewTime, getPublicationTime: async () => publicationTime },
+  );
+  assert.equal(result[0].ageHours, 168);
+});
+
+test('rejects a selected version 167h59m59s old', async () => {
+  const reviewTime = new Date('2026-08-26T12:00:00Z');
+  const publicationTime = new Date(reviewTime.getTime() - MIN_VERSION_AGE_MS + 1_000).toISOString();
+  await assert.rejects(
+    verifyPublicationAges(
+      [{ name: 'safe-package', version: '1.2.3', section: 'dependencies' }],
+      { reviewTime, getPublicationTime: async () => publicationTime },
+    ),
+    (error) => {
+      assert.ok(error instanceof SupplyChainVerificationError);
+      assert.match(error.message, /168 full hours are required/u);
+      return true;
+    },
+  );
+});
+
+test('fails closed on malformed publication metadata', async () => {
+  await assert.rejects(
+    verifyPublicationAges(
+      [{ name: 'safe-package', version: '1.2.3', section: 'devDependencies' }],
+      { reviewTime: new Date('2026-08-26T12:00:00Z'), getPublicationTime: async () => 'not-a-date' },
+    ),
+    (error) => {
+      assert.ok(error instanceof SupplyChainVerificationError);
+      assert.match(error.message, /publication timestamp is missing or malformed/u);
+      return true;
+    },
+  );
+});


### PR DESCRIPTION
## Summary

- adds workflow_dispatch as a trusted-main fallback while keeping canonical artifacts limited to push/manual runs on main
- adds a dependency-free supply-chain verifier and offline boundary/source/integrity/lifecycle tests
- pins authoritative direct dependencies to their already-selected lockfile versions without lockfile churn
- verifies npm registry signatures and reviews PR dependency changes with the official pinned dependency-review Action
- establishes deterministic LF checkout behavior and records the trusted-main recovery procedure

## Dependency review

- decision: APPROVE
- no new npm package or selected package version
- package-lock.json is byte-identical
- actions/dependency-review-action v5.0.0 is pinned to a1d282b36b6f3519aa1f3fc636f609c47dddb294 from the official GitHub actions repository; the release was over 168 hours old at review
- permissions remain contents: read and checkout credentials remain disabled
- the quarantined legacy Options package is not installed or treated as an accepted baseline

## Validation

- supply-chain verifier: PASS (316 lock packages, 11 exact direct pins, fsevents 2.3.3 lifecycle baseline)
- focused verifier tests: 11 passing
- npm audit signatures: 315 signatures, 27 attestations
- production audit: 0 vulnerabilities
- full audit: accepted Mocha dev-only baseline (1 low, 1 moderate, 1 high)
- PAC: 26 passing
- MV3: 353 passing
- aggregate: 369 passing
- Chrome Stable 151.0.7922.174 browser smoke: PASS
- docs integrity and focused lint/build checks: PASS
- canonical LF MV3 package vs trusted artifact 9611883956: 70 files, missing 0, extra 0, changed 0

No product/runtime feature, PAC, service-worker, auth, state, dependency selection, lockfile, release, or legacy Options toolchain change is included.