### PR TITLE
Add Firefox declarative dataset runtime

### DIFF
--- a/docs/development/FIREFOX_MV3_SKELETON.md
+++ b/docs/development/FIREFOX_MV3_SKELETON.md
@@ -6,14 +6,15 @@
 
 Текущий пакет намеренно остаётся в состоянии `OFF`. Он содержит Firefox MV3
 manifest, непостоянную background event page, минимальное долговременное
-состояние `OFF`, read-only capability RPC и неактивный Firefox routing adapter.
+состояние `OFF`, read-only capability RPC, неактивный Firefox routing adapter и
+реализацию declarative dataset runtime без самого provider dataset.
 Adapter заранее регистрирует `proxy.onRequest` и блокирующий
 `webRequest.onBeforeRequest`, поэтому manifest уже запрашивает `proxy`,
 `webRequest`, `webRequestBlocking` и `<all_urls>`. Пока durable intent равен
 `OFF`, proxy listener не задаёт маршрут, а guard разрешает обычный трафик.
 
-Активация, provider dataset, updater, proxy ownership, аутентификация и health-
-проверки ещё не реализованы. Команда активации всегда отвечает
+Реальный provider dataset, updater, активация, proxy ownership, аутентификация
+и health-проверки ещё не реализованы. Команда активации всегда отвечает
 `ACTIVATION_NOT_IMPLEMENTED`; наличие широких сетевых разрешений не делает
 маршрутизацию доступной пользователю.
 
