### PR TITLE
Add Firefox routing adapter and default-cancel guard

### DIFF
--- a/docs/development/FIREFOX_MV3_SKELETON.md
+++ b/docs/development/FIREFOX_MV3_SKELETON.md
@@ -4,12 +4,18 @@
 `src/extension-firefox-mv3`. Она пока **не является поддерживаемым Firefox-
 продуктом** и не входит в публичные инструкции установки или выпуска.
 
-Текущий пакет намеренно остаётся в состоянии `OFF`. Он содержит только Firefox
-MV3 manifest, непостоянную background event page, минимальное долговременное
-состояние `OFF` и read-only capability RPC. В нём нет proxy/WebRequest-
-разрешений, host permissions, маршрутизации, provider dataset, updater,
-аутентификации или сетевых обращений. Команда активации всегда отвечает
-`ACTIVATION_NOT_IMPLEMENTED`.
+Текущий пакет намеренно остаётся в состоянии `OFF`. Он содержит Firefox MV3
+manifest, непостоянную background event page, минимальное долговременное
+состояние `OFF`, read-only capability RPC и неактивный Firefox routing adapter.
+Adapter заранее регистрирует `proxy.onRequest` и блокирующий
+`webRequest.onBeforeRequest`, поэтому manifest уже запрашивает `proxy`,
+`webRequest`, `webRequestBlocking` и `<all_urls>`. Пока durable intent равен
+`OFF`, proxy listener не задаёт маршрут, а guard разрешает обычный трафик.
+
+Активация, provider dataset, updater, proxy ownership, аутентификация и health-
+проверки ещё не реализованы. Команда активации всегда отвечает
+`ACTIVATION_NOT_IMPLEMENTED`; наличие широких сетевых разрешений не делает
+маршрутизацию доступной пользователю.
 
 Для каркаса используется development-only Gecko ID
 `firefox-mv3-skeleton@runet-censorship-bypass.invalid`. Production Gecko/AMO ID
