### PR TITLE
Add declarative provider dataset schema and verifier

### DIFF
--- a/extensions/chromium/runet-censorship-bypass/src/extension-chromium-mv3/test/provider-dataset.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-chromium-mv3/test/provider-dataset.js
@@ -1,0 +1,727 @@
+'use strict';
+
+
+const Chai = require('chai');
+const Crypto = require('crypto');
+const Fs = require('fs');
+const Mocha = require('mocha');
+const Path = require('path');
+const Dataset = require('../../extension-mv3-common/provider-dataset');
+const DatasetState = require(
+    '../../extension-mv3-common/provider-dataset-state',
+);
+const PROVIDER_KEY = 'synthetic-provider';
+
+function sha256(bytes) {
+
+  return Crypto.createHash('sha256').update(bytes).digest('hex');
+
+}
+
+function validPayload() {
+
+  return {
+    format: Dataset.PAYLOAD_FORMAT,
+    buckets: [
+      {
+        key: 'a',
+        rules: [
+          {host: 'alpha.example', routeRef: 'PROVIDER_PROXY'},
+          {host: 'amber.example', routeRef: 'PROVIDER_DIRECT'},
+        ],
+      },
+      {
+        key: 'b',
+        rules: [
+          {host: 'beta.example', routeRef: 'PROVIDER_PROXY'},
+        ],
+      },
+    ],
+  };
+
+}
+
+function countRules(payload) {
+
+  if (!payload || !Array.isArray(payload.buckets)) {
+    return 1;
+  }
+  return payload.buckets.reduce((total, bucket) =>
+    total + (Array.isArray(bucket.rules) ? bucket.rules.length : 0), 0);
+
+}
+
+function encodePayload(payload) {
+
+  return Buffer.from(JSON.stringify(payload), 'utf8');
+
+}
+
+function createArtifact({
+  payload = validPayload(),
+  artifactBytes = null,
+  envelopeOverrides = {},
+  trust = Dataset.TRUST.PACKAGED_TRUSTED,
+} = {}) {
+
+  const bytes = artifactBytes || encodePayload(payload);
+  const envelope = Object.assign({
+    schemaVersion: Dataset.SCHEMA_VERSION,
+    providerKey: PROVIDER_KEY,
+    datasetVersion: '2026.09.01-test.1',
+    generatedAt: '2026-09-01T00:00:00.000Z',
+    sourceRevisions: [{
+      sourceId: 'synthetic-source',
+      revision: 'fixture-revision-1',
+    }],
+    ruleCount: countRules(payload),
+    artifactByteCount: bytes.byteLength,
+    artifactSha256: sha256(bytes),
+    routeTableVersion: Dataset.ROUTE_TABLE_VERSION,
+  }, envelopeOverrides);
+  return {envelope, artifactBytes: bytes, trust};
+
+}
+
+async function verify(artifact) {
+
+  return Dataset.verifyProviderDataset(Object.assign({}, artifact, {sha256}));
+
+}
+
+function mutatePayload(mutator) {
+
+  const payload = validPayload();
+  mutator(payload);
+  return payload;
+
+}
+
+function versionedArtifact(datasetVersion, trust) {
+
+  return createArtifact({
+    trust,
+    envelopeOverrides: {datasetVersion},
+  });
+
+}
+
+function selectedRef(verification) {
+
+  return {
+    providerKey: verification.dataset.identity.providerKey,
+    datasetVersion: verification.dataset.identity.datasetVersion,
+    artifactSha256: verification.dataset.identity.artifactSha256,
+    trust: verification.trust,
+  };
+
+}
+
+const REJECTION_CASES = Object.freeze([
+  {
+    name: 'unknown schema version',
+    create() {
+      return createArtifact({envelopeOverrides: {schemaVersion: 2}});
+    },
+    code: 'UNSUPPORTED_SCHEMA_VERSION',
+  },
+  {
+    name: 'missing required envelope field',
+    create() {
+      const artifact = createArtifact();
+      delete artifact.envelope.providerKey;
+      return artifact;
+    },
+    code: 'MISSING_REQUIRED_FIELD',
+  },
+  {
+    name: 'unknown PAC envelope field',
+    create() {
+      return createArtifact({envelopeOverrides: {pacScript: 'not allowed'}});
+    },
+    code: 'UNKNOWN_FIELD',
+  },
+  {
+    name: 'invalid provider identifier',
+    create() {
+      return createArtifact({envelopeOverrides: {providerKey: 'Bad Provider'}});
+    },
+    code: 'INVALID_PROVIDER_KEY',
+  },
+  {
+    name: 'invalid dataset identifier',
+    create() {
+      return createArtifact({envelopeOverrides: {datasetVersion: 'bad version'}});
+    },
+    code: 'INVALID_DATASET_VERSION',
+  },
+  {
+    name: 'invalid generated timestamp',
+    create() {
+      return createArtifact({
+        envelopeOverrides: {generatedAt: '2026-09-01'},
+      });
+    },
+    code: 'INVALID_GENERATED_TIMESTAMP',
+  },
+  {
+    name: 'invalid SHA-256 format',
+    create() {
+      return createArtifact({envelopeOverrides: {artifactSha256: 'abc'}});
+    },
+    code: 'INVALID_ARTIFACT_SHA256',
+  },
+  {
+    name: 'declared byte-count mismatch',
+    create() {
+      const artifact = createArtifact();
+      artifact.envelope.artifactByteCount += 1;
+      return artifact;
+    },
+    code: 'ARTIFACT_BYTE_COUNT_MISMATCH',
+  },
+  {
+    name: 'exact-byte SHA-256 mismatch',
+    create() {
+      return createArtifact({
+        envelopeOverrides: {artifactSha256: '0'.repeat(64)},
+      });
+    },
+    code: 'ARTIFACT_SHA256_MISMATCH',
+  },
+  {
+    name: 'declared rule-count mismatch',
+    create() {
+      const artifact = createArtifact();
+      artifact.envelope.ruleCount += 1;
+      return artifact;
+    },
+    code: 'RULE_COUNT_MISMATCH',
+  },
+  {
+    name: 'malformed JSON bytes',
+    create() {
+      return createArtifact({artifactBytes: Buffer.from('{', 'utf8')});
+    },
+    code: 'MALFORMED_JSON',
+  },
+  {
+    name: 'malformed top-level object',
+    create() {
+      return createArtifact({payload: []});
+    },
+    code: 'INVALID_FIELD_TYPE',
+  },
+  {
+    name: 'invalid host syntax',
+    create() {
+      return createArtifact({
+        payload: mutatePayload((payload) => {
+          payload.buckets[0].rules[0].host = 'Alpha_example';
+        }),
+      });
+    },
+    code: 'INVALID_HOST',
+  },
+  {
+    name: 'duplicate host rule',
+    create() {
+      return createArtifact({
+        payload: mutatePayload((payload) => {
+          payload.buckets[0].rules[1].host = 'alpha.example';
+        }),
+      });
+    },
+    code: 'DUPLICATE_RULE',
+  },
+  {
+    name: 'unsorted buckets',
+    create() {
+      return createArtifact({
+        payload: mutatePayload((payload) => {
+          payload.buckets.reverse();
+        }),
+      });
+    },
+    code: 'UNSORTED_BUCKETS',
+  },
+  {
+    name: 'unsorted rules',
+    create() {
+      return createArtifact({
+        payload: mutatePayload((payload) => {
+          payload.buckets[0].rules.reverse();
+        }),
+      });
+    },
+    code: 'UNSORTED_RULES',
+  },
+  {
+    name: 'invalid route reference',
+    create() {
+      return createArtifact({
+        payload: mutatePayload((payload) => {
+          payload.buckets[0].rules[0].routeRef = 'DYNAMIC_CALLBACK';
+        }),
+      });
+    },
+    code: 'INVALID_ROUTE_REFERENCE',
+  },
+  {
+    name: 'excessive declared rule count',
+    create() {
+      return createArtifact({
+        envelopeOverrides: {ruleCount: Dataset.LIMITS.MAX_RULES + 1},
+      });
+    },
+    code: 'TOO_MANY_RULES',
+  },
+  {
+    name: 'oversized artifact',
+    create() {
+      return createArtifact({
+        envelopeOverrides: {
+          artifactByteCount: Dataset.LIMITS.MAX_ARTIFACT_BYTES + 1,
+        },
+      });
+    },
+    code: 'ARTIFACT_TOO_LARGE',
+  },
+  {
+    name: 'malformed bucket structure',
+    create() {
+      return createArtifact({
+        payload: mutatePayload((payload) => {
+          payload.buckets[0].rules = [];
+        }),
+      });
+    },
+    code: 'MALFORMED_BUCKET_STRUCTURE',
+  },
+  {
+    name: 'unsupported source-revision data type',
+    create() {
+      return createArtifact({
+        envelopeOverrides: {sourceRevisions: 'not-an-array'},
+      });
+    },
+    code: 'INVALID_SOURCE_REVISIONS',
+  },
+  {
+    name: 'callback field inside a rule',
+    create() {
+      return createArtifact({
+        payload: mutatePayload((payload) => {
+          payload.buckets[0].rules[0].callback = 'not allowed';
+        }),
+      });
+    },
+    code: 'UNKNOWN_FIELD',
+  },
+  {
+    name: 'unknown route-table version',
+    create() {
+      return createArtifact({envelopeOverrides: {routeTableVersion: 2}});
+    },
+    code: 'UNSUPPORTED_ROUTE_TABLE_VERSION',
+  },
+]);
+
+Mocha.describe('declarative provider dataset', function() {
+
+  Mocha.it('verifies a valid packaged dataset', async function() {
+
+    const result = await verify(createArtifact());
+
+    Chai.expect(result).to.include({
+      ok: true,
+      status: 'VERIFIED',
+      trust: Dataset.TRUST.PACKAGED_TRUSTED,
+      activationEligible: true,
+    });
+    Chai.expect(result.dataset.envelope).to.include({
+      schemaVersion: 1,
+      routeTableVersion: 1,
+      ruleCount: 3,
+    });
+    Chai.expect(result.dataset.payload).to.deep.equal(validPayload());
+
+  });
+
+  Mocha.it('verifies an authenticated remote update as eligible',
+      async function() {
+
+        const result = await verify(createArtifact({
+          trust: Dataset.TRUST.REMOTE_AUTHENTICATED,
+          envelopeOverrides: {datasetVersion: '2026.09.02-update.1'},
+        }));
+
+        Chai.expect(result).to.include({
+          ok: true,
+          trust: Dataset.TRUST.REMOTE_AUTHENTICATED,
+          activationEligible: true,
+        });
+
+      });
+
+  Mocha.it('verifies but never activates an unauthenticated candidate',
+      async function() {
+
+        const result = await verify(createArtifact({
+          trust: Dataset.TRUST.REMOTE_UNAUTHENTICATED,
+        }));
+
+        Chai.expect(result).to.include({
+          ok: true,
+          trust: Dataset.TRUST.REMOTE_UNAUTHENTICATED,
+          activationEligible: false,
+        });
+
+      });
+
+  Mocha.it('allows inert provenance text without treating it as code',
+      async function() {
+
+        const revision = 'function marker() { return "metadata only"; }';
+        const result = await verify(createArtifact({
+          envelopeOverrides: {
+            sourceRevisions: [{sourceId: 'source', revision}],
+          },
+        }));
+
+        Chai.expect(result.ok).to.equal(true);
+        Chai.expect(result.dataset.envelope.sourceRevisions[0].revision)
+            .to.equal(revision);
+
+      });
+
+  Mocha.it('hashes exact payload bytes rather than reserialized JSON',
+      async function() {
+
+        const payload = validPayload();
+        const compactBytes = encodePayload(payload);
+        const prettyBytes = Buffer.from(JSON.stringify(payload, null, 2), 'utf8');
+        const artifact = createArtifact({
+          payload,
+          artifactBytes: prettyBytes,
+          envelopeOverrides: {artifactSha256: sha256(compactBytes)},
+        });
+        const result = await verify(artifact);
+
+        Chai.expect(result).to.deep.equal({
+          ok: false,
+          status: 'REJECTED',
+          code: 'ARTIFACT_SHA256_MISMATCH',
+        });
+
+      });
+
+  Mocha.it('isolates parsed bytes from a mutating hash implementation',
+      async function() {
+
+        const artifact = createArtifact();
+        const result = await Dataset.verifyProviderDataset(Object.assign(
+            {},
+            artifact,
+            {
+              sha256(bytes) {
+                const digest = sha256(bytes);
+                bytes.fill(0);
+                return digest;
+              },
+            },
+        ));
+
+        Chai.expect(result.ok).to.equal(true);
+        Chai.expect(result.dataset.payload).to.deep.equal(validPayload());
+
+      });
+
+  REJECTION_CASES.forEach((testCase) => {
+    Mocha.it(`rejects ${testCase.name}`, async function() {
+
+      const result = await verify(testCase.create());
+
+      Chai.expect(result).to.deep.equal({
+        ok: false,
+        status: 'REJECTED',
+        code: testCase.code,
+      });
+
+    });
+  });
+
+  Mocha.it('contains no browser, storage, Node, or execution dependency',
+      function() {
+
+        const commonDirectory = Path.resolve(
+            __dirname,
+            '..',
+            '..',
+            'extension-mv3-common',
+        );
+        const sources = [
+          'provider-dataset.js',
+          'provider-dataset-state.js',
+        ].map((filename) => Fs.readFileSync(
+            Path.join(commonDirectory, filename),
+            'utf8',
+        )).join('\n');
+
+        Chai.expect(sources).not.to.match(/\b(?:chrome|browser)\s*\./);
+        Chai.expect(sources).not.to.match(
+            /\b(?:indexedDB|localStorage|sessionStorage)\b/,
+        );
+        Chai.expect(sources).not.to.match(/\brequire\s*\(/);
+        Chai.expect(sources).not.to.match(
+            /\b(?:eval|Function)\s*\(/,
+        );
+
+      });
+
+});
+
+Mocha.describe('provider dataset activation model', function() {
+
+  let active;
+  let authenticatedCandidate;
+  let lkg;
+  let packaged;
+  let unauthenticatedCandidate;
+
+  Mocha.before(async function() {
+
+    active = await verify(versionedArtifact(
+        'active.1',
+        Dataset.TRUST.REMOTE_AUTHENTICATED,
+    ));
+    authenticatedCandidate = await verify(versionedArtifact(
+        'candidate.2',
+        Dataset.TRUST.REMOTE_AUTHENTICATED,
+    ));
+    lkg = await verify(versionedArtifact(
+        'lkg.1',
+        Dataset.TRUST.REMOTE_AUTHENTICATED,
+    ));
+    packaged = await verify(versionedArtifact(
+        'packaged.1',
+        Dataset.TRUST.PACKAGED_TRUSTED,
+    ));
+    unauthenticatedCandidate = await verify(versionedArtifact(
+        'candidate.unauthenticated',
+        Dataset.TRUST.REMOTE_UNAUTHENTICATED,
+    ));
+
+  });
+
+  Mocha.it('makes an authenticated candidate eligible for atomic activation',
+      function() {
+
+        const plan = DatasetState.planDatasetActivation({
+          protectionIntended: true,
+          providerKey: PROVIDER_KEY,
+          active,
+          previousLkg: lkg,
+          packagedBaseline: packaged,
+          candidate: authenticatedCandidate,
+        });
+
+        Chai.expect(plan).to.deep.equal({
+          kind: DatasetState.ACTIONS.ACTIVATE_CANDIDATE,
+          selected: selectedRef(authenticatedCandidate),
+          previousLkg: selectedRef(active),
+        });
+
+      });
+
+  Mocha.it('keeps active data for an unauthenticated candidate', function() {
+
+    const plan = DatasetState.planDatasetActivation({
+      protectionIntended: true,
+      providerKey: PROVIDER_KEY,
+      active,
+      previousLkg: lkg,
+      packagedBaseline: packaged,
+      candidate: unauthenticatedCandidate,
+    });
+
+    Chai.expect(plan).to.deep.equal({
+      kind: DatasetState.ACTIONS.KEEP_ACTIVE,
+      selected: selectedRef(active),
+      previousLkg: selectedRef(lkg),
+      candidateRejection: 'UNAUTHENTICATED_REMOTE_CANDIDATE',
+    });
+
+  });
+
+  Mocha.it('keeps active data when a candidate hash is invalid', async function() {
+
+    const invalidCandidate = await verify(createArtifact({
+      trust: Dataset.TRUST.REMOTE_AUTHENTICATED,
+      envelopeOverrides: {artifactSha256: '0'.repeat(64)},
+    }));
+    const plan = DatasetState.planDatasetActivation({
+      protectionIntended: true,
+      providerKey: PROVIDER_KEY,
+      active,
+      previousLkg: lkg,
+      packagedBaseline: packaged,
+      candidate: invalidCandidate,
+    });
+
+    Chai.expect(plan).to.deep.equal({
+      kind: DatasetState.ACTIONS.KEEP_ACTIVE,
+      selected: selectedRef(active),
+      previousLkg: selectedRef(lkg),
+      candidateRejection: 'ARTIFACT_SHA256_MISMATCH',
+    });
+
+  });
+
+  Mocha.it('keeps active data when external freshness policy rejects a candidate',
+      function() {
+
+        const staleCandidate = Object.assign({}, authenticatedCandidate, {
+          usable: false,
+          code: 'STALE_DATASET',
+        });
+        const plan = DatasetState.planDatasetActivation({
+          protectionIntended: true,
+          providerKey: PROVIDER_KEY,
+          active,
+          previousLkg: lkg,
+          packagedBaseline: packaged,
+          candidate: staleCandidate,
+        });
+
+        Chai.expect(plan).to.deep.equal({
+          kind: DatasetState.ACTIONS.KEEP_ACTIVE,
+          selected: selectedRef(active),
+          previousLkg: selectedRef(lkg),
+          candidateRejection: 'STALE_DATASET',
+        });
+
+      });
+
+  Mocha.it('falls back from corrupt active data to previous LKG', function() {
+
+    const plan = DatasetState.planDatasetActivation({
+      protectionIntended: true,
+      providerKey: PROVIDER_KEY,
+      active: {ok: false, code: 'UNREADABLE_ACTIVE'},
+      previousLkg: lkg,
+      packagedBaseline: packaged,
+    });
+
+    Chai.expect(plan).to.deep.equal({
+      kind: DatasetState.ACTIONS.USE_PREVIOUS_LKG,
+      selected: selectedRef(lkg),
+      candidateRejection: null,
+    });
+
+  });
+
+  Mocha.it('falls back from corrupt active and LKG to packaged baseline',
+      function() {
+
+        const plan = DatasetState.planDatasetActivation({
+          protectionIntended: true,
+          providerKey: PROVIDER_KEY,
+          active: {ok: false, code: 'UNREADABLE_ACTIVE'},
+          previousLkg: {ok: false, code: 'UNREADABLE_LKG'},
+          packagedBaseline: packaged,
+        });
+
+        Chai.expect(plan).to.deep.equal({
+          kind: DatasetState.ACTIONS.USE_PACKAGED_BASELINE,
+          selected: selectedRef(packaged),
+          candidateRejection: null,
+        });
+
+      });
+
+  Mocha.it('does not authorize malformed local verification state', function() {
+
+    const malformedActive = {
+      ok: true,
+      status: 'VERIFIED',
+      activationEligible: true,
+      trust: Dataset.TRUST.REMOTE_AUTHENTICATED,
+      dataset: {identity: {}},
+    };
+    const plan = DatasetState.planDatasetActivation({
+      protectionIntended: true,
+      providerKey: PROVIDER_KEY,
+      active: malformedActive,
+      previousLkg: {ok: false, code: 'UNREADABLE_LKG'},
+      packagedBaseline: packaged,
+    });
+
+    Chai.expect(plan).to.deep.equal({
+      kind: DatasetState.ACTIONS.USE_PACKAGED_BASELINE,
+      selected: selectedRef(packaged),
+      candidateRejection: null,
+    });
+
+  });
+
+  Mocha.it('keeps active data for a different-provider candidate',
+      async function() {
+
+        const otherProviderCandidate = await verify(createArtifact({
+          trust: Dataset.TRUST.REMOTE_AUTHENTICATED,
+          envelopeOverrides: {providerKey: 'other-provider'},
+        }));
+        const plan = DatasetState.planDatasetActivation({
+          protectionIntended: true,
+          providerKey: PROVIDER_KEY,
+          active,
+          previousLkg: lkg,
+          packagedBaseline: packaged,
+          candidate: otherProviderCandidate,
+        });
+
+        Chai.expect(plan).to.deep.equal({
+          kind: DatasetState.ACTIONS.KEEP_ACTIVE,
+          selected: selectedRef(active),
+          previousLkg: selectedRef(lkg),
+          candidateRejection: 'PROVIDER_KEY_MISMATCH',
+        });
+
+      });
+
+  Mocha.it('fails closed when protection has no usable dataset', function() {
+
+    const plan = DatasetState.planDatasetActivation({
+      protectionIntended: true,
+      providerKey: PROVIDER_KEY,
+      active: {ok: false, code: 'UNREADABLE_ACTIVE'},
+      previousLkg: {ok: false, code: 'UNREADABLE_LKG'},
+      packagedBaseline: {ok: false, code: 'UNREADABLE_PACKAGED'},
+    });
+
+    Chai.expect(plan).to.deep.equal({
+      kind: DatasetState.ACTIONS.FAIL_CLOSED,
+      code: 'NO_USABLE_PROVIDER_DATASET',
+      candidateRejection: null,
+    });
+    Chai.expect(JSON.stringify(plan)).not.to.include('DIRECT');
+
+  });
+
+  Mocha.it('does not activate or fall back while protection is off', function() {
+
+    const plan = DatasetState.planDatasetActivation({
+      protectionIntended: false,
+      providerKey: PROVIDER_KEY,
+      active,
+      previousLkg: lkg,
+      packagedBaseline: packaged,
+      candidate: authenticatedCandidate,
+    });
+
+    Chai.expect(plan).to.deep.equal({kind: DatasetState.ACTIONS.OFF});
+
+  });
+
+});

--- a/extensions/chromium/runet-censorship-bypass/src/extension-chromium-mv3/test/provider-dataset.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-chromium-mv3/test/provider-dataset.js
@@ -11,6 +11,13 @@ const DatasetState = require(
     '../../extension-mv3-common/provider-dataset-state',
 );
 const PROVIDER_KEY = 'synthetic-provider';
+const PROVEN_BUCKET_WIDTHS = Object.freeze([
+  2, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+  21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36,
+  37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52,
+  53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68,
+  69, 70, 71, 72, 73, 74, 75, 76, 78, 79, 81, 83, 120, 131,
+]);
 
 function sha256(bytes) {
 
@@ -24,17 +31,14 @@ function validPayload() {
     format: Dataset.PAYLOAD_FORMAT,
     buckets: [
       {
-        key: 'a',
-        rules: [
-          {host: 'alpha.example', routeRef: 'PROVIDER_PROXY'},
-          {host: 'amber.example', routeRef: 'PROVIDER_DIRECT'},
-        ],
+        width: 12,
+        routeRef: 'PROVIDER_PROXY',
+        hosts: 'beta.example',
       },
       {
-        key: 'b',
-        rules: [
-          {host: 'beta.example', routeRef: 'PROVIDER_PROXY'},
-        ],
+        width: 13,
+        routeRef: 'PROVIDER_DIRECT',
+        hosts: 'alpha.exampleamber.example',
       },
     ],
   };
@@ -47,7 +51,9 @@ function countRules(payload) {
     return 1;
   }
   return payload.buckets.reduce((total, bucket) =>
-    total + (Array.isArray(bucket.rules) ? bucket.rules.length : 0), 0);
+    total + (typeof bucket.hosts === 'string' &&
+      Number.isSafeInteger(bucket.width) && bucket.width > 0 ?
+      bucket.hosts.length / bucket.width : 0), 0);
 
 }
 
@@ -94,6 +100,56 @@ function mutatePayload(mutator) {
   const payload = validPayload();
   mutator(payload);
   return payload;
+
+}
+
+function fixedDnsTail(length) {
+
+  const labels = [];
+  let remaining = length;
+  while (remaining > 63) {
+    const labelLength = Math.min(63, remaining - 2);
+    labels.push('x'.repeat(labelLength));
+    remaining -= labelLength + 1;
+  }
+  labels.push('x'.repeat(remaining));
+  return labels.join('.');
+
+}
+
+function fixedWidthHost(width, index = null) {
+
+  if (width === 2 && index === null) {
+    return 'ua';
+  }
+  if (index === null) {
+    return `a.${fixedDnsTail(width - 2)}`;
+  }
+  const sequence = index.toString(36).padStart(6, '0');
+  return `${sequence}.${fixedDnsTail(width - sequence.length - 1)}`;
+
+}
+
+function fixedWidthPayload(bucketLayout, productionRuleCount = null) {
+
+  const widths = Array.isArray(bucketLayout) ?
+    bucketLayout :
+    Array.from({length: bucketLayout}, (_value, index) => index + 2);
+  const denseWidth = 18;
+  const denseRuleCount = productionRuleCount === null ?
+    null : productionRuleCount - widths.length + 1;
+  return {
+    format: Dataset.PAYLOAD_FORMAT,
+    buckets: widths.map((width) => {
+      const count = width === denseWidth && denseRuleCount !== null ?
+        denseRuleCount : 1;
+      const hosts = count === 1 ?
+        fixedWidthHost(width) :
+        Array.from({length: count}, (_value, index) =>
+          fixedWidthHost(width, index)).join('');
+      return {width, routeRef: 'PROVIDER_PROXY', hosts};
+    }),
+  };
 
 }
 
@@ -217,7 +273,7 @@ const REJECTION_CASES = Object.freeze([
     create() {
       return createArtifact({
         payload: mutatePayload((payload) => {
-          payload.buckets[0].rules[0].host = 'Alpha_example';
+          payload.buckets[0].hosts = 'beta/example';
         }),
       });
     },
@@ -228,7 +284,22 @@ const REJECTION_CASES = Object.freeze([
     create() {
       return createArtifact({
         payload: mutatePayload((payload) => {
-          payload.buckets[0].rules[1].host = 'alpha.example';
+          payload.buckets[1].hosts = 'alpha.examplealpha.example';
+        }),
+      });
+    },
+    code: 'DUPLICATE_RULE',
+  },
+  {
+    name: 'duplicate host across route buckets',
+    create() {
+      return createArtifact({
+        payload: mutatePayload((payload) => {
+          payload.buckets.push({
+            width: 13,
+            routeRef: 'PROVIDER_PROXY',
+            hosts: 'alpha.example',
+          });
         }),
       });
     },
@@ -250,7 +321,7 @@ const REJECTION_CASES = Object.freeze([
     create() {
       return createArtifact({
         payload: mutatePayload((payload) => {
-          payload.buckets[0].rules.reverse();
+          payload.buckets[1].hosts = 'amber.examplealpha.example';
         }),
       });
     },
@@ -261,7 +332,7 @@ const REJECTION_CASES = Object.freeze([
     create() {
       return createArtifact({
         payload: mutatePayload((payload) => {
-          payload.buckets[0].rules[0].routeRef = 'DYNAMIC_CALLBACK';
+          payload.buckets[0].routeRef = 'DYNAMIC_CALLBACK';
         }),
       });
     },
@@ -292,7 +363,7 @@ const REJECTION_CASES = Object.freeze([
     create() {
       return createArtifact({
         payload: mutatePayload((payload) => {
-          payload.buckets[0].rules = [];
+          payload.buckets[0].hosts = '';
         }),
       });
     },
@@ -308,11 +379,11 @@ const REJECTION_CASES = Object.freeze([
     code: 'INVALID_SOURCE_REVISIONS',
   },
   {
-    name: 'callback field inside a rule',
+    name: 'callback field inside a bucket',
     create() {
       return createArtifact({
         payload: mutatePayload((payload) => {
-          payload.buckets[0].rules[0].callback = 'not allowed';
+          payload.buckets[0].callback = 'not allowed';
         }),
       });
     },
@@ -345,6 +416,78 @@ Mocha.describe('declarative provider dataset', function() {
       ruleCount: 3,
     });
     Chai.expect(result.dataset.payload).to.deep.equal(validPayload());
+
+  });
+
+  Mocha.it('accepts the proven 80-bucket and 662,819-rule scale',
+      async function() {
+
+        const payload = fixedWidthPayload(PROVEN_BUCKET_WIDTHS, 662819);
+        const artifact = createArtifact({payload});
+        const result = await verify(artifact);
+
+        Chai.expect(artifact.envelope).to.include({
+          ruleCount: 662819,
+        });
+        Chai.expect(payload.buckets).to.have.length(80);
+        Chai.expect(payload.buckets.at(-1).width).to.equal(131);
+        Chai.expect(artifact.artifactBytes.byteLength).to.be.greaterThan(
+            11 * 1024 * 1024,
+        );
+        Chai.expect(artifact.artifactBytes.byteLength).to.be.at.most(
+            Dataset.LIMITS.MAX_ARTIFACT_BYTES,
+        );
+        Chai.expect(result).to.include({
+          ok: true,
+          status: 'VERIFIED',
+        });
+
+      }).timeout(20000);
+
+  Mocha.it('accepts the pinned suffix-token character shapes as inert data',
+      async function() {
+
+        const payload = {
+          format: Dataset.PAYLOAD_FORMAT,
+          buckets: [
+            {width: 2, routeRef: 'PROVIDER_PROXY', hosts: 'ua'},
+            {width: 5, routeRef: 'PROVIDER_PROXY', hosts: 'name&'},
+            {width: 13, routeRef: 'PROVIDER_PROXY', hosts: 'example.test.'},
+            {width: 14, routeRef: 'PROVIDER_PROXY', hosts: 'site.test\\path'},
+            {
+              width: 16,
+              routeRef: 'PROVIDER_PROXY',
+              hosts: '_service.example',
+            },
+          ],
+        };
+        const result = await verify(createArtifact({payload}));
+
+        Chai.expect(result).to.include({ok: true, status: 'VERIFIED'});
+
+      });
+
+  Mocha.it('accepts the maximum fixed-width bucket count', async function() {
+
+    const payload = fixedWidthPayload(Dataset.LIMITS.MAX_BUCKETS);
+    const result = await verify(createArtifact({payload}));
+
+    Chai.expect(payload.buckets).to.have.length(128);
+    Chai.expect(result).to.include({ok: true, status: 'VERIFIED'});
+
+  });
+
+  Mocha.it('rejects one bucket beyond the fixed limit', async function() {
+
+    const payload = fixedWidthPayload(Dataset.LIMITS.MAX_BUCKETS + 1);
+    const result = await verify(createArtifact({payload}));
+
+    Chai.expect(payload.buckets).to.have.length(129);
+    Chai.expect(result).to.deep.equal({
+      ok: false,
+      status: 'REJECTED',
+      code: 'TOO_MANY_BUCKETS',
+    });
 
   });
 

--- a/extensions/chromium/runet-censorship-bypass/src/extension-mv3-common/provider-dataset-state.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-mv3-common/provider-dataset-state.js
@@ -1,0 +1,167 @@
+'use strict';
+
+(function publishProviderDatasetState(root, factory) {
+
+  const providerDatasetState = factory();
+  if (typeof module === 'object' && module.exports) {
+    module.exports = providerDatasetState;
+    return;
+  }
+  root.mv3ProviderDatasetState = providerDatasetState;
+
+})(typeof globalThis === 'object' ? globalThis : this, function() {
+
+  const ACTIONS = Object.freeze({
+    ACTIVATE_CANDIDATE: 'ACTIVATE_CANDIDATE',
+    KEEP_ACTIVE: 'KEEP_ACTIVE',
+    USE_PREVIOUS_LKG: 'USE_PREVIOUS_LKG',
+    USE_PACKAGED_BASELINE: 'USE_PACKAGED_BASELINE',
+    FAIL_CLOSED: 'FAIL_CLOSED',
+    OFF: 'OFF',
+  });
+  const ELIGIBLE_TRUST = Object.freeze([
+    'PACKAGED_TRUSTED',
+    'REMOTE_AUTHENTICATED',
+  ]);
+  const SHA256_PATTERN = /^[a-f0-9]{64}$/;
+  const PROVIDER_KEY_PATTERN = /^[a-z0-9](?:[a-z0-9._-]{0,63})$/;
+
+  function hasValidIdentity(value) {
+
+    const identity = value && value.dataset && value.dataset.identity;
+    return Boolean(
+        identity &&
+        typeof identity.providerKey === 'string' &&
+        identity.providerKey.length &&
+        typeof identity.datasetVersion === 'string' &&
+        identity.datasetVersion.length &&
+        typeof identity.artifactSha256 === 'string' &&
+        SHA256_PATTERN.test(identity.artifactSha256),
+    );
+
+  }
+
+  function isVerified(value) {
+
+    return Boolean(
+        value &&
+        value.ok === true &&
+        value.status === 'VERIFIED' &&
+        value.activationEligible === true &&
+        value.usable !== false &&
+        ELIGIBLE_TRUST.includes(value.trust) &&
+        hasValidIdentity(value),
+    );
+
+  }
+
+  function datasetRef(verification, providerKey) {
+
+    if (!isVerified(verification)) {
+      return null;
+    }
+    const identity = verification.dataset.identity;
+    if (identity.providerKey !== providerKey) {
+      return null;
+    }
+    return {
+      providerKey: identity.providerKey,
+      datasetVersion: identity.datasetVersion,
+      artifactSha256: identity.artifactSha256,
+      trust: verification.trust,
+    };
+
+  }
+
+  function candidateRejection(candidate, providerKey) {
+
+    if (!candidate) {
+      return null;
+    }
+    if (candidate.ok !== true) {
+      return candidate.code || 'CANDIDATE_REJECTED';
+    }
+    if (candidate.usable === false) {
+      return candidate.code || 'CANDIDATE_NOT_USABLE';
+    }
+    if (candidate.activationEligible !== true) {
+      return 'UNAUTHENTICATED_REMOTE_CANDIDATE';
+    }
+    if (!isVerified(candidate)) {
+      return candidate.code || 'CANDIDATE_NOT_USABLE';
+    }
+    if (candidate.dataset.identity.providerKey !== providerKey) {
+      return 'PROVIDER_KEY_MISMATCH';
+    }
+    return null;
+
+  }
+
+  function planDatasetActivation({
+    protectionIntended,
+    providerKey,
+    active,
+    previousLkg,
+    packagedBaseline,
+    candidate,
+  } = {}) {
+
+    if (protectionIntended !== true) {
+      return {kind: ACTIONS.OFF};
+    }
+    if (typeof providerKey !== 'string' ||
+        !PROVIDER_KEY_PATTERN.test(providerKey)) {
+      return {
+        kind: ACTIONS.FAIL_CLOSED,
+        code: 'INVALID_PROVIDER_KEY',
+        candidateRejection: null,
+      };
+    }
+    const activeRef = datasetRef(active, providerKey);
+    const previousLkgRef = datasetRef(previousLkg, providerKey);
+    const packagedRef = datasetRef(packagedBaseline, providerKey);
+    const candidateRef = datasetRef(candidate, providerKey);
+    if (candidateRef) {
+      return {
+        kind: ACTIONS.ACTIVATE_CANDIDATE,
+        selected: candidateRef,
+        previousLkg: activeRef || previousLkgRef,
+      };
+    }
+    const rejection = candidateRejection(candidate, providerKey);
+    if (activeRef) {
+      return {
+        kind: ACTIONS.KEEP_ACTIVE,
+        selected: activeRef,
+        previousLkg: previousLkgRef,
+        candidateRejection: rejection,
+      };
+    }
+    if (previousLkgRef) {
+      return {
+        kind: ACTIONS.USE_PREVIOUS_LKG,
+        selected: previousLkgRef,
+        candidateRejection: rejection,
+      };
+    }
+    if (packagedRef && packagedBaseline.trust === 'PACKAGED_TRUSTED') {
+      return {
+        kind: ACTIONS.USE_PACKAGED_BASELINE,
+        selected: packagedRef,
+        candidateRejection: rejection,
+      };
+    }
+    return {
+      kind: ACTIONS.FAIL_CLOSED,
+      code: 'NO_USABLE_PROVIDER_DATASET',
+      candidateRejection: rejection,
+    };
+
+  }
+
+  return Object.freeze({
+    ACTIONS,
+    planDatasetActivation,
+  });
+
+});

--- a/extensions/chromium/runet-censorship-bypass/src/extension-mv3-common/provider-dataset.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-mv3-common/provider-dataset.js
@@ -1,0 +1,422 @@
+'use strict';
+
+(function publishProviderDataset(root, factory) {
+
+  const providerDataset = factory();
+  if (typeof module === 'object' && module.exports) {
+    module.exports = providerDataset;
+    return;
+  }
+  root.mv3ProviderDataset = providerDataset;
+
+})(typeof globalThis === 'object' ? globalThis : this, function() {
+
+  const SCHEMA_VERSION = 1;
+  const ROUTE_TABLE_VERSION = 1;
+  const PAYLOAD_FORMAT = 'HOST_BUCKETS_V1';
+  const MAX_ARTIFACT_BYTES = 16 * 1024 * 1024;
+  const MAX_RULES = 750000;
+  const MAX_BUCKETS = 36;
+  const MAX_SOURCE_REVISIONS = 32;
+  const TRUST = Object.freeze({
+    PACKAGED_TRUSTED: 'PACKAGED_TRUSTED',
+    REMOTE_AUTHENTICATED: 'REMOTE_AUTHENTICATED',
+    REMOTE_UNAUTHENTICATED: 'REMOTE_UNAUTHENTICATED',
+  });
+  const ROUTE_REFS = Object.freeze([
+    'PROVIDER_DIRECT',
+    'PROVIDER_PROXY',
+  ]);
+  const ENVELOPE_FIELDS = Object.freeze([
+    'artifactByteCount',
+    'artifactSha256',
+    'datasetVersion',
+    'generatedAt',
+    'providerKey',
+    'routeTableVersion',
+    'ruleCount',
+    'schemaVersion',
+    'sourceRevisions',
+  ]);
+  const SOURCE_REVISION_FIELDS = Object.freeze([
+    'revision',
+    'sourceId',
+  ]);
+  const PAYLOAD_FIELDS = Object.freeze([
+    'buckets',
+    'format',
+  ]);
+  const BUCKET_FIELDS = Object.freeze([
+    'key',
+    'rules',
+  ]);
+  const RULE_FIELDS = Object.freeze([
+    'host',
+    'routeRef',
+  ]);
+  const IDENTIFIER_PATTERN = /^[a-z0-9](?:[a-z0-9._-]{0,63})$/;
+  const VERSION_PATTERN = /^[A-Za-z0-9](?:[A-Za-z0-9._+-]{0,127})$/;
+  const SHA256_PATTERN = /^[a-f0-9]{64}$/;
+  const BUCKET_KEY_PATTERN = /^[a-z0-9]$/;
+  const HOST_LABEL_PATTERN = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/;
+
+  function verificationError(code) {
+
+    const error = new TypeError(code);
+    error.code = code;
+    return error;
+
+  }
+
+  function reject(error) {
+
+    return Object.freeze({
+      ok: false,
+      status: 'REJECTED',
+      code: error && error.code ?
+        error.code :
+        'DATASET_VERIFICATION_FAILED',
+    });
+
+  }
+
+  function isPlainObject(value) {
+
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+      return false;
+    }
+    const prototype = Object.getPrototypeOf(value);
+    return prototype === Object.prototype || prototype === null;
+
+  }
+
+  function requireExactObject(value, fields) {
+
+    if (!isPlainObject(value)) {
+      throw verificationError('INVALID_FIELD_TYPE');
+    }
+    const keys = Object.keys(value);
+    if (keys.some((key) => !fields.includes(key))) {
+      throw verificationError('UNKNOWN_FIELD');
+    }
+    if (fields.some((field) =>
+      !Object.prototype.hasOwnProperty.call(value, field))) {
+      throw verificationError('MISSING_REQUIRED_FIELD');
+    }
+
+  }
+
+  function requireIdentifier(value, code) {
+
+    if (typeof value !== 'string' || !IDENTIFIER_PATTERN.test(value)) {
+      throw verificationError(code);
+    }
+    return value;
+
+  }
+
+  function requireVersion(value) {
+
+    if (typeof value !== 'string' || !VERSION_PATTERN.test(value)) {
+      throw verificationError('INVALID_DATASET_VERSION');
+    }
+    return value;
+
+  }
+
+  function requireTimestamp(value) {
+
+    if (typeof value !== 'string') {
+      throw verificationError('INVALID_GENERATED_TIMESTAMP');
+    }
+    const timestamp = Date.parse(value);
+    if (!Number.isFinite(timestamp) ||
+        new Date(timestamp).toISOString() !== value) {
+      throw verificationError('INVALID_GENERATED_TIMESTAMP');
+    }
+    return value;
+
+  }
+
+  function requirePositiveInteger(value, code) {
+
+    if (!Number.isSafeInteger(value) || value < 1) {
+      throw verificationError(code);
+    }
+    return value;
+
+  }
+
+  function validateSourceRevisions(value) {
+
+    if (!Array.isArray(value) || !value.length ||
+        value.length > MAX_SOURCE_REVISIONS) {
+      throw verificationError('INVALID_SOURCE_REVISIONS');
+    }
+    return value.map((sourceRevision) => {
+      requireExactObject(sourceRevision, SOURCE_REVISION_FIELDS);
+      const sourceId = requireIdentifier(
+          sourceRevision.sourceId,
+          'INVALID_SOURCE_ID',
+      );
+      if (typeof sourceRevision.revision !== 'string' ||
+          !sourceRevision.revision.length ||
+          sourceRevision.revision.length > 256 ||
+          /[\u0000-\u001f\u007f]/.test(sourceRevision.revision)) {
+        throw verificationError('INVALID_SOURCE_REVISION');
+      }
+      return {sourceId, revision: sourceRevision.revision};
+    });
+
+  }
+
+  function validateEnvelope(value) {
+
+    requireExactObject(value, ENVELOPE_FIELDS);
+    if (value.schemaVersion !== SCHEMA_VERSION) {
+      throw verificationError('UNSUPPORTED_SCHEMA_VERSION');
+    }
+    if (value.routeTableVersion !== ROUTE_TABLE_VERSION) {
+      throw verificationError('UNSUPPORTED_ROUTE_TABLE_VERSION');
+    }
+    const providerKey = requireIdentifier(
+        value.providerKey,
+        'INVALID_PROVIDER_KEY',
+    );
+    const datasetVersion = requireVersion(value.datasetVersion);
+    const generatedAt = requireTimestamp(value.generatedAt);
+    const sourceRevisions = validateSourceRevisions(value.sourceRevisions);
+    const ruleCount = requirePositiveInteger(
+        value.ruleCount,
+        'INVALID_RULE_COUNT',
+    );
+    if (ruleCount > MAX_RULES) {
+      throw verificationError('TOO_MANY_RULES');
+    }
+    const artifactByteCount = requirePositiveInteger(
+        value.artifactByteCount,
+        'INVALID_ARTIFACT_BYTE_COUNT',
+    );
+    if (artifactByteCount > MAX_ARTIFACT_BYTES) {
+      throw verificationError('ARTIFACT_TOO_LARGE');
+    }
+    if (typeof value.artifactSha256 !== 'string' ||
+        !SHA256_PATTERN.test(value.artifactSha256)) {
+      throw verificationError('INVALID_ARTIFACT_SHA256');
+    }
+    return {
+      schemaVersion: SCHEMA_VERSION,
+      providerKey,
+      datasetVersion,
+      generatedAt,
+      sourceRevisions,
+      ruleCount,
+      artifactByteCount,
+      artifactSha256: value.artifactSha256,
+      routeTableVersion: ROUTE_TABLE_VERSION,
+    };
+
+  }
+
+  function validateTrust(value) {
+
+    if (!Object.values(TRUST).includes(value)) {
+      throw verificationError('INVALID_ARTIFACT_TRUST');
+    }
+    return value;
+
+  }
+
+  function isValidHost(value) {
+
+    if (typeof value !== 'string' || value.length > 253 ||
+        value !== value.toLowerCase() || value.endsWith('.')) {
+      return false;
+    }
+    const labels = value.split('.');
+    return labels.length >= 2 && labels.every((label) =>
+      label.length <= 63 && HOST_LABEL_PATTERN.test(label));
+
+  }
+
+  function validateRule(rule, bucketKey) {
+
+    requireExactObject(rule, RULE_FIELDS);
+    if (!isValidHost(rule.host) || !rule.host.startsWith(bucketKey)) {
+      throw verificationError('INVALID_HOST');
+    }
+    if (typeof rule.routeRef !== 'string' ||
+        !ROUTE_REFS.includes(rule.routeRef)) {
+      throw verificationError('INVALID_ROUTE_REFERENCE');
+    }
+    return {host: rule.host, routeRef: rule.routeRef};
+
+  }
+
+  function validatePayload(value, declaredRuleCount) {
+
+    requireExactObject(value, PAYLOAD_FIELDS);
+    if (value.format !== PAYLOAD_FORMAT) {
+      throw verificationError('UNSUPPORTED_PAYLOAD_FORMAT');
+    }
+    if (!Array.isArray(value.buckets) || !value.buckets.length ||
+        value.buckets.length > MAX_BUCKETS) {
+      throw verificationError('MALFORMED_BUCKET_STRUCTURE');
+    }
+    const seenHosts = new Set();
+    let previousBucketKey = '';
+    let actualRuleCount = 0;
+    const buckets = value.buckets.map((bucket) => {
+      requireExactObject(bucket, BUCKET_FIELDS);
+      if (typeof bucket.key !== 'string' ||
+          !BUCKET_KEY_PATTERN.test(bucket.key)) {
+        throw verificationError('MALFORMED_BUCKET_STRUCTURE');
+      }
+      if (previousBucketKey && bucket.key <= previousBucketKey) {
+        throw verificationError('UNSORTED_BUCKETS');
+      }
+      previousBucketKey = bucket.key;
+      if (!Array.isArray(bucket.rules) || !bucket.rules.length) {
+        throw verificationError('MALFORMED_BUCKET_STRUCTURE');
+      }
+      let previousHost = '';
+      const rules = bucket.rules.map((rule) => {
+        const normalized = validateRule(rule, bucket.key);
+        if (previousHost && normalized.host <= previousHost) {
+          if (normalized.host === previousHost) {
+            throw verificationError('DUPLICATE_RULE');
+          }
+          throw verificationError('UNSORTED_RULES');
+        }
+        previousHost = normalized.host;
+        if (seenHosts.has(normalized.host)) {
+          throw verificationError('DUPLICATE_RULE');
+        }
+        seenHosts.add(normalized.host);
+        actualRuleCount += 1;
+        if (actualRuleCount > MAX_RULES) {
+          throw verificationError('TOO_MANY_RULES');
+        }
+        return normalized;
+      });
+      return {key: bucket.key, rules};
+    });
+    if (actualRuleCount !== declaredRuleCount) {
+      throw verificationError('RULE_COUNT_MISMATCH');
+    }
+    return {format: PAYLOAD_FORMAT, buckets};
+
+  }
+
+  function copyExactBytes(value) {
+
+    if (!(value instanceof Uint8Array)) {
+      throw verificationError('UNSUPPORTED_ARTIFACT_BYTES');
+    }
+    if (!value.byteLength) {
+      throw verificationError('EMPTY_ARTIFACT');
+    }
+    if (value.byteLength > MAX_ARTIFACT_BYTES) {
+      throw verificationError('ARTIFACT_TOO_LARGE');
+    }
+    const copy = new Uint8Array(value.byteLength);
+    copy.set(value);
+    return copy;
+
+  }
+
+  function decodePayload(bytes) {
+
+    if (typeof TextDecoder !== 'function') {
+      throw verificationError('UTF8_DECODER_UNAVAILABLE');
+    }
+    let text;
+    try {
+      text = new TextDecoder('utf-8', {fatal: true}).decode(bytes);
+    } catch (_error) {
+      throw verificationError('INVALID_UTF8');
+    }
+    try {
+      return JSON.parse(text);
+    } catch (_error) {
+      throw verificationError('MALFORMED_JSON');
+    }
+
+  }
+
+  async function verifyProviderDataset({
+    envelope,
+    artifactBytes,
+    sha256,
+    trust,
+  } = {}) {
+
+    try {
+      const normalizedEnvelope = validateEnvelope(envelope);
+      const normalizedTrust = validateTrust(trust);
+      if (typeof sha256 !== 'function') {
+        throw verificationError('SHA256_IMPLEMENTATION_REQUIRED');
+      }
+      const exactBytes = copyExactBytes(artifactBytes);
+      if (exactBytes.byteLength !== normalizedEnvelope.artifactByteCount) {
+        throw verificationError('ARTIFACT_BYTE_COUNT_MISMATCH');
+      }
+      let actualSha256;
+      try {
+        const hashInput = new Uint8Array(exactBytes.byteLength);
+        hashInput.set(exactBytes);
+        actualSha256 = await sha256(hashInput);
+      } catch (_error) {
+        throw verificationError('SHA256_COMPUTATION_FAILED');
+      }
+      if (typeof actualSha256 !== 'string' ||
+          !SHA256_PATTERN.test(actualSha256.toLowerCase())) {
+        throw verificationError('INVALID_COMPUTED_SHA256');
+      }
+      if (actualSha256.toLowerCase() !==
+          normalizedEnvelope.artifactSha256) {
+        throw verificationError('ARTIFACT_SHA256_MISMATCH');
+      }
+      const payload = validatePayload(
+          decodePayload(exactBytes),
+          normalizedEnvelope.ruleCount,
+      );
+      const activationEligible = normalizedTrust !==
+        TRUST.REMOTE_UNAUTHENTICATED;
+      return Object.freeze({
+        ok: true,
+        status: 'VERIFIED',
+        trust: normalizedTrust,
+        activationEligible,
+        dataset: Object.freeze({
+          identity: Object.freeze({
+            providerKey: normalizedEnvelope.providerKey,
+            datasetVersion: normalizedEnvelope.datasetVersion,
+            artifactSha256: normalizedEnvelope.artifactSha256,
+          }),
+          envelope: normalizedEnvelope,
+          payload,
+        }),
+      });
+    } catch (error) {
+      return reject(error);
+    }
+
+  }
+
+  return Object.freeze({
+    LIMITS: Object.freeze({
+      MAX_ARTIFACT_BYTES,
+      MAX_BUCKETS,
+      MAX_RULES,
+      MAX_SOURCE_REVISIONS,
+    }),
+    PAYLOAD_FORMAT,
+    ROUTE_REFS,
+    ROUTE_TABLE_VERSION,
+    SCHEMA_VERSION,
+    TRUST,
+    verifyProviderDataset,
+  });
+
+});

--- a/extensions/chromium/runet-censorship-bypass/src/extension-mv3-common/provider-dataset.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-mv3-common/provider-dataset.js
@@ -16,7 +16,11 @@
   const PAYLOAD_FORMAT = 'HOST_BUCKETS_V1';
   const MAX_ARTIFACT_BYTES = 16 * 1024 * 1024;
   const MAX_RULES = 750000;
-  const MAX_BUCKETS = 36;
+  // The pinned production-scale input occupies 80 hostname-width buckets
+  // (widths 2 through 131, with gaps). A 128-bucket ceiling leaves bounded
+  // growth room without making bucket metadata or index setup unbounded.
+  const MAX_BUCKETS = 128;
+  const MAX_HOST_LENGTH = 253;
   const MAX_SOURCE_REVISIONS = 32;
   const TRUST = Object.freeze({
     PACKAGED_TRUSTED: 'PACKAGED_TRUSTED',
@@ -47,18 +51,18 @@
     'format',
   ]);
   const BUCKET_FIELDS = Object.freeze([
-    'key',
-    'rules',
-  ]);
-  const RULE_FIELDS = Object.freeze([
-    'host',
+    'hosts',
     'routeRef',
+    'width',
   ]);
   const IDENTIFIER_PATTERN = /^[a-z0-9](?:[a-z0-9._-]{0,63})$/;
   const VERSION_PATTERN = /^[A-Za-z0-9](?:[A-Za-z0-9._+-]{0,127})$/;
   const SHA256_PATTERN = /^[a-f0-9]{64}$/;
-  const BUCKET_KEY_PATTERN = /^[a-z0-9]$/;
-  const HOST_LABEL_PATTERN = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/;
+  // These are provider lookup suffixes, not executable text or values passed
+  // to a URL parser. The pinned source includes underscores and a few inert
+  // non-DNS lookup characters, so the rigid grammar mirrors its comparator
+  // inputs while excluding whitespace, controls, delimiters, and code syntax.
+  const HOST_SUFFIX_PATTERN = /^[a-z0-9._&\\-]+$/;
 
   function verificationError(code) {
 
@@ -229,27 +233,63 @@
 
   function isValidHost(value) {
 
-    if (typeof value !== 'string' || value.length > 253 ||
-        value !== value.toLowerCase() || value.endsWith('.')) {
+    if (typeof value !== 'string' || !value.length ||
+        value.length > MAX_HOST_LENGTH || value !== value.toLowerCase() ||
+        !HOST_SUFFIX_PATTERN.test(value)) {
       return false;
     }
-    const labels = value.split('.');
-    return labels.length >= 2 && labels.every((label) =>
-      label.length <= 63 && HOST_LABEL_PATTERN.test(label));
+    const absolute = value.endsWith('.');
+    const labels = (absolute ? value.slice(0, -1) : value).split('.');
+    return labels.length >= 1 && labels.every((label) =>
+      label.length >= 1 && label.length <= 63);
 
   }
 
-  function validateRule(rule, bucketKey) {
+  function fixedBucketsOverlap(left, right, width) {
 
-    requireExactObject(rule, RULE_FIELDS);
-    if (!isValidHost(rule.host) || !rule.host.startsWith(bucketKey)) {
-      throw verificationError('INVALID_HOST');
+    let leftOffset = 0;
+    let rightOffset = 0;
+    while (leftOffset < left.length && rightOffset < right.length) {
+      const leftHost = left.slice(leftOffset, leftOffset + width);
+      const rightHost = right.slice(rightOffset, rightOffset + width);
+      if (leftHost === rightHost) {
+        return true;
+      }
+      if (leftHost < rightHost) {
+        leftOffset += width;
+      } else {
+        rightOffset += width;
+      }
     }
-    if (typeof rule.routeRef !== 'string' ||
-        !ROUTE_REFS.includes(rule.routeRef)) {
-      throw verificationError('INVALID_ROUTE_REFERENCE');
+    return false;
+
+  }
+
+  function validateBucketHosts(hosts, width) {
+
+    // `hosts` is one concatenated, lexicographically sorted sequence. Every
+    // entry has exactly `width` characters, matching the provider's compact
+    // fixed-width lookup representation without per-rule JSON object cost.
+    if (typeof hosts !== 'string' || !hosts.length ||
+        hosts.length % width !== 0) {
+      throw verificationError('MALFORMED_BUCKET_STRUCTURE');
     }
-    return {host: rule.host, routeRef: rule.routeRef};
+    let previousHost = '';
+    const ruleCount = hosts.length / width;
+    for (let offset = 0; offset < hosts.length; offset += width) {
+      const host = hosts.slice(offset, offset + width);
+      if (!isValidHost(host)) {
+        throw verificationError('INVALID_HOST');
+      }
+      if (previousHost && host <= previousHost) {
+        if (host === previousHost) {
+          throw verificationError('DUPLICATE_RULE');
+        }
+        throw verificationError('UNSORTED_RULES');
+      }
+      previousHost = host;
+    }
+    return ruleCount;
 
   }
 
@@ -259,47 +299,51 @@
     if (value.format !== PAYLOAD_FORMAT) {
       throw verificationError('UNSUPPORTED_PAYLOAD_FORMAT');
     }
-    if (!Array.isArray(value.buckets) || !value.buckets.length ||
-        value.buckets.length > MAX_BUCKETS) {
+    if (!Array.isArray(value.buckets) || !value.buckets.length) {
       throw verificationError('MALFORMED_BUCKET_STRUCTURE');
     }
-    const seenHosts = new Set();
-    let previousBucketKey = '';
+    if (value.buckets.length > MAX_BUCKETS) {
+      throw verificationError('TOO_MANY_BUCKETS');
+    }
+    const bucketsByWidth = new Map();
+    let previousWidth = 0;
+    let previousRouteIndex = -1;
     let actualRuleCount = 0;
     const buckets = value.buckets.map((bucket) => {
       requireExactObject(bucket, BUCKET_FIELDS);
-      if (typeof bucket.key !== 'string' ||
-          !BUCKET_KEY_PATTERN.test(bucket.key)) {
+      if (!Number.isSafeInteger(bucket.width) || bucket.width < 1 ||
+          bucket.width > MAX_HOST_LENGTH) {
         throw verificationError('MALFORMED_BUCKET_STRUCTURE');
       }
-      if (previousBucketKey && bucket.key <= previousBucketKey) {
+      const routeIndex = ROUTE_REFS.indexOf(bucket.routeRef);
+      if (routeIndex === -1) {
+        throw verificationError('INVALID_ROUTE_REFERENCE');
+      }
+      if (bucket.width < previousWidth ||
+          (bucket.width === previousWidth &&
+           routeIndex <= previousRouteIndex)) {
         throw verificationError('UNSORTED_BUCKETS');
       }
-      previousBucketKey = bucket.key;
-      if (!Array.isArray(bucket.rules) || !bucket.rules.length) {
-        throw verificationError('MALFORMED_BUCKET_STRUCTURE');
-      }
-      let previousHost = '';
-      const rules = bucket.rules.map((rule) => {
-        const normalized = validateRule(rule, bucket.key);
-        if (previousHost && normalized.host <= previousHost) {
-          if (normalized.host === previousHost) {
-            throw verificationError('DUPLICATE_RULE');
-          }
-          throw verificationError('UNSORTED_RULES');
-        }
-        previousHost = normalized.host;
-        if (seenHosts.has(normalized.host)) {
+      previousWidth = bucket.width;
+      previousRouteIndex = routeIndex;
+      const ruleCount = validateBucketHosts(bucket.hosts, bucket.width);
+      const sameWidthBuckets = bucketsByWidth.get(bucket.width) || [];
+      for (const existingHosts of sameWidthBuckets) {
+        if (fixedBucketsOverlap(existingHosts, bucket.hosts, bucket.width)) {
           throw verificationError('DUPLICATE_RULE');
         }
-        seenHosts.add(normalized.host);
-        actualRuleCount += 1;
-        if (actualRuleCount > MAX_RULES) {
-          throw verificationError('TOO_MANY_RULES');
-        }
-        return normalized;
-      });
-      return {key: bucket.key, rules};
+      }
+      sameWidthBuckets.push(bucket.hosts);
+      bucketsByWidth.set(bucket.width, sameWidthBuckets);
+      actualRuleCount += ruleCount;
+      if (actualRuleCount > MAX_RULES) {
+        throw verificationError('TOO_MANY_RULES');
+      }
+      return {
+        width: bucket.width,
+        routeRef: bucket.routeRef,
+        hosts: bucket.hosts,
+      };
     });
     if (actualRuleCount !== declaredRuleCount) {
       throw verificationError('RULE_COUNT_MISMATCH');
@@ -408,6 +452,7 @@
     LIMITS: Object.freeze({
       MAX_ARTIFACT_BYTES,
       MAX_BUCKETS,
+      MAX_HOST_LENGTH,
       MAX_RULES,
       MAX_SOURCE_REVISIONS,
     }),


### PR DESCRIPTION
# Summary

- Adds a browser-neutral, versioned declarative provider-dataset envelope and compact fixed-width HOST_BUCKETS_V1 payload.
- Adds an exact-byte verifier with injected SHA-256, explicit packaged/authenticated/unauthenticated trust classes, strict size/count/schema validation, and no browser, storage, PAC, or executable-code dependency.
- Adds a pure activation planner covering authenticated candidate activation, current/LKG/packaged fallback, provider binding, and fail-closed behavior.
- Uses only synthetic committed fixtures: no real provider dataset, provider JavaScript, or PAC source is included.

# Production-scale compatibility audit

- A bucket is one numeric hostname-suffix width plus one fixed route reference and one concatenated lexicographically sorted suffix string.
- The ignored proven artifact converted losslessly: 80 occupied widths (2 through 131), 662,819 rules, and all rules verified.
- Converted HOST_BUCKETS_V1 payload: 11,642,895 bytes, below the unchanged 16 MiB limit.
- MAX_BUCKETS is 128: above the proven 80 with bounded growth room; 80, 128, and 129 boundary behavior is tested.
- Rule and byte ceilings remain 750,000 and 16 MiB.

# Verification

- Dataset/verifier/state tests: 45
- Supply-chain: 11
- PAC: 26
- MV3: 428
- Aggregate: 444
- Chromium runtime package: 70 vs 70 files; added 0; missing 0; SHA-256 differences 0
- Dependencies and lockfiles: unchanged

# Runtime impact

None. The common modules are not imported by current Chromium production code. Manifests, PAC cooker/output, service worker, and Firefox runtime are unchanged.

# Integrity and safety boundary

The verifier hashes the exact detached payload bytes via an injected SHA-256 implementation. Signature/authentication is intentionally not implemented here; a future updater must authenticate an envelope and its bound artifact hash before assigning REMOTE_AUTHENTICATED trust. Unauthenticated candidates are never activation-eligible. Bucket parsing is bounded by 128 bucket records, 750,000 rules, and 16 MiB; compact fixed-width strings avoid per-rule JSON-object overhead.