@@ -31,9 +32,18 @@ npm --prefix $Project run lint:firefox
 npm --prefix $Project run build:firefox
 ```
 
-Сборка содержит только `manifest.json`, Firefox background-скрипты и точную
-копию browser-neutral routing contract в `build/extension-firefox-mv3`. Она не
-меняет Chromium build output. Отдельный
+Сборка содержит только `manifest.json`, Firefox background-скрипты и точные
+копии browser-neutral routing/dataset contract в
+`build/extension-firefox-mv3`. Dataset runtime использует неизменяемые
+SHA-256-addressed артефакты, строгую общую верификацию и fallback
+active -> previous LKG -> packaged baseline; parsed index хранится только в
+памяти event page. Неизменяемые bytes и маленькие provider pointers находятся
+в отдельных object stores Firefox-specific IndexedDB; запись артефакта и
+переключение pointer выполняются одной транзакцией только после проверки точных
+bytes. Remote candidate с unauthenticated trust не может стать active. Пакет не
+содержит реального или синтетического provider
+dataset и в `OFF` не открывает dataset storage. Он не меняет Chromium build
+output. Отдельный
 локальный smoke с установленным Firefox 154.0.1 и одноразовым профилем можно
 запустить командой:
 
@@ -45,4 +55,6 @@ Smoke проверяет реальное уничтожение и пересо
 сохранение `OFF` и отсутствие изменений заранее настроенного localhost proxy.
 Он не является обязательным сетевым CI-шагом. Маршрутизация и пользовательский
 Firefox-интерфейс должны появляться только в последующих отдельно проверяемых
-изменениях.
+изменениях. Источник, лицензия и authenticated publication production-scale
+provider dataset остаются нерешённым prerelease-блокером; этот пакет не
+предполагает их одобрения.

--- a/extensions/chromium/runet-censorship-bypass/gulpfile.js
+++ b/extensions/chromium/runet-censorship-bypass/gulpfile.js
@@ -87,11 +87,16 @@ const chromiumMv3Src = './src/extension-chromium-mv3/**/*';
 const firefoxMv3RuntimeSrc = [
   './src/extension-firefox-mv3/manifest.json',
   './src/extension-firefox-mv3/background/off-state.js',
+  './src/extension-firefox-mv3/background/dataset-store.js',
+  './src/extension-firefox-mv3/background/provider-lookup.js',
+  './src/extension-firefox-mv3/background/dataset-runtime.js',
   './src/extension-firefox-mv3/background/routing-adapter.js',
   './src/extension-firefox-mv3/background/event-page.js',
 ];
 const firefoxMv3CommonSrc = [
   './src/extension-mv3-common/routing-contract.js',
+  './src/extension-mv3-common/provider-dataset.js',
+  './src/extension-mv3-common/provider-dataset-state.js',
 ];
 const firefoxSrc = './src/extension-firefox/**/*';
 const chromiumMv3TldtsSrc = [

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/background/dataset-runtime.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/background/dataset-runtime.js
@@ -1,0 +1,249 @@
+'use strict';
+/* global require */
+
+(function publishFirefoxDatasetRuntime(root, factory) {
+
+  const routing = typeof module === 'object' && module.exports ?
+    require('../../extension-mv3-common/routing-contract') :
+    root.mv3RoutingContract;
+  const datasetState = typeof module === 'object' && module.exports ?
+    require('../../extension-mv3-common/provider-dataset-state') :
+    root.mv3ProviderDatasetState;
+  const providerLookup = typeof module === 'object' && module.exports ?
+    require('./provider-lookup') : root.rucbFirefoxProviderLookup;
+  const api = factory(routing, datasetState, providerLookup);
+  if (typeof module === 'object' && module.exports) {
+    module.exports = api;
+    return;
+  }
+  root.rucbFirefoxDatasetRuntime = api;
+
+})(typeof globalThis === 'object' ? globalThis : this,
+    function(Routing, DatasetState, ProviderLookup) {
+
+      const STATES = Object.freeze({
+        OFF: 'OFF',
+        INITIALIZING: 'INITIALIZING',
+        READY: 'READY',
+        FAILED: 'FAILED',
+      });
+
+      function runtimeError(code) {
+
+        const error = new TypeError(code);
+        error.code = code;
+        return error;
+
+      }
+
+      function matchingVerification(stored, selected) {
+
+        if (!selected) {
+          return null;
+        }
+        return [
+          stored.active,
+          stored.previousLkg,
+          stored.packagedBaseline,
+        ].find((verification) => verification && verification.ok === true &&
+          verification.dataset.identity.artifactSha256 ===
+            selected.artifactSha256 &&
+          verification.dataset.identity.providerKey === selected.providerKey) ||
+          null;
+
+      }
+
+      function requestHostname(details, baseInput) {
+
+        if (baseInput && typeof baseInput.hostname === 'string') {
+          return ProviderLookup.normalizeHostname(baseInput.hostname);
+        }
+        if (!details || typeof details.url !== 'string') {
+          throw runtimeError('REQUEST_HOSTNAME_UNAVAILABLE');
+        }
+        try {
+          return ProviderLookup.normalizeHostname(new URL(details.url).hostname);
+        } catch (_error) {
+          throw runtimeError('REQUEST_HOSTNAME_UNAVAILABLE');
+        }
+
+      }
+
+      function providerDecision(resolution, baseInput) {
+
+        const source = resolution.kind === ProviderLookup.KINDS.MISS ?
+          'PROVIDER_DATASET_MISS' : 'PROVIDER_DATASET';
+        if (resolution.kind === ProviderLookup.KINDS.FAILURE) {
+          return {
+            kind: Routing.KINDS.FAIL_CLOSED,
+            source: 'PROVIDER_DATASET',
+            code: resolution.code || 'PROVIDER_LOOKUP_FAILED',
+          };
+        }
+        if (resolution.kind === ProviderLookup.KINDS.PROVIDER_PROXY) {
+          return {
+            kind: Routing.KINDS.PROXY,
+            source,
+            candidates: Array.isArray(baseInput.providerCandidates) ?
+              baseInput.providerCandidates : [],
+            fallback: baseInput.providerFallback || Routing.FALLBACKS.DIRECT,
+          };
+        }
+        if (resolution.kind === ProviderLookup.KINDS.PROVIDER_DIRECT ||
+            resolution.kind === ProviderLookup.KINDS.MISS) {
+          return {kind: Routing.KINDS.DIRECT, source};
+        }
+        return {
+          kind: Routing.KINDS.FAIL_CLOSED,
+          source: 'PROVIDER_DATASET',
+          code: 'INVALID_PROVIDER_LOOKUP_RESULT',
+        };
+
+      }
+
+      function createRuntime(options = {}) {
+
+        const protectionIntended = options.protectionIntended === true;
+        const providerKey = options.providerKey;
+        const store = options.store;
+        const baseInputForRequest = options.baseInputForRequest;
+        const buildLookup = options.buildLookup || ProviderLookup.buildLookup;
+        let state = protectionIntended ? STATES.INITIALIZING : STATES.OFF;
+        let failureCode = null;
+        let selected = null;
+        let lookupIndex = null;
+        let initialization;
+
+        async function initializeUnchecked() {
+
+          if (state === STATES.OFF) {
+            return snapshot();
+          }
+          if (!store || typeof store.loadVerifications !== 'function') {
+            throw runtimeError('DATASET_STORE_UNAVAILABLE');
+          }
+          const stored = await store.loadVerifications(providerKey, {
+            firstUsableOnly: true,
+          });
+          const plan = DatasetState.planDatasetActivation({
+            protectionIntended: true,
+            providerKey,
+            active: stored.active,
+            previousLkg: stored.previousLkg,
+            packagedBaseline: stored.packagedBaseline,
+            candidate: null,
+          });
+          if (plan.kind === DatasetState.ACTIONS.FAIL_CLOSED) {
+            throw runtimeError(plan.code || 'NO_USABLE_PROVIDER_DATASET');
+          }
+          const verification = matchingVerification(stored, plan.selected);
+          if (!verification) {
+            throw runtimeError('SELECTED_DATASET_UNAVAILABLE');
+          }
+          const nextLookup = buildLookup(verification);
+          if (!nextLookup || typeof nextLookup.lookup !== 'function') {
+            throw runtimeError('DATASET_INDEX_BUILD_FAILED');
+          }
+          lookupIndex = nextLookup;
+          selected = Object.freeze({
+            providerKey: plan.selected.providerKey,
+            datasetVersion: plan.selected.datasetVersion,
+            artifactSha256: plan.selected.artifactSha256,
+            source: plan.kind,
+          });
+          state = STATES.READY;
+          return snapshot();
+
+        }
+
+        function initialize() {
+
+          if (!initialization) {
+            initialization = initializeUnchecked().catch((error) => {
+              lookupIndex = null;
+              selected = null;
+              state = STATES.FAILED;
+              failureCode = error && error.code ?
+                error.code : 'DATASET_INITIALIZATION_FAILED';
+              return snapshot();
+            });
+          }
+          return initialization;
+
+        }
+
+        function getState() {
+
+          return state;
+
+        }
+
+        function snapshot() {
+
+          return Object.freeze({
+            state,
+            failureCode,
+            selected,
+          });
+
+        }
+
+        function resolveProvider(rawHostname) {
+
+          if (state !== STATES.READY || !lookupIndex) {
+            return Object.freeze({
+              kind: ProviderLookup.KINDS.FAILURE,
+              code: state === STATES.FAILED ?
+                failureCode : 'PROVIDER_DATASET_NOT_READY',
+            });
+          }
+          try {
+            return lookupIndex.lookup(rawHostname);
+          } catch (_error) {
+            return Object.freeze({
+              kind: ProviderLookup.KINDS.FAILURE,
+              code: 'PROVIDER_LOOKUP_FAILED',
+            });
+          }
+
+        }
+
+        function routingInputForRequest(details) {
+
+          if (state !== STATES.READY || !lookupIndex) {
+            throw runtimeError('PROVIDER_DATASET_NOT_READY');
+          }
+          const baseInput = typeof baseInputForRequest === 'function' ?
+            baseInputForRequest(details) : {};
+          if (!baseInput || typeof baseInput !== 'object' ||
+              Array.isArray(baseInput)) {
+            throw runtimeError('INVALID_ROUTING_BASE_INPUT');
+          }
+          const hostname = requestHostname(details, baseInput);
+          const provider = providerDecision(
+              resolveProvider(hostname),
+              baseInput,
+          );
+          const input = Object.assign({}, baseInput, {hostname, provider});
+          delete input.providerCandidates;
+          delete input.providerFallback;
+          return input;
+
+        }
+
+        return Object.freeze({
+          getState,
+          initialize,
+          resolveProvider,
+          routingInputForRequest,
+          snapshot,
+        });
+
+      }
+
+      return Object.freeze({
+        STATES,
+        createRuntime,
+      });
+
+    });

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/background/dataset-store.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/background/dataset-store.js
@@ -1,0 +1,496 @@
+'use strict';
+/* global require */
+
+(function publishFirefoxDatasetStore(root, factory) {
+
+  const dataset = typeof module === 'object' && module.exports ?
+    require('../../extension-mv3-common/provider-dataset') :
+    root.mv3ProviderDataset;
+  const datasetState = typeof module === 'object' && module.exports ?
+    require('../../extension-mv3-common/provider-dataset-state') :
+    root.mv3ProviderDatasetState;
+  const api = factory(dataset, datasetState);
+  if (typeof module === 'object' && module.exports) {
+    module.exports = api;
+    return;
+  }
+  root.rucbFirefoxDatasetStore = api;
+
+})(typeof globalThis === 'object' ? globalThis : this,
+    function(Dataset, DatasetState) {
+
+      const DATABASE_NAME = 'rucb-firefox-provider-datasets-v1';
+      const DATABASE_VERSION = 1;
+      const POINTER_SCHEMA_VERSION = 1;
+      const ARTIFACT_STORE = 'artifacts';
+      const POINTER_STORE = 'providerPointers';
+      const SHA256_PATTERN = /^[a-f0-9]{64}$/;
+      const PROVIDER_KEY_PATTERN =
+        /^[a-z0-9](?:[a-z0-9._-]{0,63})$/;
+      const POINTER_FIELDS = Object.freeze([
+        'activeArtifactSha256',
+        'packagedBaselineArtifactSha256',
+        'previousLkgArtifactSha256',
+      ]);
+      const POINTER_RECORD_FIELDS = Object.freeze([
+        'activeArtifactSha256',
+        'packagedBaselineArtifactSha256',
+        'previousLkgArtifactSha256',
+        'providerKey',
+        'schemaVersion',
+      ]);
+      const ARTIFACT_RECORD_FIELDS = Object.freeze([
+        'artifactBytes',
+        'artifactSha256',
+        'envelope',
+        'providerKey',
+        'trust',
+      ]);
+
+      function storeError(code) {
+
+        const error = new TypeError(code);
+        error.code = code;
+        return error;
+
+      }
+
+      function rejection(code) {
+
+        return Object.freeze({
+          ok: false,
+          status: 'REJECTED',
+          code,
+        });
+
+      }
+
+      function isProviderKey(value) {
+
+        return typeof value === 'string' && PROVIDER_KEY_PATTERN.test(value);
+
+      }
+
+      function isSha256(value) {
+
+        return typeof value === 'string' && SHA256_PATTERN.test(value);
+
+      }
+
+      function emptyPointers(providerKey) {
+
+        if (!isProviderKey(providerKey)) {
+          throw storeError('INVALID_PROVIDER_KEY');
+        }
+        return {
+          schemaVersion: POINTER_SCHEMA_VERSION,
+          providerKey,
+          activeArtifactSha256: null,
+          previousLkgArtifactSha256: null,
+          packagedBaselineArtifactSha256: null,
+        };
+
+      }
+
+      function normalizePointers(value, providerKey) {
+
+        const normalized = emptyPointers(providerKey);
+        const corruptions = {};
+        if (!value || typeof value !== 'object' || Array.isArray(value) ||
+            Object.keys(value).length !== POINTER_RECORD_FIELDS.length ||
+            Object.keys(value).some((key) =>
+              !POINTER_RECORD_FIELDS.includes(key)) ||
+            value.schemaVersion !== POINTER_SCHEMA_VERSION ||
+            value.providerKey !== providerKey) {
+          POINTER_FIELDS.forEach((field) => {
+            corruptions[field] = value !== null && value !== undefined;
+          });
+          return {pointers: normalized, corruptions};
+        }
+        for (const field of POINTER_FIELDS) {
+          const pointer = value[field];
+          if (pointer === null || pointer === undefined) {
+            normalized[field] = null;
+          } else if (isSha256(pointer)) {
+            normalized[field] = pointer;
+          } else {
+            corruptions[field] = true;
+          }
+        }
+        return {pointers: normalized, corruptions};
+
+      }
+
+      function copyBytes(value) {
+
+        let source;
+        if (value instanceof Uint8Array) {
+          source = value;
+        } else if (value instanceof ArrayBuffer) {
+          source = new Uint8Array(value);
+        } else {
+          throw storeError('UNSUPPORTED_ARTIFACT_BYTES');
+        }
+        const copy = new Uint8Array(source.byteLength);
+        copy.set(source);
+        return copy;
+
+      }
+
+      function artifactRecord(verification, artifactBytes) {
+
+        const identity = verification.dataset.identity;
+        return {
+          artifactSha256: identity.artifactSha256,
+          providerKey: identity.providerKey,
+          trust: verification.trust,
+          envelope: verification.dataset.envelope,
+          artifactBytes: copyBytes(artifactBytes),
+        };
+
+      }
+
+      function sameBytes(leftValue, rightValue) {
+
+        const left = copyBytes(leftValue);
+        const right = copyBytes(rightValue);
+        if (left.byteLength !== right.byteLength) {
+          return false;
+        }
+        for (let index = 0; index < left.byteLength; index += 1) {
+          if (left[index] !== right[index]) {
+            return false;
+          }
+        }
+        return true;
+
+      }
+
+      function sameArtifact(left, right) {
+
+        return Boolean(
+            left && right &&
+            left.artifactSha256 === right.artifactSha256 &&
+            left.providerKey === right.providerKey &&
+            left.trust === right.trust &&
+            JSON.stringify(left.envelope) === JSON.stringify(right.envelope) &&
+            sameBytes(left.artifactBytes, right.artifactBytes),
+        );
+
+      }
+
+      function createIndexedDbBackend(indexedDb, options = {}) {
+
+        if (!indexedDb || typeof indexedDb.open !== 'function') {
+          throw storeError('INDEXED_DB_UNAVAILABLE');
+        }
+        const databaseName = options.databaseName || DATABASE_NAME;
+        let databasePromise;
+
+        function openDatabase() {
+
+          if (!databasePromise) {
+            databasePromise = new Promise((resolve, reject) => {
+              const request = indexedDb.open(databaseName, DATABASE_VERSION);
+              request.onupgradeneeded = () => {
+                const database = request.result;
+                if (!database.objectStoreNames.contains(ARTIFACT_STORE)) {
+                  database.createObjectStore(ARTIFACT_STORE, {
+                    keyPath: 'artifactSha256',
+                  });
+                }
+                if (!database.objectStoreNames.contains(POINTER_STORE)) {
+                  database.createObjectStore(POINTER_STORE, {
+                    keyPath: 'providerKey',
+                  });
+                }
+              };
+              request.onsuccess = () => resolve(request.result);
+              request.onerror = () => reject(
+                  request.error || storeError('INDEXED_DB_OPEN_FAILED'),
+              );
+              request.onblocked = () => reject(
+                  storeError('INDEXED_DB_OPEN_BLOCKED'),
+              );
+            });
+          }
+          return databasePromise;
+
+        }
+
+        async function read(storeName, key) {
+
+          const database = await openDatabase();
+          return new Promise((resolve, reject) => {
+            const transaction = database.transaction(storeName, 'readonly');
+            const request = transaction.objectStore(storeName).get(key);
+            request.onsuccess = () => resolve(request.result || null);
+            request.onerror = () => reject(
+                request.error || storeError('INDEXED_DB_READ_FAILED'),
+            );
+            transaction.onabort = () => reject(
+                transaction.error || storeError('INDEXED_DB_READ_ABORTED'),
+            );
+          });
+
+        }
+
+        async function commit(nextArtifact, nextPointers) {
+
+          const database = await openDatabase();
+          return new Promise((resolve, reject) => {
+            const transaction = database.transaction(
+                [ARTIFACT_STORE, POINTER_STORE],
+                'readwrite',
+            );
+            const artifacts = transaction.objectStore(ARTIFACT_STORE);
+            const pointers = transaction.objectStore(POINTER_STORE);
+            let failure = null;
+            const existingRequest = artifacts.get(
+                nextArtifact.artifactSha256,
+            );
+            existingRequest.onsuccess = () => {
+              try {
+                const existing = existingRequest.result;
+                if (existing && !sameArtifact(existing, nextArtifact)) {
+                  failure = storeError('IMMUTABLE_ARTIFACT_CONFLICT');
+                  transaction.abort();
+                  return;
+                }
+                if (!existing) {
+                  artifacts.add(nextArtifact);
+                }
+                pointers.put(nextPointers);
+              } catch (error) {
+                failure = error;
+                transaction.abort();
+              }
+            };
+            existingRequest.onerror = () => {
+              failure = existingRequest.error ||
+                storeError('INDEXED_DB_READ_FAILED');
+              transaction.abort();
+            };
+            transaction.oncomplete = () => resolve();
+            transaction.onerror = () => {};
+            transaction.onabort = () => reject(
+                failure || transaction.error ||
+                storeError('INDEXED_DB_COMMIT_ABORTED'),
+            );
+          });
+
+        }
+
+        return Object.freeze({
+          commit,
+          readArtifact(artifactSha256) {
+
+            return read(ARTIFACT_STORE, artifactSha256);
+
+          },
+          readPointers(providerKey) {
+
+            return read(POINTER_STORE, providerKey);
+
+          },
+        });
+
+      }
+
+      function createStore({backend, sha256} = {}) {
+
+        if (!backend || typeof backend.readArtifact !== 'function' ||
+            typeof backend.readPointers !== 'function' ||
+            typeof backend.commit !== 'function') {
+          throw storeError('INVALID_DATASET_STORE_BACKEND');
+        }
+        if (typeof sha256 !== 'function') {
+          throw storeError('SHA256_IMPLEMENTATION_REQUIRED');
+        }
+
+        async function verifyInput(input) {
+
+          return Dataset.verifyProviderDataset(Object.assign({}, input, {
+            sha256,
+          }));
+
+        }
+
+        async function readPointerState(providerKey) {
+
+          try {
+            return normalizePointers(
+                await backend.readPointers(providerKey),
+                providerKey,
+            );
+          } catch (_error) {
+            const normalized = normalizePointers(null, providerKey);
+            POINTER_FIELDS.forEach((field) => {
+              normalized.corruptions[field] = true;
+            });
+            return normalized;
+          }
+
+        }
+
+        async function verifyStored(providerKey, artifactSha256, code) {
+
+          if (!artifactSha256) {
+            return null;
+          }
+          let record;
+          try {
+            record = await backend.readArtifact(artifactSha256);
+          } catch (_error) {
+            return rejection(`${code}_UNREADABLE`);
+          }
+          if (!record) {
+            return rejection(`${code}_MISSING`);
+          }
+          try {
+            if (!record || typeof record !== 'object' ||
+                Array.isArray(record) ||
+                Object.keys(record).length !== ARTIFACT_RECORD_FIELDS.length ||
+                Object.keys(record).some((key) =>
+                  !ARTIFACT_RECORD_FIELDS.includes(key)) ||
+                record.providerKey !== providerKey ||
+                record.artifactSha256 !== artifactSha256 ||
+                !record.envelope ||
+                record.envelope.providerKey !== providerKey ||
+                record.envelope.artifactSha256 !== artifactSha256) {
+              return rejection(`${code}_IDENTITY_MISMATCH`);
+            }
+            return verifyInput({
+              envelope: record.envelope,
+              artifactBytes: copyBytes(record.artifactBytes),
+              trust: record.trust,
+            });
+          } catch (_error) {
+            return rejection(`${code}_MALFORMED`);
+          }
+
+        }
+
+        async function loadVerifications(providerKey, options = {}) {
+
+          if (!isProviderKey(providerKey)) {
+            throw storeError('INVALID_PROVIDER_KEY');
+          }
+          const pointerState = await readPointerState(providerKey);
+          const roles = [
+            ['active', 'activeArtifactSha256', 'ACTIVE_ARTIFACT'],
+            ['previousLkg', 'previousLkgArtifactSha256', 'LKG_ARTIFACT'],
+            [
+              'packagedBaseline',
+              'packagedBaselineArtifactSha256',
+              'PACKAGED_BASELINE_ARTIFACT',
+            ],
+          ];
+          const result = {pointers: pointerState.pointers};
+          for (const [role, field, code] of roles) {
+            if (pointerState.corruptions[field]) {
+              result[role] = rejection(`${code}_POINTER_CORRUPT`);
+            } else {
+              result[role] = await verifyStored(
+                  providerKey,
+                  pointerState.pointers[field],
+                  code,
+              );
+            }
+            if (options.firstUsableOnly === true &&
+                result[role] && result[role].ok === true) {
+              break;
+            }
+          }
+          roles.forEach(([role]) => {
+            if (!Object.prototype.hasOwnProperty.call(result, role)) {
+              result[role] = null;
+            }
+          });
+          return result;
+
+        }
+
+        async function commitPackagedBaseline(input) {
+
+          const verification = await verifyInput(input);
+          if (!verification.ok ||
+              verification.trust !== Dataset.TRUST.PACKAGED_TRUSTED) {
+            return verification.ok ?
+              rejection('PACKAGED_BASELINE_TRUST_REQUIRED') : verification;
+          }
+          const providerKey = verification.dataset.identity.providerKey;
+          const current = await readPointerState(providerKey);
+          const pointers = current.pointers;
+          pointers.packagedBaselineArtifactSha256 =
+            verification.dataset.identity.artifactSha256;
+          await backend.commit(
+              artifactRecord(verification, input.artifactBytes),
+              pointers,
+          );
+          return verification;
+
+        }
+
+        async function activateCandidate(input) {
+
+          const candidate = await verifyInput(input);
+          const providerKey = input && input.envelope &&
+            input.envelope.providerKey;
+          if (!isProviderKey(providerKey)) {
+            return candidate.ok ? rejection('INVALID_PROVIDER_KEY') : candidate;
+          }
+          const stored = await loadVerifications(providerKey);
+          const plan = DatasetState.planDatasetActivation({
+            protectionIntended: true,
+            providerKey,
+            active: stored.active,
+            previousLkg: stored.previousLkg,
+            packagedBaseline: stored.packagedBaseline,
+            candidate,
+          });
+          if (plan.kind !== DatasetState.ACTIONS.ACTIVATE_CANDIDATE) {
+            return Object.freeze({verification: candidate, plan});
+          }
+          if (candidate.trust !== Dataset.TRUST.REMOTE_AUTHENTICATED) {
+            return Object.freeze({
+              verification: candidate,
+              plan: {
+                kind: DatasetState.ACTIONS.KEEP_ACTIVE,
+                selected: plan.previousLkg || null,
+                candidateRejection: 'AUTHENTICATED_CANDIDATE_REQUIRED',
+              },
+            });
+          }
+          const pointers = stored.pointers;
+          pointers.previousLkgArtifactSha256 = plan.previousLkg ?
+            plan.previousLkg.artifactSha256 : null;
+          pointers.activeArtifactSha256 =
+            candidate.dataset.identity.artifactSha256;
+          await backend.commit(
+              artifactRecord(candidate, input.artifactBytes),
+              pointers,
+          );
+          return Object.freeze({verification: candidate, plan});
+
+        }
+
+        return Object.freeze({
+          activateCandidate,
+          commitPackagedBaseline,
+          loadVerifications,
+        });
+
+      }
+
+      return Object.freeze({
+        DATABASE_NAME,
+        DATABASE_VERSION,
+        POINTER_SCHEMA_VERSION,
+        createIndexedDbBackend,
+        createStore,
+        emptyPointers,
+        normalizePointers,
+      });
+
+    });

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/background/event-page.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/background/event-page.js
@@ -4,10 +4,14 @@
 
   const offState = root.rucbFirefoxOffState;
   const routing = root.rucbFirefoxRoutingAdapter;
-  const routingAdapter = routing.createAdapter({
-    initialState: routing.STATES.OFF,
+  const datasetRuntime = root.rucbFirefoxDatasetRuntime.createRuntime({
+    protectionIntended: false,
+    providerKey: 'anticensority',
   });
-  const runtimeState = routingAdapter.runtimeState;
+  const routingAdapter = routing.createAdapter({
+    runtimeStateForRequest: datasetRuntime.getState,
+    routingInputForRequest: datasetRuntime.routingInputForRequest,
+  });
   const durableIntent = offState.OFF;
   const bootId = root.crypto && typeof root.crypto.randomUUID === 'function' ?
     root.crypto.randomUUID() :
@@ -43,11 +47,12 @@
           browser: 'FIREFOX',
           manifestVersion: manifest.manifest_version,
           runtimeModel: 'BACKGROUND_EVENT_PAGE',
-          runtimeState,
+          runtimeState: routingAdapter.runtimeState,
           durableIntent,
           privateWindowAccess: await readPrivateWindowAccess(),
           routingImplemented: true,
           activationSupported: false,
+          providerDatasetImplemented: true,
           providerDatasetAvailable: false,
         },
       };
@@ -78,8 +83,12 @@
   );
   browser.runtime.onMessage.addListener(handleMessage);
 
-  const initialization = offState.initialize(browser.storage.local).catch(() =>
-    offState.normalizeDurableState(null));
+  const initialization = offState.initialize(browser.storage.local)
+      .catch(() => offState.normalizeDurableState(null))
+      .then(async (state) => {
+        await datasetRuntime.initialize();
+        return state;
+      });
 
   root.rucbFirefoxSkeletonRuntime = Object.freeze({
     bootId,

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/background/provider-lookup.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/background/provider-lookup.js
@@ -1,0 +1,142 @@
+'use strict';
+
+(function publishFirefoxProviderLookup(root, factory) {
+
+  const api = factory();
+  if (typeof module === 'object' && module.exports) {
+    module.exports = api;
+    return;
+  }
+  root.rucbFirefoxProviderLookup = api;
+
+})(typeof globalThis === 'object' ? globalThis : this, function() {
+
+  const KINDS = Object.freeze({
+    PROVIDER_PROXY: 'PROVIDER_PROXY',
+    PROVIDER_DIRECT: 'PROVIDER_DIRECT',
+    MISS: 'MISS',
+    FAILURE: 'FAILURE',
+  });
+
+  function lookupError(code) {
+
+    const error = new TypeError(code);
+    error.code = code;
+    return error;
+
+  }
+
+  function normalizeHostname(value) {
+
+    if (typeof value !== 'string') {
+      throw lookupError('INVALID_LOOKUP_HOSTNAME');
+    }
+    let hostname = value.trim().toLowerCase();
+    while (hostname.endsWith('.')) {
+      hostname = hostname.slice(0, -1);
+    }
+    if (hostname.startsWith('[') && hostname.endsWith(']')) {
+      hostname = hostname.slice(1, -1);
+    }
+    if (!hostname || hostname.length > 253 ||
+        /[/\\?#@]/.test(hostname) ||
+        Array.from(hostname).some((character) => character.charCodeAt(0) <= 32)) {
+      throw lookupError('INVALID_LOOKUP_HOSTNAME');
+    }
+    return hostname;
+
+  }
+
+  function fixedBucketContains(hosts, width, target) {
+
+    if (typeof hosts !== 'string' || !Number.isSafeInteger(width) ||
+        width < 1 || hosts.length % width !== 0 || target.length !== width) {
+      throw lookupError('MALFORMED_LOOKUP_INDEX');
+    }
+    let low = 0;
+    let high = hosts.length / width;
+    while (low < high) {
+      const middle = (low + high) >>> 1;
+      const candidate = hosts.slice(middle * width, (middle + 1) * width);
+      if (candidate < target) {
+        low = middle + 1;
+      } else {
+        high = middle;
+      }
+    }
+    return low < hosts.length / width &&
+      hosts.slice(low * width, (low + 1) * width) === target;
+
+  }
+
+  function buildLookup(verification) {
+
+    if (!verification || verification.ok !== true ||
+        verification.status !== 'VERIFIED' ||
+        !verification.dataset || !verification.dataset.payload ||
+        verification.dataset.payload.format !== 'HOST_BUCKETS_V1' ||
+        !Array.isArray(verification.dataset.payload.buckets)) {
+      throw lookupError('INVALID_VERIFIED_DATASET');
+    }
+    const byWidth = new Map();
+    for (const bucket of verification.dataset.payload.buckets) {
+      if (!bucket || !Number.isSafeInteger(bucket.width) ||
+          bucket.width < 1 || typeof bucket.hosts !== 'string' ||
+          !bucket.hosts.length ||
+          bucket.hosts.length % bucket.width !== 0 ||
+          ![KINDS.PROVIDER_PROXY, KINDS.PROVIDER_DIRECT].includes(
+              bucket.routeRef,
+          )) {
+        throw lookupError('MALFORMED_LOOKUP_INDEX');
+      }
+      const entries = byWidth.get(bucket.width) || [];
+      entries.push(Object.freeze({
+        width: bucket.width,
+        routeRef: bucket.routeRef,
+        hosts: bucket.hosts,
+      }));
+      byWidth.set(bucket.width, entries);
+    }
+
+    function lookup(rawHostname) {
+
+      try {
+        let hostname = normalizeHostname(rawHostname);
+        while (hostname && hostname.includes('.')) {
+          const buckets = byWidth.get(hostname.length) || [];
+          for (const bucket of buckets) {
+            if (fixedBucketContains(
+                bucket.hosts,
+                bucket.width,
+                hostname,
+            )) {
+              return Object.freeze({kind: bucket.routeRef});
+            }
+          }
+          hostname = hostname.slice(hostname.indexOf('.') + 1);
+        }
+        return Object.freeze({kind: KINDS.MISS});
+      } catch (error) {
+        return Object.freeze({
+          kind: KINDS.FAILURE,
+          code: error && error.code ? error.code : 'PROVIDER_LOOKUP_FAILED',
+        });
+      }
+
+    }
+
+    return Object.freeze({
+      bucketCount: verification.dataset.payload.buckets.length,
+      lookup,
+    });
+
+  }
+
+  return Object.freeze({
+    KINDS,
+    buildLookup,
+    fixedBucketContains,
+    normalizeHostname,
+  });
+
+});

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/background/routing-adapter.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/background/routing-adapter.js
@@ -126,13 +126,25 @@
 
   function createAdapter(options = {}) {
 
-    const runtimeState = options.initialState || STATES.OFF;
-    if (!Object.values(STATES).includes(runtimeState)) {
+    const initialState = options.initialState || STATES.OFF;
+    if (!Object.values(STATES).includes(initialState)) {
       throw new TypeError('INVALID_FIREFOX_RUNTIME_STATE');
     }
+    const runtimeStateForRequest = options.runtimeStateForRequest ||
+      (() => initialState);
     const decideRoute = options.decideRoute || Routing.decideRoute;
     const routingInputForRequest = options.routingInputForRequest;
     let authorizations = options.authorizations || new Map();
+
+    function currentRuntimeState() {
+
+      const runtimeState = runtimeStateForRequest();
+      if (!Object.values(STATES).includes(runtimeState)) {
+        throw new TypeError('INVALID_FIREFOX_RUNTIME_STATE');
+      }
+      return runtimeState;
+
+    }
 
     function resetAuthorizations() {
 
@@ -173,16 +185,17 @@
 
     function onProxyRequest(details) {
 
-      if (runtimeState === STATES.OFF) {
-        return undefined;
-      }
       const requestId = details && details.requestId;
-      clearAuthorization(requestId);
-      if (runtimeState !== STATES.READY ||
-          typeof routingInputForRequest !== 'function') {
-        return DIRECT;
-      }
       try {
+        const runtimeState = currentRuntimeState();
+        if (runtimeState === STATES.OFF) {
+          return undefined;
+        }
+        clearAuthorization(requestId);
+        if (runtimeState !== STATES.READY ||
+            typeof routingInputForRequest !== 'function') {
+          return DIRECT;
+        }
         const decision = decideRoute(routingInputForRequest(details));
         const converted = convertDecision(decision);
         if (!converted ||
@@ -201,6 +214,7 @@
     function onBeforeRequest(details) {
 
       try {
+        const runtimeState = currentRuntimeState();
         if (runtimeState === STATES.OFF) {
           return ALLOW;
         }
@@ -244,13 +258,18 @@
 
     }
 
-    return Object.freeze({
+    const api = {
       authorizationCount,
+      currentRuntimeState,
       onBeforeRequest,
       onProxyRequest,
       onRequestTerminal,
-      runtimeState,
+    };
+    Object.defineProperty(api, 'runtimeState', {
+      enumerable: true,
+      get: currentRuntimeState,
     });
+    return Object.freeze(api);
 
   }
 

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/manifest.json
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/manifest.json
@@ -15,7 +15,12 @@
   "background": {
     "scripts": [
       "background/common/routing-contract.js",
+      "background/common/provider-dataset.js",
+      "background/common/provider-dataset-state.js",
       "background/off-state.js",
+      "background/dataset-store.js",
+      "background/provider-lookup.js",
+      "background/dataset-runtime.js",
       "background/routing-adapter.js",
       "background/event-page.js"
     ],

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/dataset-runtime.test.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/dataset-runtime.test.js
@@ -1,0 +1,499 @@
+'use strict';
+
+const Assert = require('node:assert');
+const Routing = require('../../extension-mv3-common/routing-contract');
+const Adapter = require('../background/routing-adapter');
+const Runtime = require('../background/dataset-runtime');
+const Store = require('../background/dataset-store');
+const {
+  Dataset,
+  PROVIDER_KEY,
+  artifact,
+  memoryBackend,
+  payload,
+  sha256,
+} = require('./dataset-test-helpers');
+
+function candidate(id, port = 8080) {
+
+  return {
+    id,
+    type: 'HTTP',
+    host: '127.0.0.1',
+    port,
+    proxyDNS: false,
+    authRef: null,
+    failoverTimeoutSeconds: null,
+  };
+
+}
+
+function routingPayload() {
+
+  return payload([
+    {
+      width: 10,
+      routeRef: 'PROVIDER_DIRECT',
+      hosts: 'alpha.test',
+    },
+    {
+      width: 10,
+      routeRef: 'PROVIDER_PROXY',
+      hosts: 'proxy.test',
+    },
+  ]);
+
+}
+
+function createStoredRuntime(options = {}) {
+
+  const backend = options.backend || memoryBackend();
+  const store = Store.createStore({backend, sha256});
+  const runtime = Runtime.createRuntime({
+    protectionIntended: options.protectionIntended !== false,
+    providerKey: options.providerKey || PROVIDER_KEY,
+    store,
+    buildLookup: options.buildLookup,
+    baseInputForRequest: options.baseInputForRequest || (() => ({
+      providerCandidates: [candidate('provider')],
+    })),
+  });
+  return {backend, runtime, store};
+
+}
+
+function adapterForRuntime(runtime) {
+
+  return Adapter.createAdapter({
+    runtimeStateForRequest: runtime.getState,
+    routingInputForRequest: runtime.routingInputForRequest,
+  });
+
+}
+
+describe('Firefox declarative dataset runtime', function() {
+
+  it('does not read dataset storage while durable protection is OFF',
+      async function() {
+
+        let reads = 0;
+        const runtime = Runtime.createRuntime({
+          protectionIntended: false,
+          providerKey: PROVIDER_KEY,
+          store: {
+            async loadVerifications() {
+
+              reads += 1;
+              throw new Error('must not run');
+
+            },
+          },
+        });
+
+        Assert.strictEqual(runtime.getState(), 'OFF');
+        Assert.deepStrictEqual(await runtime.initialize(), {
+          state: 'OFF',
+          failureCode: null,
+          selected: null,
+        });
+        Assert.strictEqual(reads, 0);
+
+      });
+
+  it('moves INITIALIZING to READY only after baseline verification and indexing',
+      async function() {
+
+        const {runtime, store} = createStoredRuntime();
+        await store.commitPackagedBaseline(artifact({payload: routingPayload()}));
+
+        Assert.strictEqual(runtime.getState(), 'INITIALIZING');
+        const initialized = await runtime.initialize();
+
+        Assert.strictEqual(initialized.state, 'READY');
+        Assert.strictEqual(initialized.selected.source, 'USE_PACKAGED_BASELINE');
+        Assert.strictEqual(runtime.getState(), 'READY');
+
+      });
+
+  it('keeps a cold request canceled while artifact loading is pending',
+      async function() {
+
+        let release;
+        const pending = new Promise((resolve) => {
+          release = resolve;
+        });
+        const runtime = Runtime.createRuntime({
+          protectionIntended: true,
+          providerKey: PROVIDER_KEY,
+          store: {loadVerifications: () => pending},
+        });
+        const adapter = adapterForRuntime(runtime);
+        const initialization = runtime.initialize();
+
+        Assert.strictEqual(runtime.getState(), 'INITIALIZING');
+        Assert.deepStrictEqual(adapter.onProxyRequest({requestId: 'cold'}), {
+          type: 'direct',
+        });
+        Assert.deepStrictEqual(adapter.onBeforeRequest({requestId: 'cold'}), {
+          cancel: true,
+        });
+        release({active: null, previousLkg: null, packagedBaseline: null});
+        Assert.strictEqual((await initialization).state, 'FAILED');
+
+      });
+
+  it('routes a provider match through the shared decision contract',
+      async function() {
+
+        const {runtime, store} = createStoredRuntime();
+        await store.commitPackagedBaseline(artifact({payload: routingPayload()}));
+        await runtime.initialize();
+        const adapter = adapterForRuntime(runtime);
+
+        Assert.deepStrictEqual(adapter.onProxyRequest({
+          requestId: 'provider-proxy',
+          url: 'http://proxy.test/path',
+        }), [
+          {type: 'http', host: '127.0.0.1', port: 8080},
+          {type: 'direct'},
+        ]);
+
+      });
+
+  it('routes provider Direct and legitimate provider miss explicitly',
+      async function() {
+
+        const {runtime, store} = createStoredRuntime();
+        await store.commitPackagedBaseline(artifact({payload: routingPayload()}));
+        await runtime.initialize();
+        const adapter = adapterForRuntime(runtime);
+
+        for (const [requestId, url] of [
+          ['provider-direct', 'http://alpha.test/'],
+          ['provider-miss', 'http://ordinary.test/'],
+        ]) {
+          Assert.deepStrictEqual(adapter.onProxyRequest({requestId, url}), {
+            type: 'direct',
+          });
+          Assert.deepStrictEqual(adapter.onBeforeRequest({requestId}), {
+            cancel: false,
+          });
+        }
+
+      });
+
+  it('preserves explicit Direct and Proxy precedence over provider data',
+      async function() {
+
+        const {runtime, store} = createStoredRuntime({
+          baseInputForRequest(details) {
+
+            return {
+              rules: {
+                direct: ['direct.override'],
+                proxy: ['proxy.test'],
+              },
+              candidateGroups: {
+                configured: {own: [candidate('explicit', 8181)]},
+              },
+              providerCandidates: [candidate('provider')],
+              hostname: new URL(details.url).hostname,
+            };
+
+          },
+        });
+        await store.commitPackagedBaseline(artifact({payload: routingPayload()}));
+        await runtime.initialize();
+        const adapter = adapterForRuntime(runtime);
+
+        Assert.deepStrictEqual(adapter.onProxyRequest({
+          requestId: 'direct-rule',
+          url: 'http://direct.override/',
+        }), {type: 'direct'});
+        Assert.deepStrictEqual(adapter.onProxyRequest({
+          requestId: 'proxy-rule',
+          url: 'http://proxy.test/',
+        }), [
+          {type: 'http', host: '127.0.0.1', port: 8181},
+          null,
+        ]);
+
+      });
+
+  it('preserves onion routing before provider policy', async function() {
+
+    const {runtime, store} = createStoredRuntime({
+      baseInputForRequest: () => ({
+        candidateGroups: {onion: {localTor: [candidate('tor', 9050)]}},
+        providerCandidates: [candidate('provider')],
+      }),
+    });
+    await store.commitPackagedBaseline(artifact({payload: routingPayload()}));
+    await runtime.initialize();
+    const decision = Routing.decideRoute(runtime.routingInputForRequest({
+      url: 'http://hidden.onion/',
+    }));
+
+    Assert.strictEqual(decision.source, Routing.SOURCES.ONION);
+    Assert.strictEqual(decision.fallback, Routing.FALLBACKS.FAIL_CLOSED);
+
+  });
+
+  it('applies noDirect only to provider/default Direct behavior',
+      async function() {
+
+        const {runtime, store} = createStoredRuntime({
+          baseInputForRequest: () => ({
+            flags: {noDirect: true},
+            providerCandidates: [candidate('provider')],
+          }),
+        });
+        await store.commitPackagedBaseline(artifact({payload: routingPayload()}));
+        await runtime.initialize();
+        const decision = Routing.decideRoute(runtime.routingInputForRequest({
+          url: 'http://ordinary.test/',
+        }));
+
+        Assert.strictEqual(decision.kind, Routing.KINDS.FAIL_CLOSED);
+
+      });
+
+  it('applies replaceDirectWithProxy through the shared routing core',
+      async function() {
+
+        const {runtime, store} = createStoredRuntime({
+          baseInputForRequest: () => ({
+            flags: {replaceDirectWithProxy: true},
+            candidateGroups: {
+              directReplacement: {warp: [candidate('replacement', 40000)]},
+            },
+            providerCandidates: [candidate('provider')],
+          }),
+        });
+        await store.commitPackagedBaseline(artifact({payload: routingPayload()}));
+        await runtime.initialize();
+        const decision = Routing.decideRoute(runtime.routingInputForRequest({
+          url: 'http://alpha.test/',
+        }));
+
+        Assert.strictEqual(decision.kind, Routing.KINDS.PROXY);
+        Assert.strictEqual(decision.candidates[0].id, 'replacement');
+        Assert.strictEqual(decision.fallback, Routing.FALLBACKS.FAIL_CLOSED);
+
+      });
+
+  it('broadens configured candidates only when own-sites-only is false',
+      async function() {
+
+        for (const expectedCount of [1, 2]) {
+          const broad = expectedCount === 2;
+          const {runtime, store} = createStoredRuntime({
+            baseInputForRequest: () => ({
+              flags: {ownProxiesOnlyForOwnSites: !broad},
+              candidateGroups: {
+                configured: {own: [candidate('own', 8181)]},
+              },
+              providerCandidates: [candidate('provider')],
+            }),
+          });
+          await store.commitPackagedBaseline(artifact({
+            payload: routingPayload(),
+          }));
+          await runtime.initialize();
+          const decision = Routing.decideRoute(runtime.routingInputForRequest({
+            url: 'http://proxy.test/',
+          }));
+          Assert.strictEqual(decision.candidates.length, expectedCount);
+        }
+
+      });
+
+  it('falls back from corrupt active bytes to a verified previous LKG',
+      async function() {
+
+        const {backend, runtime, store} = createStoredRuntime();
+        const previous = artifact({
+          payload: payload([{
+            width: 13,
+            routeRef: 'PROVIDER_PROXY',
+            hosts: 'previous.test',
+          }]),
+          datasetVersion: 'previous',
+          trust: Dataset.TRUST.REMOTE_AUTHENTICATED,
+        });
+        const active = artifact({
+          payload: routingPayload(),
+          datasetVersion: 'active',
+          trust: Dataset.TRUST.REMOTE_AUTHENTICATED,
+        });
+        await store.activateCandidate(previous);
+        await store.activateCandidate(active);
+        backend.artifacts.get(active.envelope.artifactSha256)
+            .artifactBytes[0] ^= 1;
+
+        const initialized = await runtime.initialize();
+
+        Assert.strictEqual(initialized.state, 'READY');
+        Assert.strictEqual(initialized.selected.datasetVersion, 'previous');
+        Assert.strictEqual(initialized.selected.source, 'USE_PREVIOUS_LKG');
+
+      });
+
+  it('falls back from corrupt active and LKG to packaged baseline',
+      async function() {
+
+        const {backend, runtime, store} = createStoredRuntime();
+        const baseline = artifact({
+          payload: payload([{
+            width: 13,
+            routeRef: 'PROVIDER_PROXY',
+            hosts: 'baseline.test',
+          }]),
+          datasetVersion: 'baseline',
+        });
+        const previous = artifact({
+          payload: payload([{
+            width: 13,
+            routeRef: 'PROVIDER_PROXY',
+            hosts: 'previous.test',
+          }]),
+          datasetVersion: 'previous',
+          trust: Dataset.TRUST.REMOTE_AUTHENTICATED,
+        });
+        const active = artifact({
+          payload: payload([{
+            width: 12,
+            routeRef: 'PROVIDER_PROXY',
+            hosts: 'current.test',
+          }]),
+          datasetVersion: 'active',
+          trust: Dataset.TRUST.REMOTE_AUTHENTICATED,
+        });
+        await store.commitPackagedBaseline(baseline);
+        await store.activateCandidate(previous);
+        await store.activateCandidate(active);
+        backend.artifacts.get(active.envelope.artifactSha256)
+            .artifactBytes[0] ^= 1;
+        backend.artifacts.get(previous.envelope.artifactSha256)
+            .artifactBytes[0] ^= 1;
+
+        const initialized = await runtime.initialize();
+
+        Assert.strictEqual(initialized.state, 'READY');
+        Assert.strictEqual(initialized.selected.datasetVersion, 'baseline');
+        Assert.strictEqual(
+            initialized.selected.source,
+            'USE_PACKAGED_BASELINE',
+        );
+
+      });
+
+  it('enters FAILED when no verified artifact is usable', async function() {
+
+    const {runtime} = createStoredRuntime();
+    const adapter = adapterForRuntime(runtime);
+    const initialized = await runtime.initialize();
+
+    Assert.deepStrictEqual(initialized, {
+      state: 'FAILED',
+      failureCode: 'NO_USABLE_PROVIDER_DATASET',
+      selected: null,
+    });
+    Assert.deepStrictEqual(adapter.onBeforeRequest({requestId: 'failed'}), {
+      cancel: true,
+    });
+
+  });
+
+  it('enters FAILED when index construction throws', async function() {
+
+    const {runtime, store} = createStoredRuntime({
+      buildLookup() {
+
+        throw new Error('injected index failure');
+
+      },
+    });
+    await store.commitPackagedBaseline(artifact({payload: routingPayload()}));
+    const initialized = await runtime.initialize();
+
+    Assert.strictEqual(initialized.state, 'FAILED');
+    Assert.strictEqual(
+        initialized.failureCode,
+        'DATASET_INITIALIZATION_FAILED',
+    );
+
+  });
+
+  it('maps a lookup exception to provider FAIL_CLOSED, never MISS',
+      async function() {
+
+        const {runtime, store} = createStoredRuntime({
+          buildLookup: () => ({
+            lookup() {
+
+              throw new Error('injected lookup failure');
+
+            },
+          }),
+        });
+        await store.commitPackagedBaseline(artifact({payload: routingPayload()}));
+        await runtime.initialize();
+        const decision = Routing.decideRoute(runtime.routingInputForRequest({
+          url: 'http://ordinary.test/',
+        }));
+
+        Assert.deepStrictEqual(decision, {
+          kind: 'FAIL_CLOSED',
+          source: 'PROVIDER_DATASET',
+          code: 'PROVIDER_LOOKUP_FAILED',
+        });
+
+      });
+
+  it('maps an unexpected lookup marker to FAIL_CLOSED, never Direct',
+      async function() {
+
+        const {runtime, store} = createStoredRuntime({
+          buildLookup: () => ({lookup: () => ({kind: 'UNKNOWN'})}),
+        });
+        await store.commitPackagedBaseline(artifact({payload: routingPayload()}));
+        await runtime.initialize();
+        const decision = Routing.decideRoute(runtime.routingInputForRequest({
+          url: 'http://ordinary.test/',
+        }));
+
+        Assert.strictEqual(decision.kind, Routing.KINDS.FAIL_CLOSED);
+        Assert.strictEqual(decision.code, 'INVALID_PROVIDER_LOOKUP_RESULT');
+
+      });
+
+  it('starts recreated runtime and authorization state from empty memory',
+      async function() {
+
+        const backend = memoryBackend();
+        const first = createStoredRuntime({backend});
+        await first.store.commitPackagedBaseline(artifact({
+          payload: routingPayload(),
+        }));
+        await first.runtime.initialize();
+        const firstAdapter = adapterForRuntime(first.runtime);
+        firstAdapter.onProxyRequest({
+          requestId: 'old-request',
+          url: 'http://alpha.test/',
+        });
+
+        const recreated = createStoredRuntime({backend});
+        const recreatedAdapter = adapterForRuntime(recreated.runtime);
+
+        Assert.strictEqual(recreated.runtime.getState(), 'INITIALIZING');
+        Assert.strictEqual(recreatedAdapter.authorizationCount(), 0);
+        Assert.deepStrictEqual(
+            recreatedAdapter.onBeforeRequest({requestId: 'old-request'}),
+            {cancel: true},
+        );
+        Assert.strictEqual((await recreated.runtime.initialize()).state, 'READY');
+
+      });
+
+});

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/dataset-store.test.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/dataset-store.test.js
@@ -1,0 +1,349 @@
+'use strict';
+
+const Assert = require('node:assert');
+const Store = require('../background/dataset-store');
+const {
+  Dataset,
+  PROVIDER_KEY,
+  artifact,
+  memoryBackend,
+  payload,
+  sha256,
+} = require('./dataset-test-helpers');
+
+function makeStore(backend = memoryBackend()) {
+
+  return {backend, store: Store.createStore({backend, sha256})};
+
+}
+
+describe('Firefox immutable provider dataset store', function() {
+
+  const invalidArtifactCases = [
+    {
+      name: 'malformed JSON',
+      create() {
+
+        const bytes = Buffer.from('{', 'utf8');
+        return artifact({
+          artifactBytes: bytes,
+          envelopeOverrides: {
+            artifactByteCount: bytes.byteLength,
+            artifactSha256: sha256(bytes),
+          },
+        });
+
+      },
+      code: 'MALFORMED_JSON',
+    },
+    {
+      name: 'unsupported schema',
+      create: () => artifact({envelopeOverrides: {schemaVersion: 2}}),
+      code: 'UNSUPPORTED_SCHEMA_VERSION',
+    },
+    {
+      name: 'rule-count mismatch',
+      create: () => artifact({envelopeOverrides: {ruleCount: 2}}),
+      code: 'RULE_COUNT_MISMATCH',
+    },
+  ];
+
+  for (const testCase of invalidArtifactCases) {
+    it(`keeps pointers unchanged for ${testCase.name}`, async function() {
+
+      const {backend, store} = makeStore();
+      const verification = await store.commitPackagedBaseline(
+          testCase.create(),
+      );
+
+      Assert.strictEqual(verification.ok, false);
+      Assert.strictEqual(verification.code, testCase.code);
+      Assert.strictEqual(backend.commits.length, 0);
+
+    });
+  }
+
+  it('stores and reloads a verified packaged baseline by exact SHA-256',
+      async function() {
+
+        const {backend, store} = makeStore();
+        const baseline = artifact();
+        const verification = await store.commitPackagedBaseline(baseline);
+        const loaded = await store.loadVerifications(PROVIDER_KEY);
+
+        Assert.strictEqual(verification.ok, true);
+        Assert.strictEqual(backend.commits.length, 1);
+        Assert.strictEqual(loaded.packagedBaseline.ok, true);
+        Assert.strictEqual(
+            loaded.packagedBaseline.dataset.identity.artifactSha256,
+            baseline.envelope.artifactSha256,
+        );
+        Assert.strictEqual(loaded.active, null);
+
+      });
+
+  it('stops cold reconstruction after the first usable artifact',
+      async function() {
+
+        const backend = memoryBackend();
+        const store = Store.createStore({backend, sha256});
+        const active = artifact({
+          datasetVersion: 'active',
+          trust: Dataset.TRUST.REMOTE_AUTHENTICATED,
+        });
+        await store.activateCandidate(active);
+        const pointers = backend.pointers.get(PROVIDER_KEY);
+        pointers.previousLkgArtifactSha256 = 'b'.repeat(64);
+        pointers.packagedBaselineArtifactSha256 = 'c'.repeat(64);
+        backend.pointers.set(PROVIDER_KEY, pointers);
+        const reads = [];
+        const originalRead = backend.readArtifact;
+        backend.readArtifact = async (artifactSha256) => {
+          reads.push(artifactSha256);
+          return originalRead.call(backend, artifactSha256);
+        };
+        const loaded = await store.loadVerifications(PROVIDER_KEY, {
+          firstUsableOnly: true,
+        });
+
+        Assert.strictEqual(loaded.active.ok, true);
+        Assert.strictEqual(loaded.previousLkg, null);
+        Assert.strictEqual(loaded.packagedBaseline, null);
+        Assert.deepStrictEqual(reads, [active.envelope.artifactSha256]);
+
+      });
+
+  it('does not move a pointer when packaged bytes fail verification',
+      async function() {
+
+        const {backend, store} = makeStore();
+        const invalid = artifact({
+          envelopeOverrides: {artifactSha256: '0'.repeat(64)},
+        });
+        const verification = await store.commitPackagedBaseline(invalid);
+
+        Assert.strictEqual(verification.ok, false);
+        Assert.strictEqual(verification.code, 'ARTIFACT_SHA256_MISMATCH');
+        Assert.strictEqual(backend.commits.length, 0);
+
+      });
+
+  it('does not move a pointer on an exact byte-count mismatch',
+      async function() {
+
+        const {backend, store} = makeStore();
+        const invalid = artifact({envelopeOverrides: {artifactByteCount: 1}});
+        const verification = await store.commitPackagedBaseline(invalid);
+
+        Assert.strictEqual(verification.ok, false);
+        Assert.strictEqual(
+            verification.code,
+            'ARTIFACT_BYTE_COUNT_MISMATCH',
+        );
+        Assert.strictEqual(backend.commits.length, 0);
+
+      });
+
+  it('rejects a non-packaged trust label for the baseline pointer',
+      async function() {
+
+        const {backend, store} = makeStore();
+        const verification = await store.commitPackagedBaseline(artifact({
+          trust: Dataset.TRUST.REMOTE_AUTHENTICATED,
+        }));
+
+        Assert.strictEqual(verification.ok, false);
+        Assert.strictEqual(
+            verification.code,
+            'PACKAGED_BASELINE_TRUST_REQUIRED',
+        );
+        Assert.strictEqual(backend.commits.length, 0);
+
+      });
+
+  it('atomically activates an authenticated candidate', async function() {
+
+    const {backend, store} = makeStore();
+    await store.commitPackagedBaseline(artifact());
+    const candidate = artifact({
+      datasetVersion: '2026.09.02-test.1',
+      trust: Dataset.TRUST.REMOTE_AUTHENTICATED,
+    });
+    const result = await store.activateCandidate(candidate);
+    const loaded = await store.loadVerifications(PROVIDER_KEY);
+
+    Assert.strictEqual(result.verification.ok, true);
+    Assert.strictEqual(result.plan.kind, 'ACTIVATE_CANDIDATE');
+    Assert.strictEqual(loaded.active.ok, true);
+    Assert.strictEqual(
+        loaded.pointers.activeArtifactSha256,
+        candidate.envelope.artifactSha256,
+    );
+    Assert.strictEqual(backend.commits.length, 2);
+
+  });
+
+  it('rotates only a verified active artifact into previous LKG',
+      async function() {
+
+        const {store} = makeStore();
+        const first = artifact({
+          datasetVersion: '2026.09.02-test.1',
+          trust: Dataset.TRUST.REMOTE_AUTHENTICATED,
+        });
+        const second = artifact({
+          payload: payload([{
+            width: 12,
+            routeRef: 'PROVIDER_PROXY',
+            hosts: 'next.example',
+          }]),
+          datasetVersion: '2026.09.03-test.1',
+          trust: Dataset.TRUST.REMOTE_AUTHENTICATED,
+        });
+        await store.activateCandidate(first);
+        await store.activateCandidate(second);
+        const loaded = await store.loadVerifications(PROVIDER_KEY);
+
+        Assert.strictEqual(loaded.active.dataset.identity.datasetVersion,
+            '2026.09.03-test.1');
+        Assert.strictEqual(loaded.previousLkg.dataset.identity.datasetVersion,
+            '2026.09.02-test.1');
+
+      });
+
+  it('never activates an unauthenticated remote candidate', async function() {
+
+    const {backend, store} = makeStore();
+    const baseline = artifact();
+    await store.commitPackagedBaseline(baseline);
+    const before = structuredClone(backend.pointers.get(PROVIDER_KEY));
+    const result = await store.activateCandidate(artifact({
+      datasetVersion: '2026.09.02-test.1',
+      trust: Dataset.TRUST.REMOTE_UNAUTHENTICATED,
+    }));
+
+    Assert.strictEqual(result.plan.kind, 'USE_PACKAGED_BASELINE');
+    Assert.strictEqual(
+        result.plan.candidateRejection,
+        'UNAUTHENTICATED_REMOTE_CANDIDATE',
+    );
+    Assert.deepStrictEqual(backend.pointers.get(PROVIDER_KEY), before);
+    Assert.strictEqual(backend.commits.length, 1);
+
+  });
+
+  it('reports a missing active artifact without converting it to a miss',
+      async function() {
+
+        const {backend, store} = makeStore();
+        backend.pointers.set(PROVIDER_KEY, Object.assign(
+            Store.emptyPointers(PROVIDER_KEY),
+            {activeArtifactSha256: 'a'.repeat(64)},
+        ));
+        const loaded = await store.loadVerifications(PROVIDER_KEY);
+
+        Assert.strictEqual(loaded.active.ok, false);
+        Assert.strictEqual(loaded.active.code, 'ACTIVE_ARTIFACT_MISSING');
+
+      });
+
+  it('reports an unreadable active artifact and preserves fallback selection',
+      async function() {
+
+        const backend = memoryBackend();
+        const baseline = artifact();
+        const store = Store.createStore({backend, sha256});
+        await store.commitPackagedBaseline(baseline);
+        const pointers = backend.pointers.get(PROVIDER_KEY);
+        pointers.activeArtifactSha256 = 'a'.repeat(64);
+        backend.pointers.set(PROVIDER_KEY, pointers);
+        const originalRead = backend.readArtifact;
+        backend.readArtifact = async (artifactSha256) => {
+          if (artifactSha256 === 'a'.repeat(64)) {
+            throw new Error('injected unreadable artifact');
+          }
+          return originalRead.call(backend, artifactSha256);
+        };
+        const loaded = await store.loadVerifications(PROVIDER_KEY);
+
+        Assert.strictEqual(loaded.active.code, 'ACTIVE_ARTIFACT_UNREADABLE');
+        Assert.strictEqual(loaded.packagedBaseline.ok, true);
+
+      });
+
+  it('preserves usable fallback fields when one pointer is corrupt',
+      async function() {
+
+        const {backend, store} = makeStore();
+        const baseline = artifact();
+        await store.commitPackagedBaseline(baseline);
+        const pointers = backend.pointers.get(PROVIDER_KEY);
+        pointers.activeArtifactSha256 = 'not-a-sha';
+        backend.pointers.set(PROVIDER_KEY, pointers);
+        const loaded = await store.loadVerifications(PROVIDER_KEY);
+
+        Assert.strictEqual(loaded.active.ok, false);
+        Assert.strictEqual(
+            loaded.active.code,
+            'ACTIVE_ARTIFACT_POINTER_CORRUPT',
+        );
+        Assert.strictEqual(loaded.packagedBaseline.ok, true);
+
+      });
+
+  it('treats unknown pointer metadata as corruption', async function() {
+
+    const {backend, store} = makeStore();
+    const pointers = Store.emptyPointers(PROVIDER_KEY);
+    pointers.extra = true;
+    backend.pointers.set(PROVIDER_KEY, pointers);
+    const loaded = await store.loadVerifications(PROVIDER_KEY);
+
+    Assert.strictEqual(loaded.active.ok, false);
+    Assert.strictEqual(
+        loaded.packagedBaseline.code,
+        'PACKAGED_BASELINE_ARTIFACT_POINTER_CORRUPT',
+    );
+
+  });
+
+  it('rejects stored artifact metadata that crosses provider identity',
+      async function() {
+
+        const {backend, store} = makeStore();
+        const baseline = artifact();
+        await store.commitPackagedBaseline(baseline);
+        const record = backend.artifacts.get(
+            baseline.envelope.artifactSha256,
+        );
+        record.providerKey = 'different-provider';
+        backend.artifacts.set(record.artifactSha256, record);
+        const loaded = await store.loadVerifications(PROVIDER_KEY);
+
+        Assert.strictEqual(loaded.packagedBaseline.ok, false);
+        Assert.strictEqual(
+            loaded.packagedBaseline.code,
+            'PACKAGED_BASELINE_ARTIFACT_IDENTITY_MISMATCH',
+        );
+
+      });
+
+  it('rejects stored bytes changed after pointer activation', async function() {
+
+    const {backend, store} = makeStore();
+    const baseline = artifact();
+    await store.commitPackagedBaseline(baseline);
+    const record = backend.artifacts.get(baseline.envelope.artifactSha256);
+    record.artifactBytes[0] ^= 1;
+    backend.artifacts.set(record.artifactSha256, record);
+    const loaded = await store.loadVerifications(PROVIDER_KEY);
+
+    Assert.strictEqual(loaded.packagedBaseline.ok, false);
+    Assert.strictEqual(
+        loaded.packagedBaseline.code,
+        'ARTIFACT_SHA256_MISMATCH',
+    );
+
+  });
+
+});

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/dataset-test-helpers.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/dataset-test-helpers.js
@@ -1,0 +1,112 @@
+'use strict';
+
+const Crypto = require('node:crypto');
+const Dataset = require('../../extension-mv3-common/provider-dataset');
+
+const PROVIDER_KEY = 'synthetic-provider';
+
+function sha256(bytes) {
+
+  return Crypto.createHash('sha256').update(bytes).digest('hex');
+
+}
+
+function countRules(payload) {
+
+  return payload.buckets.reduce((total, bucket) =>
+    total + bucket.hosts.length / bucket.width, 0);
+
+}
+
+function payload(buckets = null) {
+
+  return {
+    format: Dataset.PAYLOAD_FORMAT,
+    buckets: buckets || [{
+      width: 12,
+      routeRef: 'PROVIDER_PROXY',
+      hosts: 'beta.example',
+    }],
+  };
+
+}
+
+function artifact(options = {}) {
+
+  const artifactPayload = options.payload || payload();
+  const artifactBytes = options.artifactBytes ||
+    Buffer.from(JSON.stringify(artifactPayload), 'utf8');
+  return {
+    envelope: Object.assign({
+      schemaVersion: Dataset.SCHEMA_VERSION,
+      providerKey: options.providerKey || PROVIDER_KEY,
+      datasetVersion: options.datasetVersion || '2026.09.01-test.1',
+      generatedAt: '2026-09-01T00:00:00.000Z',
+      sourceRevisions: [{
+        sourceId: 'synthetic-source',
+        revision: 'fixture-only',
+      }],
+      ruleCount: countRules(artifactPayload),
+      artifactByteCount: artifactBytes.byteLength,
+      artifactSha256: sha256(artifactBytes),
+      routeTableVersion: Dataset.ROUTE_TABLE_VERSION,
+    }, options.envelopeOverrides),
+    artifactBytes,
+    trust: options.trust || Dataset.TRUST.PACKAGED_TRUSTED,
+  };
+
+}
+
+function copy(value) {
+
+  if (value === null || value === undefined) {
+    return value;
+  }
+  if (value instanceof Uint8Array) {
+    return new Uint8Array(value);
+  }
+  return structuredClone(value);
+
+}
+
+function memoryBackend() {
+
+  const artifacts = new Map();
+  const pointers = new Map();
+  const commits = [];
+  return {
+    artifacts,
+    pointers,
+    commits,
+    async readArtifact(artifactSha256) {
+
+      return copy(artifacts.get(artifactSha256) || null);
+
+    },
+    async readPointers(providerKey) {
+
+      return copy(pointers.get(providerKey) || null);
+
+    },
+    async commit(nextArtifact, nextPointers) {
+
+      artifacts.set(nextArtifact.artifactSha256, copy(nextArtifact));
+      pointers.set(nextPointers.providerKey, copy(nextPointers));
+      commits.push({
+        artifactSha256: nextArtifact.artifactSha256,
+        pointers: copy(nextPointers),
+      });
+
+    },
+  };
+
+}
+
+module.exports = Object.freeze({
+  Dataset,
+  PROVIDER_KEY,
+  artifact,
+  memoryBackend,
+  payload,
+  sha256,
+});

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/package.test.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/package.test.js
@@ -13,12 +13,12 @@ function makePackage() {
   const root = Fs.mkdtempSync(Path.join(Os.tmpdir(), 'firefox-skeleton-package-'));
   for (const relativePath of EXPECTED_FILES) {
     const target = Path.join(root, relativePath);
-    const source = relativePath === 'background/common/routing-contract.js' ?
+    const source = relativePath.startsWith('background/common/') ?
       Path.resolve(
           sourceRoot,
           '..',
           'extension-mv3-common',
-          'routing-contract.js',
+          Path.basename(relativePath),
       ) :
       Path.join(sourceRoot, relativePath);
     Fs.mkdirSync(Path.dirname(target), {recursive: true});
@@ -41,14 +41,15 @@ describe('Firefox MV3 package verifier', function() {
 
   });
 
-  it('accepts only the exact OFF-only routing package', function() {
+  it('accepts only the exact OFF-only dataset-capable routing package',
+      function() {
 
-    packageRoot = makePackage();
-    const result = verifyPackage(packageRoot, sourceRoot);
+        packageRoot = makePackage();
+        const result = verifyPackage(packageRoot, sourceRoot);
 
-    Assert.deepStrictEqual(result.files, [...EXPECTED_FILES]);
+        Assert.deepStrictEqual(result.files, [...EXPECTED_FILES]);
 
-  });
+      });
 
   it('rejects an unexpected packaged artifact', function() {
 
@@ -67,6 +68,19 @@ describe('Firefox MV3 package verifier', function() {
     manifest.permissions = manifest.permissions.filter((value) =>
       value !== 'webRequestBlocking');
     Fs.writeFileSync(manifestPath, JSON.stringify(manifest));
+
+    Assert.throws(() => verifyPackage(packageRoot, sourceRoot));
+
+  });
+
+  it('rejects a packaged provider artifact or synthetic fixture', function() {
+
+    packageRoot = makePackage();
+    Fs.mkdirSync(Path.join(packageRoot, 'provider'), {recursive: true});
+    Fs.writeFileSync(
+        Path.join(packageRoot, 'provider', 'synthetic-dataset.json'),
+        '{}',
+    );
 
     Assert.throws(() => verifyPackage(packageRoot, sourceRoot));
 

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/provider-lookup.test.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/provider-lookup.test.js
@@ -1,0 +1,208 @@
+'use strict';
+
+const Assert = require('node:assert');
+const Lookup = require('../background/provider-lookup');
+const {
+  Dataset,
+  artifact,
+  payload,
+  sha256,
+} = require('./dataset-test-helpers');
+
+async function build(buckets) {
+
+  const input = artifact({payload: payload(buckets)});
+  const verification = await Dataset.verifyProviderDataset(Object.assign(
+      {},
+      input,
+      {sha256},
+  ));
+  Assert.strictEqual(verification.ok, true, verification.code);
+  return Lookup.buildLookup(verification);
+
+}
+
+function fixedWidthHost(width) {
+
+  const labels = [];
+  let remaining = width;
+  while (remaining > 63) {
+    const labelLength = Math.min(63, remaining - 2);
+    labels.push('x'.repeat(labelLength));
+    remaining -= labelLength + 1;
+  }
+  labels.push('x'.repeat(remaining));
+  return labels.join('.');
+
+}
+
+describe('Firefox HOST_BUCKETS_V1 lookup', function() {
+
+  it('matches a base domain', async function() {
+
+    const lookup = await build([{
+      width: 12,
+      routeRef: 'PROVIDER_PROXY',
+      hosts: 'beta.example',
+    }]);
+
+    Assert.deepStrictEqual(lookup.lookup('beta.example'), {
+      kind: 'PROVIDER_PROXY',
+    });
+
+  });
+
+  it('matches the same rule as a subdomain suffix', async function() {
+
+    const lookup = await build([{
+      width: 12,
+      routeRef: 'PROVIDER_PROXY',
+      hosts: 'beta.example',
+    }]);
+
+    Assert.deepStrictEqual(lookup.lookup('deep.sub.beta.example'), {
+      kind: 'PROVIDER_PROXY',
+    });
+
+  });
+
+  it('does not confuse a label suffix with a domain suffix', async function() {
+
+    const lookup = await build([{
+      width: 12,
+      routeRef: 'PROVIDER_PROXY',
+      hosts: 'beta.example',
+    }]);
+
+    Assert.deepStrictEqual(lookup.lookup('notbeta.example'), {kind: 'MISS'});
+
+  });
+
+  it('returns the fixed route class attached to the matching bucket',
+      async function() {
+
+        const lookup = await build([
+          {
+            width: 10,
+            routeRef: 'PROVIDER_DIRECT',
+            hosts: 'alpha.test',
+          },
+          {
+            width: 10,
+            routeRef: 'PROVIDER_PROXY',
+            hosts: 'proxy.test',
+          },
+        ]);
+
+        Assert.deepStrictEqual(lookup.lookup('alpha.test'), {
+          kind: 'PROVIDER_DIRECT',
+        });
+        Assert.deepStrictEqual(lookup.lookup('proxy.test'), {
+          kind: 'PROVIDER_PROXY',
+        });
+
+      });
+
+  it('selects across different fixed widths without linear rule scans',
+      async function() {
+
+        const lookup = await build([
+          {width: 3, routeRef: 'PROVIDER_PROXY', hosts: 'a.b'},
+          {width: 13, routeRef: 'PROVIDER_DIRECT', hosts: 'alpha.example'},
+        ]);
+
+        Assert.deepStrictEqual(lookup.lookup('x.a.b'), {
+          kind: 'PROVIDER_PROXY',
+        });
+        Assert.deepStrictEqual(lookup.lookup('alpha.example'), {
+          kind: 'PROVIDER_DIRECT',
+        });
+
+      });
+
+  it('supports the longest schema-valid synthetic hostname width',
+      async function() {
+
+        const longest = fixedWidthHost(Dataset.LIMITS.MAX_HOST_LENGTH);
+        const lookup = await build([{
+          width: longest.length,
+          routeRef: 'PROVIDER_PROXY',
+          hosts: longest,
+        }]);
+
+        Assert.strictEqual(longest.length, 253);
+        Assert.deepStrictEqual(lookup.lookup(longest), {
+          kind: 'PROVIDER_PROXY',
+        });
+
+      });
+
+  it('preserves the provider comparator rule that a TLD-only suffix is not a match',
+      async function() {
+
+        const lookup = await build([{
+          width: 2,
+          routeRef: 'PROVIDER_PROXY',
+          hosts: 'ua',
+        }]);
+
+        Assert.deepStrictEqual(lookup.lookup('example.ua'), {kind: 'MISS'});
+
+      });
+
+  it('returns a legitimate MISS distinctly from lookup failure',
+      async function() {
+
+        const lookup = await build([{
+          width: 12,
+          routeRef: 'PROVIDER_PROXY',
+          hosts: 'beta.example',
+        }]);
+
+        Assert.deepStrictEqual(lookup.lookup('ordinary.example'), {
+          kind: 'MISS',
+        });
+        Assert.deepStrictEqual(lookup.lookup(null), {
+          kind: 'FAILURE',
+          code: 'INVALID_LOOKUP_HOSTNAME',
+        });
+        Assert.deepStrictEqual(lookup.lookup('bad/host'), {
+          kind: 'FAILURE',
+          code: 'INVALID_LOOKUP_HOSTNAME',
+        });
+
+      });
+
+  it('normalizes case and an absolute trailing dot', async function() {
+
+    const lookup = await build([{
+      width: 12,
+      routeRef: 'PROVIDER_PROXY',
+      hosts: 'beta.example',
+    }]);
+
+    Assert.deepStrictEqual(lookup.lookup('BETA.EXAMPLE.'), {
+      kind: 'PROVIDER_PROXY',
+    });
+
+  });
+
+  it('refuses an object that did not pass the common verifier', function() {
+
+    Assert.throws(
+        () => Lookup.buildLookup({ok: true, dataset: {payload: {}}}),
+        /INVALID_VERIFIED_DATASET/,
+    );
+
+  });
+
+  it('detects malformed fixed-width state instead of returning MISS', function() {
+
+    Assert.throws(
+        () => Lookup.fixedBucketContains('abc', 2, 'ab'),
+        /MALFORMED_LOOKUP_INDEX/,
+    );
+
+  });
+
+});

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/skeleton.test.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/skeleton.test.js
@@ -19,6 +19,31 @@ const routingContractSource = Fs.readFileSync(
     Path.resolve(sourceRoot, '..', 'extension-mv3-common', 'routing-contract.js'),
     'utf8',
 );
+const providerDatasetSource = Fs.readFileSync(
+    Path.resolve(sourceRoot, '..', 'extension-mv3-common', 'provider-dataset.js'),
+    'utf8',
+);
+const providerDatasetStateSource = Fs.readFileSync(
+    Path.resolve(
+        sourceRoot,
+        '..',
+        'extension-mv3-common',
+        'provider-dataset-state.js',
+    ),
+    'utf8',
+);
+const datasetStoreSource = Fs.readFileSync(
+    Path.join(sourceRoot, 'background', 'dataset-store.js'),
+    'utf8',
+);
+const providerLookupSource = Fs.readFileSync(
+    Path.join(sourceRoot, 'background', 'provider-lookup.js'),
+    'utf8',
+);
+const datasetRuntimeSource = Fs.readFileSync(
+    Path.join(sourceRoot, 'background', 'dataset-runtime.js'),
+    'utf8',
+);
 const routingAdapterSource = Fs.readFileSync(
     Path.join(sourceRoot, 'background', 'routing-adapter.js'),
     'utf8',
@@ -144,7 +169,20 @@ function startEventPage(options = {}) {
   Vm.runInContext(routingContractSource, context, {
     filename: 'routing-contract.js',
   });
+  Vm.runInContext(providerDatasetSource, context, {
+    filename: 'provider-dataset.js',
+  });
+  Vm.runInContext(providerDatasetStateSource, context, {
+    filename: 'provider-dataset-state.js',
+  });
   Vm.runInContext(offStateSource, context, {filename: 'off-state.js'});
+  Vm.runInContext(datasetStoreSource, context, {filename: 'dataset-store.js'});
+  Vm.runInContext(providerLookupSource, context, {
+    filename: 'provider-lookup.js',
+  });
+  Vm.runInContext(datasetRuntimeSource, context, {
+    filename: 'dataset-runtime.js',
+  });
   Vm.runInContext(routingAdapterSource, context, {
     filename: 'routing-adapter.js',
   });
@@ -178,7 +216,12 @@ describe('Firefox MV3 inert skeleton', function() {
     Assert.deepStrictEqual(manifest.background, {
       scripts: [
         'background/common/routing-contract.js',
+        'background/common/provider-dataset.js',
+        'background/common/provider-dataset-state.js',
         'background/off-state.js',
+        'background/dataset-store.js',
+        'background/provider-lookup.js',
+        'background/dataset-runtime.js',
         'background/routing-adapter.js',
         'background/event-page.js',
       ],
@@ -319,6 +362,7 @@ describe('Firefox MV3 inert skeleton', function() {
         privateWindowAccess: 'GRANTED',
         routingImplemented: true,
         activationSupported: false,
+        providerDatasetImplemented: true,
         providerDatasetAvailable: false,
       },
     });
@@ -376,6 +420,9 @@ describe('Firefox MV3 inert skeleton', function() {
 
     const runtimeSource = [
       offStateSource,
+      datasetStoreSource,
+      providerLookupSource,
+      datasetRuntimeSource,
       routingAdapterSource,
       eventPageSource,
     ].join('\n');
@@ -384,7 +431,8 @@ describe('Firefox MV3 inert skeleton', function() {
       'XMLHttpRequest',
       'fetch(',
       'extension-chromium-mv3',
-      'provider-dataset',
+      'eval(',
+      'Function(',
     ]) {
       Assert.strictEqual(runtimeSource.includes(forbidden), false, forbidden);
     }

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/verify-package.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/verify-package.js
@@ -5,9 +5,14 @@ const Fs = require('node:fs');
 const Path = require('node:path');
 
 const EXPECTED_FILES = Object.freeze([
+  'background/common/provider-dataset-state.js',
+  'background/common/provider-dataset.js',
   'background/common/routing-contract.js',
+  'background/dataset-runtime.js',
+  'background/dataset-store.js',
   'background/event-page.js',
   'background/off-state.js',
+  'background/provider-lookup.js',
   'background/routing-adapter.js',
   'manifest.json',
 ]);
@@ -17,7 +22,10 @@ const FORBIDDEN_RUNTIME_TEXT = Object.freeze([
   'fetch(',
   'BEGIN PRIVATE KEY',
   'extension-chromium-mv3',
-  'provider-dataset',
+  'BEGIN PAC',
+  'FindProxyForURL',
+  'eval(',
+  'Function(',
 ]);
 
 function listFiles(root) {
@@ -51,8 +59,13 @@ function verifyPackage(packageRoot, sourceRoot) {
 
   for (const relativePath of files) {
     const packaged = Fs.readFileSync(Path.join(packageRoot, relativePath));
-    const sourcePath = relativePath === 'background/common/routing-contract.js' ?
-      Path.resolve(sourceRoot, '..', 'extension-mv3-common', 'routing-contract.js') :
+    const sourcePath = relativePath.startsWith('background/common/') ?
+      Path.resolve(
+          sourceRoot,
+          '..',
+          'extension-mv3-common',
+          Path.basename(relativePath),
+      ) :
       Path.join(sourceRoot, relativePath);
     const source = Fs.readFileSync(sourcePath);
     Assert.deepStrictEqual(packaged, source, `Changed package bytes: ${relativePath}`);
@@ -72,7 +85,12 @@ function verifyPackage(packageRoot, sourceRoot) {
   Assert.strictEqual(manifest.background.persistent, false);
   Assert.deepStrictEqual(manifest.background.scripts, [
     'background/common/routing-contract.js',
+    'background/common/provider-dataset.js',
+    'background/common/provider-dataset-state.js',
     'background/off-state.js',
+    'background/dataset-store.js',
+    'background/provider-lookup.js',
+    'background/dataset-runtime.js',
     'background/routing-adapter.js',
     'background/event-page.js',
   ]);
@@ -98,7 +116,7 @@ if (require.main === module) {
       Path.join(projectRoot, 'src', 'extension-firefox-mv3'),
   );
   console.log(
-      `Verified OFF-only Firefox MV3 routing package: ${result.files.length} files.`,
+      `Verified OFF-only Firefox MV3 dataset package: ${result.files.length} files.`,
   );
 }
 


### PR DESCRIPTION
## Summary

- adds a Firefox-specific immutable IndexedDB artifact store with SHA-256-addressed bytes and atomic provider-pointer updates
- reconstructs provider data through the existing browser-neutral verifier and activation/LKG model
- builds an in-memory `HOST_BUCKETS_V1` suffix lookup and feeds provider resolution into the shared routing contract
- keeps the shipped Firefox event page in durable `OFF`; activation remains unavailable

## Dataset safety boundary

- exact artifact bytes are hashed and verified before parsing, indexing, or pointer activation
- cold reconstruction checks active, previous LKG, then packaged baseline and stops at the first usable same-provider artifact
- invalid, unreadable, missing, malformed, or unexpected lookup state becomes `FAILED` / `FAIL_CLOSED`, never provider-miss Direct
- unauthenticated remote candidates cannot become active
- parsed indexes and request authorizations remain event-page memory only

## Scope exclusions

- no real 662,819-rule provider dataset is shipped
- no provider PAC/JavaScript execution
- no remote fetch, updater, signature verification, update server, ownership/Clear, authentication, health, activation UI, or release work
- provider provenance, redistribution licensing, and authenticated publication remain unresolved

## Verification

- supply-chain tests: 11/11
- Chromium PAC: 26/26
- Chromium MV3: 428/428
- Firefox deterministic: 78/78
- aggregate: 523/523
- Firefox package: 10 exact allowlisted files; no real or synthetic dataset artifact
- Chromium runtime: 70/70 files, added 0, missing 0, SHA-256 differences 0 against post-#47 main
- dependencies and lockfile: unchanged

## Firefox 154.0.1 browser smoke

An untracked, disposable-profile, localhost-only instrumented copy using the exact packaged runtime modules verified provider Proxy, provider Direct/miss, explicit Proxy/Direct, two-candidate failover, INITIALIZING cancellation, READY routing, invalid/missing dataset FAILED behavior, and genuine idle event-page recreation. Protected-origin contacts: 0.

The unmodified production package was installed separately and remained `OFF` through genuine event-page recreation without changing a pre-existing manual proxy.

An untracked compatibility run converted the existing pinned audit artifact into the tracked schema and verified 662,819 rules in 80 buckets (11,642,895 artifact bytes): exact hash/parse/validation 273.6 ms, index build 0.23 ms, warm lookup about 0.87 µs average. This is engineering evidence only, not provenance or license approval.