@@ -25,8 +31,9 @@ npm --prefix $Project run lint:firefox
 npm --prefix $Project run build:firefox
 ```
 
-Сборка содержит только `manifest.json` и два background-скрипта в
-`build/extension-firefox-mv3`. Она не меняет Chromium build output. Отдельный
+Сборка содержит только `manifest.json`, Firefox background-скрипты и точную
+копию browser-neutral routing contract в `build/extension-firefox-mv3`. Она не
+меняет Chromium build output. Отдельный
 локальный smoke с установленным Firefox 154.0.1 и одноразовым профилем можно
 запустить командой:
 

--- a/extensions/chromium/runet-censorship-bypass/gulpfile.js
+++ b/extensions/chromium/runet-censorship-bypass/gulpfile.js
@@ -87,7 +87,11 @@ const chromiumMv3Src = './src/extension-chromium-mv3/**/*';
 const firefoxMv3RuntimeSrc = [
   './src/extension-firefox-mv3/manifest.json',
   './src/extension-firefox-mv3/background/off-state.js',
+  './src/extension-firefox-mv3/background/routing-adapter.js',
   './src/extension-firefox-mv3/background/event-page.js',
+];
+const firefoxMv3CommonSrc = [
+  './src/extension-mv3-common/routing-contract.js',
 ];
 const firefoxSrc = './src/extension-firefox/**/*';
 const chromiumMv3TldtsSrc = [
@@ -195,13 +199,27 @@ const copyFirefoxMv3 = function(cb) {
 
 };
 
+const copyFirefoxMv3Common = function(cb) {
+
+  gulp.src(firefoxMv3CommonSrc, {
+    base: './src/extension-mv3-common',
+    encoding: false,
+  })
+    .pipe(gulp.dest(`${firefoxMv3Dst}/background/common`))
+    .on('end', cb);
+
+};
+
 const buildAll = gulp.series(clean, gulp.parallel(copyMini, copyFull, copyBeta));
 const buildBeta = copyBeta;
 const buildChromiumMv3 = gulp.series(
     cleanChromiumMv3,
     gulp.parallel(copyChromiumMv3, copyChromiumMv3Tldts),
 );
-const buildFirefoxMv3 = gulp.series(cleanFirefoxMv3, copyFirefoxMv3);
+const buildFirefoxMv3 = gulp.series(
+    cleanFirefoxMv3,
+    gulp.parallel(copyFirefoxMv3, copyFirefoxMv3Common),
+);
 
 module.exports = {
   default: buildAll,

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/background/event-page.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/background/event-page.js
@@ -3,7 +3,11 @@
 (function startFirefoxEventPage(root) {
 
   const offState = root.rucbFirefoxOffState;
-  const runtimeState = offState.OFF;
+  const routing = root.rucbFirefoxRoutingAdapter;
+  const routingAdapter = routing.createAdapter({
+    initialState: routing.STATES.OFF,
+  });
+  const runtimeState = routingAdapter.runtimeState;
   const durableIntent = offState.OFF;
   const bootId = root.crypto && typeof root.crypto.randomUUID === 'function' ?
     root.crypto.randomUUID() :
@@ -42,7 +46,7 @@
           runtimeState,
           durableIntent,
           privateWindowAccess: await readPrivateWindowAccess(),
-          routingImplemented: false,
+          routingImplemented: true,
           activationSupported: false,
           providerDatasetAvailable: false,
         },
@@ -55,6 +59,23 @@
 
   }
 
+  browser.proxy.onRequest.addListener(
+      routingAdapter.onProxyRequest,
+      {urls: ['<all_urls>']},
+  );
+  browser.webRequest.onBeforeRequest.addListener(
+      routingAdapter.onBeforeRequest,
+      {urls: ['<all_urls>']},
+      ['blocking'],
+  );
+  browser.webRequest.onCompleted.addListener(
+      routingAdapter.onRequestTerminal,
+      {urls: ['<all_urls>']},
+  );
+  browser.webRequest.onErrorOccurred.addListener(
+      routingAdapter.onRequestTerminal,
+      {urls: ['<all_urls>']},
+  );
   browser.runtime.onMessage.addListener(handleMessage);
 
   const initialization = offState.initialize(browser.storage.local).catch(() =>

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/background/routing-adapter.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/background/routing-adapter.js
@@ -1,0 +1,268 @@
+'use strict';
+/* global require */
+
+(function publishFirefoxRoutingAdapter(root, factory) {
+
+  const routingContract = typeof module === 'object' && module.exports ?
+    require('../../extension-mv3-common/routing-contract') :
+    root.mv3RoutingContract;
+  const api = factory(routingContract);
+  if (typeof module === 'object' && module.exports) {
+    module.exports = api;
+    return;
+  }
+  root.rucbFirefoxRoutingAdapter = api;
+
+})(typeof globalThis === 'object' ? globalThis : this, function(Routing) {
+
+  const STATES = Object.freeze({
+    OFF: 'OFF',
+    INITIALIZING: 'INITIALIZING',
+    READY: 'READY',
+    FAILED: 'FAILED',
+  });
+  const MAX_AUTHORIZATIONS = 256;
+  const MAX_CALLBACK_BUDGET = 256;
+  const ALLOW = Object.freeze({cancel: false});
+  const CANCEL = Object.freeze({cancel: true});
+  const DIRECT = Object.freeze({type: 'direct'});
+  const FIREFOX_TYPES = Object.freeze({
+    HTTP: 'http',
+    HTTPS: 'https',
+    SOCKS4: 'socks4',
+    SOCKS5: 'socks',
+  });
+
+  function isRequestId(value) {
+
+    return (typeof value === 'string' || typeof value === 'number') &&
+      String(value).length > 0;
+
+  }
+
+  function validCandidateHost(value) {
+
+    return typeof value === 'string' && value.length > 0 &&
+      !Array.from(value).some((character) => character.charCodeAt(0) <= 32) &&
+      !/[/\\?#@]/.test(value);
+
+  }
+
+  function candidateToProxyInfo(candidate) {
+
+    if (!candidate || typeof candidate !== 'object' ||
+        Array.isArray(candidate) ||
+        ['credentials', 'password', 'username'].some((key) =>
+          Object.prototype.hasOwnProperty.call(candidate, key)) ||
+        !Object.prototype.hasOwnProperty.call(FIREFOX_TYPES, candidate.type) ||
+        !validCandidateHost(candidate.host) ||
+        !Number.isSafeInteger(candidate.port) ||
+        candidate.port < 1 || candidate.port > 65535 ||
+        typeof candidate.proxyDNS !== 'boolean' ||
+        candidate.authRef !== null ||
+        typeof candidate.id !== 'string' || !candidate.id) {
+      return null;
+    }
+    if (candidate.failoverTimeoutSeconds !== null &&
+        (!Number.isSafeInteger(candidate.failoverTimeoutSeconds) ||
+        candidate.failoverTimeoutSeconds < 1)) {
+      return null;
+    }
+    const proxyInfo = {
+      type: FIREFOX_TYPES[candidate.type],
+      host: candidate.host,
+      port: candidate.port,
+    };
+    if (candidate.type === 'SOCKS4' || candidate.type === 'SOCKS5') {
+      proxyInfo.proxyDNS = candidate.proxyDNS;
+    }
+    if (candidate.failoverTimeoutSeconds !== null) {
+      proxyInfo.failoverTimeout = candidate.failoverTimeoutSeconds;
+    }
+    return proxyInfo;
+
+  }
+
+  function convertDecision(decision) {
+
+    if (!decision || typeof decision !== 'object' || Array.isArray(decision)) {
+      return null;
+    }
+    if (decision.kind === Routing.KINDS.DIRECT) {
+      return {proxyResult: DIRECT, callbackBudget: 1};
+    }
+    if (decision.kind === Routing.KINDS.FAIL_CLOSED) {
+      return null;
+    }
+    if (decision.kind !== Routing.KINDS.PROXY ||
+        !Array.isArray(decision.candidates) ||
+        decision.candidates.length < 1 ||
+        decision.candidates.length > MAX_CALLBACK_BUDGET ||
+        !Object.values(Routing.FALLBACKS).includes(decision.fallback)) {
+      return null;
+    }
+    const proxies = [];
+    for (const candidate of decision.candidates) {
+      const proxyInfo = candidateToProxyInfo(candidate);
+      if (!proxyInfo) {
+        return null;
+      }
+      proxies.push(proxyInfo);
+    }
+    if (decision.fallback === Routing.FALLBACKS.DIRECT) {
+      if (proxies.length === MAX_CALLBACK_BUDGET) {
+        return null;
+      }
+      proxies.push(DIRECT);
+      return {proxyResult: proxies, callbackBudget: proxies.length};
+    }
+    proxies.push(null);
+    return {
+      proxyResult: proxies,
+      callbackBudget: proxies.length - 1,
+    };
+
+  }
+
+  function createAdapter(options = {}) {
+
+    const runtimeState = options.initialState || STATES.OFF;
+    if (!Object.values(STATES).includes(runtimeState)) {
+      throw new TypeError('INVALID_FIREFOX_RUNTIME_STATE');
+    }
+    const decideRoute = options.decideRoute || Routing.decideRoute;
+    const routingInputForRequest = options.routingInputForRequest;
+    let authorizations = options.authorizations || new Map();
+
+    function resetAuthorizations() {
+
+      authorizations = new Map();
+
+    }
+
+    function clearAuthorization(requestId) {
+
+      try {
+        authorizations.delete(requestId);
+      } catch (_error) {
+        resetAuthorizations();
+      }
+
+    }
+
+    function authorize(requestId, callbackBudget) {
+
+      if (!isRequestId(requestId) ||
+          !Number.isSafeInteger(callbackBudget) || callbackBudget < 1 ||
+          callbackBudget > MAX_CALLBACK_BUDGET) {
+        return false;
+      }
+      try {
+        authorizations.delete(requestId);
+        if (authorizations.size >= MAX_AUTHORIZATIONS) {
+          return false;
+        }
+        authorizations.set(requestId, callbackBudget);
+        return authorizations.size <= MAX_AUTHORIZATIONS;
+      } catch (_error) {
+        resetAuthorizations();
+        return false;
+      }
+
+    }
+
+    function onProxyRequest(details) {
+
+      if (runtimeState === STATES.OFF) {
+        return undefined;
+      }
+      const requestId = details && details.requestId;
+      clearAuthorization(requestId);
+      if (runtimeState !== STATES.READY ||
+          typeof routingInputForRequest !== 'function') {
+        return DIRECT;
+      }
+      try {
+        const decision = decideRoute(routingInputForRequest(details));
+        const converted = convertDecision(decision);
+        if (!converted ||
+            !authorize(requestId, converted.callbackBudget)) {
+          clearAuthorization(requestId);
+          return DIRECT;
+        }
+        return converted.proxyResult;
+      } catch (_error) {
+        clearAuthorization(requestId);
+        return DIRECT;
+      }
+
+    }
+
+    function onBeforeRequest(details) {
+
+      try {
+        if (runtimeState === STATES.OFF) {
+          return ALLOW;
+        }
+        if (runtimeState !== STATES.READY) {
+          return CANCEL;
+        }
+        const requestId = details.requestId;
+        const remaining = authorizations.get(requestId);
+        if (!Number.isSafeInteger(remaining) || remaining < 1 ||
+            remaining > MAX_CALLBACK_BUDGET) {
+          authorizations.delete(requestId);
+          return CANCEL;
+        }
+        if (remaining === 1) {
+          authorizations.delete(requestId);
+        } else {
+          authorizations.set(requestId, remaining - 1);
+        }
+        return ALLOW;
+      } catch (_error) {
+        resetAuthorizations();
+        return CANCEL;
+      }
+
+    }
+
+    function onRequestTerminal(details) {
+
+      clearAuthorization(details && details.requestId);
+
+    }
+
+    function authorizationCount() {
+
+      try {
+        return authorizations.size;
+      } catch (_error) {
+        resetAuthorizations();
+        return 0;
+      }
+
+    }
+
+    return Object.freeze({
+      authorizationCount,
+      onBeforeRequest,
+      onProxyRequest,
+      onRequestTerminal,
+      runtimeState,
+    });
+
+  }
+
+  return Object.freeze({
+    ALLOW,
+    CANCEL,
+    MAX_AUTHORIZATIONS,
+    MAX_CALLBACK_BUDGET,
+    STATES,
+    candidateToProxyInfo,
+    convertDecision,
+    createAdapter,
+  });
+
+});

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/manifest.json
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/manifest.json
@@ -2,13 +2,21 @@
   "manifest_version": 3,
   "name": "Runet Censorship Bypass Firefox MV3 development skeleton",
   "version": "0.0.0.1",
-  "description": "Inert Firefox MV3 architecture package. Routing is not implemented.",
+  "description": "Firefox MV3 architecture package. Routing activation is not implemented.",
   "permissions": [
-    "storage"
+    "storage",
+    "proxy",
+    "webRequest",
+    "webRequestBlocking"
+  ],
+  "host_permissions": [
+    "<all_urls>"
   ],
   "background": {
     "scripts": [
+      "background/common/routing-contract.js",
       "background/off-state.js",
+      "background/routing-adapter.js",
       "background/event-page.js"
     ],
     "persistent": false

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/firefox-lifecycle-smoke.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/firefox-lifecycle-smoke.js
@@ -490,6 +490,19 @@ async function main() {
     Assert.strictEqual(await bodyText(client), MANUAL_PROXY_MARKER);
     await client.command('Addon:Install', {
       allowPrivateBrowsing: false,
+      path: packageRoot,
+      temporary: true,
+    });
+    await navigate(
+        client,
+        'http://manual-proxy-check.invalid/after-production-install',
+    );
+    Assert.strictEqual(await bodyText(client), MANUAL_PROXY_MARKER);
+    await client.command('Addon:Uninstall', {
+      id: 'firefox-mv3-skeleton@runet-censorship-bypass.invalid',
+    });
+    await client.command('Addon:Install', {
+      allowPrivateBrowsing: false,
       path: extensionDirectory,
       temporary: true,
     });
@@ -517,7 +530,12 @@ async function main() {
     await navigate(client, 'http://manual-proxy-check.invalid/after-recreation');
     Assert.strictEqual(await bodyText(client), MANUAL_PROXY_MARKER);
 
-    const phases = ['before-install', 'after-install', 'after-recreation'];
+    const phases = [
+      'before-install',
+      'after-production-install',
+      'after-install',
+      'after-recreation',
+    ];
     for (const phase of phases) {
       Assert.ok(proxyRequests.some((url) => url.includes(`/${phase}`)), phase);
     }
@@ -529,6 +547,7 @@ async function main() {
       durableIntent: secondRpc.capabilities.result.durableIntent,
       privateWindowAccess: secondRpc.capabilities.result.privateWindowAccess,
       manualProxyChecks: phases.length,
+      productionPackageInstalledSeparately: true,
     }, null, 2));
   } catch (error) {
     throw new Error(`${error && error.stack ? error.stack : error}\n${stderr}`);

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/package.test.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/package.test.js
@@ -13,8 +13,16 @@ function makePackage() {
   const root = Fs.mkdtempSync(Path.join(Os.tmpdir(), 'firefox-skeleton-package-'));
   for (const relativePath of EXPECTED_FILES) {
     const target = Path.join(root, relativePath);
+    const source = relativePath === 'background/common/routing-contract.js' ?
+      Path.resolve(
+          sourceRoot,
+          '..',
+          'extension-mv3-common',
+          'routing-contract.js',
+      ) :
+      Path.join(sourceRoot, relativePath);
     Fs.mkdirSync(Path.dirname(target), {recursive: true});
-    Fs.copyFileSync(Path.join(sourceRoot, relativePath), target);
+    Fs.copyFileSync(source, target);
   }
   return root;
 
@@ -33,7 +41,7 @@ describe('Firefox MV3 package verifier', function() {
 
   });
 
-  it('accepts only the exact inert package', function() {
+  it('accepts only the exact OFF-only routing package', function() {
 
     packageRoot = makePackage();
     const result = verifyPackage(packageRoot, sourceRoot);
@@ -51,12 +59,13 @@ describe('Firefox MV3 package verifier', function() {
 
   });
 
-  it('rejects a routing permission in the package manifest', function() {
+  it('rejects a package missing a required routing permission', function() {
 
     packageRoot = makePackage();
     const manifestPath = Path.join(packageRoot, 'manifest.json');
     const manifest = JSON.parse(Fs.readFileSync(manifestPath, 'utf8'));
-    manifest.permissions.push('proxy');
+    manifest.permissions = manifest.permissions.filter((value) =>
+      value !== 'webRequestBlocking');
     Fs.writeFileSync(manifestPath, JSON.stringify(manifest));
 
     Assert.throws(() => verifyPackage(packageRoot, sourceRoot));

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/routing-adapter.test.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/routing-adapter.test.js
@@ -1,0 +1,386 @@
+'use strict';
+
+const Assert = require('node:assert');
+const Routing = require('../../extension-mv3-common/routing-contract');
+const Adapter = require('../background/routing-adapter');
+
+const DIRECT_DECISION = Object.freeze({
+  kind: Routing.KINDS.DIRECT,
+  source: Routing.SOURCES.EXPLICIT_DIRECT,
+});
+
+function candidate(id, type, host, port, overrides = {}) {
+
+  return Object.assign({
+    id,
+    type,
+    host,
+    port,
+    proxyDNS: type === 'SOCKS4' || type === 'SOCKS5',
+    authRef: null,
+    failoverTimeoutSeconds: null,
+  }, overrides);
+
+}
+
+function proxyDecision(candidates, fallback = Routing.FALLBACKS.FAIL_CLOSED) {
+
+  return {
+    kind: Routing.KINDS.PROXY,
+    source: Routing.SOURCES.EXPLICIT_PROXY,
+    candidates,
+    fallback,
+  };
+
+}
+
+function adapterForDecision(decision, options = {}) {
+
+  return Adapter.createAdapter({
+    initialState: Adapter.STATES.READY,
+    decideRoute: options.decideRoute || ((value) => value),
+    routingInputForRequest: options.routingInputForRequest || (() => decision),
+    authorizations: options.authorizations,
+  });
+
+}
+
+describe('Firefox fail-closed routing adapter', function() {
+
+  it('leaves ordinary traffic alone while durable runtime is OFF', function() {
+
+    const adapter = Adapter.createAdapter();
+
+    Assert.strictEqual(adapter.runtimeState, Adapter.STATES.OFF);
+    Assert.strictEqual(adapter.onProxyRequest({requestId: 'off'}), undefined);
+    Assert.deepStrictEqual(adapter.onBeforeRequest({requestId: 'off'}), {
+      cancel: false,
+    });
+    Assert.strictEqual(adapter.authorizationCount(), 0);
+
+  });
+
+  it('authorizes exactly one callback for an intentional Direct route', function() {
+
+    const adapter = adapterForDecision(DIRECT_DECISION);
+
+    Assert.deepStrictEqual(adapter.onProxyRequest({requestId: 'direct'}), {
+      type: 'direct',
+    });
+    Assert.deepStrictEqual(adapter.onBeforeRequest({requestId: 'direct'}), {
+      cancel: false,
+    });
+    Assert.deepStrictEqual(adapter.onBeforeRequest({requestId: 'direct'}), {
+      cancel: true,
+    });
+
+  });
+
+  it('does not authorize Direct after a fail-closed proxy candidate', function() {
+
+    const adapter = adapterForDecision(proxyDecision([
+      candidate('one', 'HTTPS', 'proxy-one.test', 443),
+    ]));
+
+    Assert.deepStrictEqual(adapter.onProxyRequest({requestId: 'proxy'}), [
+      {type: 'https', host: 'proxy-one.test', port: 443},
+      null,
+    ]);
+    Assert.deepStrictEqual(adapter.onBeforeRequest({requestId: 'proxy'}), {
+      cancel: false,
+    });
+    Assert.deepStrictEqual(adapter.onBeforeRequest({requestId: 'proxy'}), {
+      cancel: true,
+    });
+
+  });
+
+  it('budgets each ordered proxy callback and cancels terminal fallback', function() {
+
+    const adapter = adapterForDecision(proxyDecision([
+      candidate('one', 'HTTP', 'proxy-one.test', 8080),
+      candidate('two', 'SOCKS5', '127.0.0.1', 9050, {
+        failoverTimeoutSeconds: 4,
+      }),
+    ]));
+
+    Assert.deepStrictEqual(adapter.onProxyRequest({requestId: 'failover'}), [
+      {type: 'http', host: 'proxy-one.test', port: 8080},
+      {
+        type: 'socks',
+        host: '127.0.0.1',
+        port: 9050,
+        proxyDNS: true,
+        failoverTimeout: 4,
+      },
+      null,
+    ]);
+    Assert.deepStrictEqual(adapter.onBeforeRequest({requestId: 'failover'}), {
+      cancel: false,
+    });
+    Assert.deepStrictEqual(adapter.onBeforeRequest({requestId: 'failover'}), {
+      cancel: false,
+    });
+    Assert.deepStrictEqual(adapter.onBeforeRequest({requestId: 'failover'}), {
+      cancel: true,
+    });
+
+  });
+
+  it('includes an intentional Direct fallback in the callback budget', function() {
+
+    const adapter = adapterForDecision(proxyDecision([
+      candidate('one', 'HTTP', 'proxy-one.test', 8080),
+      candidate('two', 'SOCKS4', '127.0.0.1', 9150),
+    ], Routing.FALLBACKS.DIRECT));
+
+    Assert.deepStrictEqual(adapter.onProxyRequest({requestId: 'fallback'}), [
+      {type: 'http', host: 'proxy-one.test', port: 8080},
+      {type: 'socks4', host: '127.0.0.1', port: 9150, proxyDNS: true},
+      {type: 'direct'},
+    ]);
+    for (let index = 0; index < 3; index += 1) {
+      Assert.deepStrictEqual(
+          adapter.onBeforeRequest({requestId: 'fallback'}),
+          {cancel: false},
+      );
+    }
+    Assert.deepStrictEqual(adapter.onBeforeRequest({requestId: 'fallback'}), {
+      cancel: true,
+    });
+
+  });
+
+  it('cancels missing and malformed authorization markers', function() {
+
+    const malformed = new Map([['bad', '1']]);
+    const adapter = adapterForDecision(DIRECT_DECISION, {
+      authorizations: malformed,
+    });
+
+    Assert.deepStrictEqual(adapter.onBeforeRequest({requestId: 'missing'}), {
+      cancel: true,
+    });
+    Assert.deepStrictEqual(adapter.onBeforeRequest({requestId: 'bad'}), {
+      cancel: true,
+    });
+    Assert.strictEqual(malformed.has('bad'), false);
+
+  });
+
+  it('does not evict an active authorization when the map cap is reached', function() {
+
+    const adapter = adapterForDecision(DIRECT_DECISION);
+    for (let index = 0; index < Adapter.MAX_AUTHORIZATIONS; index += 1) {
+      adapter.onProxyRequest({requestId: `active-${index}`});
+    }
+
+    Assert.strictEqual(adapter.authorizationCount(), Adapter.MAX_AUTHORIZATIONS);
+    Assert.deepStrictEqual(adapter.onProxyRequest({requestId: 'overflow'}), {
+      type: 'direct',
+    });
+    Assert.deepStrictEqual(adapter.onBeforeRequest({requestId: 'overflow'}), {
+      cancel: true,
+    });
+    Assert.deepStrictEqual(adapter.onBeforeRequest({requestId: 'active-0'}), {
+      cancel: false,
+    });
+
+  });
+
+  it('cleans an authorization defensively on terminal events', function() {
+
+    const adapter = adapterForDecision(DIRECT_DECISION);
+    adapter.onProxyRequest({requestId: 'terminal'});
+    Assert.strictEqual(adapter.authorizationCount(), 1);
+
+    adapter.onRequestTerminal({requestId: 'terminal'});
+
+    Assert.strictEqual(adapter.authorizationCount(), 0);
+    Assert.deepStrictEqual(adapter.onBeforeRequest({requestId: 'terminal'}), {
+      cancel: true,
+    });
+
+  });
+
+  it('fails closed before authorization for invalid or auth-dependent candidates', function() {
+
+    for (const invalid of [
+      candidate('bad-host', 'HTTP', 'https://proxy.test', 8080),
+      candidate('bad-port', 'HTTP', 'proxy.test', 0),
+      candidate('needs-auth', 'HTTPS', 'proxy.test', 443, {authRef: 'secret'}),
+      Object.assign(
+          candidate('credential', 'HTTP', 'proxy.test', 8080),
+          {password: 'x'},
+      ),
+    ]) {
+      const adapter = adapterForDecision(proxyDecision([invalid]));
+      Assert.deepStrictEqual(adapter.onProxyRequest({requestId: invalid.id}), {
+        type: 'direct',
+      });
+      Assert.deepStrictEqual(adapter.onBeforeRequest({requestId: invalid.id}), {
+        cancel: true,
+      });
+      Assert.strictEqual(adapter.authorizationCount(), 0);
+    }
+
+  });
+
+  it('fails closed for empty Proxy and core FAIL_CLOSED decisions', function() {
+
+    for (const decision of [
+      proxyDecision([]),
+      {
+        kind: Routing.KINDS.FAIL_CLOSED,
+        source: Routing.SOURCES.ROUTING_INPUT,
+        code: 'NO_VALID_ROUTE',
+      },
+    ]) {
+      const adapter = adapterForDecision(decision);
+      Assert.deepStrictEqual(adapter.onProxyRequest({requestId: 'closed'}), {
+        type: 'direct',
+      });
+      Assert.deepStrictEqual(adapter.onBeforeRequest({requestId: 'closed'}), {
+        cancel: true,
+      });
+    }
+
+  });
+
+  it('fails closed when route selection throws or returns async state', function() {
+
+    for (const decideRoute of [
+      () => {
+
+        throw new Error('injected routing failure');
+
+      },
+      () => Promise.resolve(DIRECT_DECISION),
+    ]) {
+      const adapter = adapterForDecision(null, {decideRoute});
+      Assert.deepStrictEqual(adapter.onProxyRequest({requestId: 'failure'}), {
+        type: 'direct',
+      });
+      Assert.deepStrictEqual(adapter.onBeforeRequest({requestId: 'failure'}), {
+        cancel: true,
+      });
+      Assert.strictEqual(adapter.authorizationCount(), 0);
+    }
+
+  });
+
+  it('cancels in INITIALIZING and FAILED without routing authorization', function() {
+
+    for (const state of [Adapter.STATES.INITIALIZING, Adapter.STATES.FAILED]) {
+      const adapter = Adapter.createAdapter({initialState: state});
+      Assert.deepStrictEqual(adapter.onProxyRequest({requestId: state}), {
+        type: 'direct',
+      });
+      Assert.deepStrictEqual(adapter.onBeforeRequest({requestId: state}), {
+        cancel: true,
+      });
+      Assert.strictEqual(adapter.authorizationCount(), 0);
+    }
+
+  });
+
+  it('catches synchronous guard state failures and cancels', function() {
+
+    const brokenMap = {
+      delete() {},
+      get() {
+
+        throw new Error('injected lookup failure');
+
+      },
+      get size() {
+
+        return 0;
+
+      },
+    };
+    const adapter = adapterForDecision(DIRECT_DECISION, {
+      authorizations: brokenMap,
+    });
+
+    Assert.deepStrictEqual(adapter.onBeforeRequest({requestId: 'fault'}), {
+      cancel: true,
+    });
+    Assert.strictEqual(adapter.authorizationCount(), 0);
+
+  });
+
+  it('starts every recreated event-page adapter with no authorization', function() {
+
+    const first = adapterForDecision(DIRECT_DECISION);
+    first.onProxyRequest({requestId: 'old-request'});
+    const recreated = adapterForDecision(DIRECT_DECISION);
+
+    Assert.strictEqual(first.authorizationCount(), 1);
+    Assert.strictEqual(recreated.authorizationCount(), 0);
+    Assert.deepStrictEqual(
+        recreated.onBeforeRequest({requestId: 'old-request'}),
+        {cancel: true},
+    );
+
+  });
+
+  it('preserves shared candidate order and Firefox type mapping', function() {
+
+    const input = {
+      hostname: 'protected.test',
+      rules: {proxy: ['protected.test']},
+      candidateGroups: {
+        configured: {
+          own: [candidate('own', 'HTTPS', 'own.test', 8443)],
+          localTor: [candidate('tor', 'SOCKS5', '127.0.0.1', 9050)],
+          torBrowser: [candidate('browser', 'SOCKS4', '127.0.0.1', 9150)],
+          warp: [candidate('warp', 'HTTP', '127.0.0.1', 40000)],
+        },
+      },
+    };
+    const adapter = Adapter.createAdapter({
+      initialState: Adapter.STATES.READY,
+      routingInputForRequest: () => input,
+    });
+
+    Assert.deepStrictEqual(adapter.onProxyRequest({requestId: 'ordered'}), [
+      {type: 'https', host: 'own.test', port: 8443},
+      {type: 'socks', host: '127.0.0.1', port: 9050, proxyDNS: true},
+      {type: 'socks4', host: '127.0.0.1', port: 9150, proxyDNS: true},
+      {type: 'http', host: '127.0.0.1', port: 40000},
+      null,
+    ]);
+
+  });
+
+  it('keeps authorizations isolated by exact request ID under concurrency', function() {
+
+    const adapter = Adapter.createAdapter({
+      initialState: Adapter.STATES.READY,
+      decideRoute: (value) => value,
+      routingInputForRequest(details) {
+
+        return details.requestId === 'direct' ?
+          DIRECT_DECISION :
+          proxyDecision([candidate('proxy', 'HTTP', 'proxy.test', 8080)]);
+
+      },
+    });
+    adapter.onProxyRequest({requestId: 'proxy'});
+    adapter.onProxyRequest({requestId: 'direct'});
+
+    Assert.deepStrictEqual(adapter.onBeforeRequest({requestId: 'unknown'}), {
+      cancel: true,
+    });
+    Assert.deepStrictEqual(adapter.onBeforeRequest({requestId: 'direct'}), {
+      cancel: false,
+    });
+    Assert.deepStrictEqual(adapter.onBeforeRequest({requestId: 'proxy'}), {
+      cancel: false,
+    });
+    Assert.strictEqual(adapter.authorizationCount(), 0);
+
+  });
+
+});

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/skeleton.test.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/skeleton.test.js
@@ -15,6 +15,14 @@ const offStateSource = Fs.readFileSync(
     Path.join(sourceRoot, 'background', 'off-state.js'),
     'utf8',
 );
+const routingContractSource = Fs.readFileSync(
+    Path.resolve(sourceRoot, '..', 'extension-mv3-common', 'routing-contract.js'),
+    'utf8',
+);
+const routingAdapterSource = Fs.readFileSync(
+    Path.join(sourceRoot, 'background', 'routing-adapter.js'),
+    'utf8',
+);
 const eventPageSource = Fs.readFileSync(
     Path.join(sourceRoot, 'background', 'event-page.js'),
     'utf8',
@@ -51,6 +59,7 @@ function startEventPage(options = {}) {
   const events = [];
   const storage = options.storage || makeStorage();
   let messageListener;
+  const networkListeners = {};
   const browser = {
     extension: {
       async isAllowedIncognitoAccess() {
@@ -75,6 +84,16 @@ function startEventPage(options = {}) {
         },
       },
     },
+    proxy: {
+      onRequest: {
+        addListener(listener, filter) {
+
+          events.push('proxy-listener-registered');
+          networkListeners.proxy = {filter, listener};
+
+        },
+      },
+    },
     storage: {
       local: {
         async get(key) {
@@ -91,16 +110,49 @@ function startEventPage(options = {}) {
         },
       },
     },
+    webRequest: {
+      onBeforeRequest: {
+        addListener(listener, filter, extraInfoSpec) {
+
+          events.push('guard-listener-registered');
+          networkListeners.before = {extraInfoSpec, filter, listener};
+
+        },
+      },
+      onCompleted: {
+        addListener(listener, filter) {
+
+          events.push('completed-listener-registered');
+          networkListeners.completed = {filter, listener};
+
+        },
+      },
+      onErrorOccurred: {
+        addListener(listener, filter) {
+
+          events.push('error-listener-registered');
+          networkListeners.error = {filter, listener};
+
+        },
+      },
+    },
   };
   const context = Vm.createContext({
     browser,
     crypto: {randomUUID: () => options.bootId || 'test-boot'},
   });
+  Vm.runInContext(routingContractSource, context, {
+    filename: 'routing-contract.js',
+  });
   Vm.runInContext(offStateSource, context, {filename: 'off-state.js'});
+  Vm.runInContext(routingAdapterSource, context, {
+    filename: 'routing-adapter.js',
+  });
   Vm.runInContext(eventPageSource, context, {filename: 'event-page.js'});
   return {
     context,
     events,
+    networkListeners,
     storage,
     async ready() {
 
@@ -124,7 +176,12 @@ describe('Firefox MV3 inert skeleton', function() {
 
     Assert.strictEqual(manifest.manifest_version, 3);
     Assert.deepStrictEqual(manifest.background, {
-      scripts: ['background/off-state.js', 'background/event-page.js'],
+      scripts: [
+        'background/common/routing-contract.js',
+        'background/off-state.js',
+        'background/routing-adapter.js',
+        'background/event-page.js',
+      ],
       persistent: false,
     });
     Assert.strictEqual(manifest.incognito, 'spanning');
@@ -140,21 +197,18 @@ describe('Firefox MV3 inert skeleton', function() {
 
   });
 
-  it('requests storage and no routing or broad host permissions', function() {
+  it('requests only the routing-adapter permissions and full routing scope',
+      function() {
 
-    Assert.deepStrictEqual(manifest.permissions, ['storage']);
-    Assert.strictEqual('host_permissions' in manifest, false);
-    const serialized = JSON.stringify(manifest);
-    for (const forbidden of [
-      'proxy',
-      'webRequest',
-      'webRequestBlocking',
-      '<all_urls>',
-    ]) {
-      Assert.strictEqual(serialized.includes(`"${forbidden}"`), false);
-    }
+        Assert.deepStrictEqual(manifest.permissions, [
+          'storage',
+          'proxy',
+          'webRequest',
+          'webRequestBlocking',
+        ]);
+        Assert.deepStrictEqual(manifest.host_permissions, ['<all_urls>']);
 
-  });
+      });
 
   it('normalizes every missing or malformed durable value to OFF', function() {
 
@@ -208,15 +262,43 @@ describe('Firefox MV3 inert skeleton', function() {
 
   });
 
-  it('registers the RPC listener before asynchronous state reading', async function() {
+  it('registers every network listener synchronously before state reading',
+      async function() {
+
+        const eventPage = startEventPage();
+        await eventPage.ready();
+
+        Assert.deepStrictEqual(eventPage.events.slice(0, 6), [
+          'proxy-listener-registered',
+          'guard-listener-registered',
+          'completed-listener-registered',
+          'error-listener-registered',
+          'listener-registered',
+          'storage-get',
+        ]);
+        Assert.deepStrictEqual(
+            JSON.parse(JSON.stringify(
+                eventPage.networkListeners.before.extraInfoSpec,
+            )),
+            ['blocking'],
+        );
+
+      });
+
+  it('keeps the registered production adapter inert while OFF', function() {
 
     const eventPage = startEventPage();
-    await eventPage.ready();
 
-    Assert.deepStrictEqual(eventPage.events.slice(0, 2), [
-      'listener-registered',
-      'storage-get',
-    ]);
+    Assert.strictEqual(
+        eventPage.networkListeners.proxy.listener({requestId: 'off'}),
+        undefined,
+    );
+    Assert.deepStrictEqual(
+        JSON.parse(JSON.stringify(
+            eventPage.networkListeners.before.listener({requestId: 'off'}),
+        )),
+        {cancel: false},
+    );
 
   });
 
@@ -235,7 +317,7 @@ describe('Firefox MV3 inert skeleton', function() {
         runtimeState: 'OFF',
         durableIntent: 'OFF',
         privateWindowAccess: 'GRANTED',
-        routingImplemented: false,
+        routingImplemented: true,
         activationSupported: false,
         providerDatasetAvailable: false,
       },
@@ -290,13 +372,15 @@ describe('Firefox MV3 inert skeleton', function() {
 
   });
 
-  it('contains no network-control, remote-fetch, or Chromium-state path', function() {
+  it('contains no ownership, remote-fetch, or Chromium-state path', function() {
 
-    const runtimeSource = `${offStateSource}\n${eventPageSource}`;
+    const runtimeSource = [
+      offStateSource,
+      routingAdapterSource,
+      eventPageSource,
+    ].join('\n');
     for (const forbidden of [
-      'browser.proxy',
       'proxy.settings',
-      'webRequest',
       'XMLHttpRequest',
       'fetch(',
       'extension-chromium-mv3',

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/verify-package.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/verify-package.js
@@ -5,14 +5,14 @@ const Fs = require('node:fs');
 const Path = require('node:path');
 
 const EXPECTED_FILES = Object.freeze([
+  'background/common/routing-contract.js',
   'background/event-page.js',
   'background/off-state.js',
+  'background/routing-adapter.js',
   'manifest.json',
 ]);
 const FORBIDDEN_RUNTIME_TEXT = Object.freeze([
-  'browser.proxy',
   'proxy.settings',
-  'webRequest',
   'XMLHttpRequest',
   'fetch(',
   'BEGIN PRIVATE KEY',
@@ -51,7 +51,10 @@ function verifyPackage(packageRoot, sourceRoot) {
 
   for (const relativePath of files) {
     const packaged = Fs.readFileSync(Path.join(packageRoot, relativePath));
-    const source = Fs.readFileSync(Path.join(sourceRoot, relativePath));
+    const sourcePath = relativePath === 'background/common/routing-contract.js' ?
+      Path.resolve(sourceRoot, '..', 'extension-mv3-common', 'routing-contract.js') :
+      Path.join(sourceRoot, relativePath);
+    const source = Fs.readFileSync(sourcePath);
     Assert.deepStrictEqual(packaged, source, `Changed package bytes: ${relativePath}`);
   }
 
@@ -60,14 +63,21 @@ function verifyPackage(packageRoot, sourceRoot) {
       'utf8',
   ));
   Assert.strictEqual(manifest.manifest_version, 3);
-  Assert.deepStrictEqual(manifest.permissions, ['storage']);
+  Assert.deepStrictEqual(manifest.permissions, [
+    'storage',
+    'proxy',
+    'webRequest',
+    'webRequestBlocking',
+  ]);
   Assert.strictEqual(manifest.background.persistent, false);
   Assert.deepStrictEqual(manifest.background.scripts, [
+    'background/common/routing-contract.js',
     'background/off-state.js',
+    'background/routing-adapter.js',
     'background/event-page.js',
   ]);
   Assert.strictEqual('service_worker' in manifest.background, false);
-  Assert.strictEqual('host_permissions' in manifest, false);
+  Assert.deepStrictEqual(manifest.host_permissions, ['<all_urls>']);
 
   const runtimeText = EXPECTED_FILES
       .filter((file) => file.endsWith('.js'))
@@ -87,7 +97,9 @@ if (require.main === module) {
       Path.join(projectRoot, 'build', 'extension-firefox-mv3'),
       Path.join(projectRoot, 'src', 'extension-firefox-mv3'),
   );
-  console.log(`Verified inert Firefox MV3 package: ${result.files.length} files.`);
+  console.log(
+      `Verified OFF-only Firefox MV3 routing package: ${result.files.length} files.`,
+  );
 }
 
 module.exports = Object.freeze({EXPECTED_FILES, listFiles, verifyPackage});


### PR DESCRIPTION
## Summary

- registers Firefox `proxy.onRequest`, blocking `webRequest.onBeforeRequest`, and terminal cleanup listeners synchronously at event-page top level
- adds the `OFF` / `INITIALIZING` / `READY` / `FAILED` Firefox adapter state model while keeping the shipped package permanently in durable `OFF`
- converts browser-neutral routing decisions into ordered Firefox `ProxyInfo` results
- enforces a bounded, per-request callback budget so fail-closed proxy chains never authorize Firefox's terminal Direct fallback
- copies the existing browser-neutral routing contract into the isolated Firefox build without changing Chromium runtime inputs

## Routing boundary

- `DIRECT`: one explicitly authorized callback
- `PROXY` + `FAIL_CLOSED`: ordered candidates, with authorization only for proxy callbacks
- `PROXY` + `DIRECT`: ordered candidates plus one explicitly authorized Direct callback
- `FAIL_CLOSED`, malformed/empty decisions, auth-dependent candidates, and route failures: no authorization; the synchronous guard cancels
- authorization map: hard cap 256; saturation does not evict another active request
- terminal completion/error cleanup is defensive; event-page recreation starts from an empty map

The top-level guard catches synchronous internal failures and cancels. The remaining platform assumption is that Firefox invokes the registered blocking listener itself.

## Intentionally not included

- activation remains `ACTIVATION_NOT_IMPLEMENTED`
- no real provider dataset or updater
- no remote fetch or executable provider content
- no `proxy.settings` ownership/Clear logic
- no proxy authentication, credentials, or health system
- no Firefox UI or release/signing work

Although the Firefox manifest now has `proxy`, `webRequest`, `webRequestBlocking`, and `<all_urls>` for the adapter boundary, durable `OFF` remains authoritative: the proxy listener returns no override and the guard allows ordinary Firefox traffic.

## Verification

- supply-chain verifier: 11 exact direct pins; focused tests 11/11
- PAC: 26/26
- Chromium MV3: 428/428
- aggregate: 477/477
- Firefox deterministic tests: 32/32
- Firefox package: 5 exact allowlisted files
- Firefox 154.0.1 build 20260824154132 localhost routing smoke: 24/24 requests matched; protected-origin contacts 0
  - valid Proxy, intentional Direct, two-proxy failover, unavailable Proxy, rejected listener, invalid `ProxyInfo`, `INITIALIZING`, `FAILED`, and concurrent Proxy + Direct covered
  - two-proxy failover produced two `onBeforeRequest` callbacks with the same correlated request ID
- production-package lifecycle smoke: exact package installed separately, remained OFF, did not alter a pre-existing manual proxy, and the instrumented copy preserved OFF across genuine automatic event-page recreation
- Chromium runtime package: 70 vs 70 files; added 0; missing 0; SHA-256 differences 0
- dependencies and lockfile: unchanged

PR artifact upload remains main-only, so this pull request is expected to publish 0 artifacts.

