### PR TITLE
Fix Firefox Direct and proxy-fallback semantics

### DIFF
--- a/docs/development/FIREFOX_MV3_SKELETON.md
+++ b/docs/development/FIREFOX_MV3_SKELETON.md
@@ -13,6 +13,29 @@ Adapter заранее регистрирует `proxy.onRequest` и блоки�
 `webRequest`, `webRequestBlocking` и `<all_urls>`. Пока durable intent равен
 `OFF`, proxy listener не задаёт маршрут, а guard разрешает обычный трафик.
 
+Firefox routing adapter фиксирует проверенную в Firefox 154.0.1 семантику
+результатов `proxy.onRequest`:
+
+- browser-neutral `DIRECT` преобразуется в top-level `null`; это явный Direct,
+  отличный от `OFF`, при котором listener возвращает `undefined` и не задаёт
+  маршрут;
+- `{type: 'direct'}` не является эквивалентом true Direct при наличии browser
+  или global `proxy.settings`, потому что Firefox продолжает применять эти
+  настройки;
+- `PROXY + FAIL_CLOSED` преобразуется в `[...proxyInfos, null]`, где последний
+  `null` завершает proxy fallback и не создаёт дополнительный
+  `webRequest.onBeforeRequest` callback;
+- browser-neutral `PROXY + DIRECT` пока не имеет безопасного эквивалента в
+  Firefox fail-closed architecture, поэтому adapter отклоняет его с внутренним
+  кодом `UNSUPPORTED_PROXY_DIRECT_FALLBACK`, не создаёт authorization и
+  полагается на default-cancel guard.
+
+Обычный provider Direct остаётся поддержанным, если shared routing core уже
+свёл решение к `{kind: 'DIRECT'}`. Это ограничение относится только к Proxy
+chain с Direct fallback; полная routing parity с Chromium пока не заявляется.
+Global fail-closed floor, private-access revocation и ownership/Clear остаются
+отдельной последующей архитектурной работой.
+
 Реальный provider dataset, updater, активация, proxy ownership, аутентификация
 и health-проверки ещё не реализованы. Команда активации всегда отвечает
 `ACTIVATION_NOT_IMPLEMENTED`; наличие широких сетевых разрешений не делает

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/background/routing-adapter.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/background/routing-adapter.js
@@ -25,7 +25,10 @@
   const MAX_CALLBACK_BUDGET = 256;
   const ALLOW = Object.freeze({cancel: false});
   const CANCEL = Object.freeze({cancel: true});
-  const DIRECT = Object.freeze({type: 'direct'});
+  const DEFAULT_ROUTE = Object.freeze({type: 'direct'});
+  const ERROR_CODES = Object.freeze({
+    UNSUPPORTED_PROXY_DIRECT_FALLBACK: 'UNSUPPORTED_PROXY_DIRECT_FALLBACK',
+  });
   const FIREFOX_TYPES = Object.freeze({
     HTTP: 'http',
     HTTPS: 'https',
@@ -89,7 +92,9 @@
       return null;
     }
     if (decision.kind === Routing.KINDS.DIRECT) {
-      return {proxyResult: DIRECT, callbackBudget: 1};
+      // Firefox treats only top-level null as true Direct. A ProxyInfo Direct
+      // continues through browser/global proxy settings.
+      return {proxyResult: null, callbackBudget: 1};
     }
     if (decision.kind === Routing.KINDS.FAIL_CLOSED) {
       return null;
@@ -110,12 +115,12 @@
       proxies.push(proxyInfo);
     }
     if (decision.fallback === Routing.FALLBACKS.DIRECT) {
-      if (proxies.length === MAX_CALLBACK_BUDGET) {
-        return null;
-      }
-      proxies.push(DIRECT);
-      return {proxyResult: proxies, callbackBudget: proxies.length};
+      return {
+        errorCode: ERROR_CODES.UNSUPPORTED_PROXY_DIRECT_FALLBACK,
+      };
     }
+    // A trailing null terminates Firefox proxy fallback and does not produce
+    // another webRequest callback, so it is intentionally outside the budget.
     proxies.push(null);
     return {
       proxyResult: proxies,
@@ -194,19 +199,19 @@
         clearAuthorization(requestId);
         if (runtimeState !== STATES.READY ||
             typeof routingInputForRequest !== 'function') {
-          return DIRECT;
+          return DEFAULT_ROUTE;
         }
         const decision = decideRoute(routingInputForRequest(details));
         const converted = convertDecision(decision);
-        if (!converted ||
+        if (!converted || converted.errorCode ||
             !authorize(requestId, converted.callbackBudget)) {
           clearAuthorization(requestId);
-          return DIRECT;
+          return DEFAULT_ROUTE;
         }
         return converted.proxyResult;
       } catch (_error) {
         clearAuthorization(requestId);
-        return DIRECT;
+        return DEFAULT_ROUTE;
       }
 
     }
@@ -276,6 +281,7 @@
   return Object.freeze({
     ALLOW,
     CANCEL,
+    ERROR_CODES,
     MAX_AUTHORIZATIONS,
     MAX_CALLBACK_BUDGET,
     STATES,

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/dataset-runtime.test.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/dataset-runtime.test.js
@@ -142,7 +142,7 @@ describe('Firefox declarative dataset runtime', function() {
 
       });
 
-  it('routes a provider match through the shared decision contract',
+  it('fails closed for a provider Proxy decision with Direct fallback',
       async function() {
 
         const {runtime, store} = createStoredRuntime();
@@ -153,10 +153,12 @@ describe('Firefox declarative dataset runtime', function() {
         Assert.deepStrictEqual(adapter.onProxyRequest({
           requestId: 'provider-proxy',
           url: 'http://proxy.test/path',
-        }), [
-          {type: 'http', host: '127.0.0.1', port: 8080},
-          {type: 'direct'},
-        ]);
+        }), {type: 'direct'});
+        Assert.strictEqual(adapter.authorizationCount(), 0);
+        Assert.deepStrictEqual(
+            adapter.onBeforeRequest({requestId: 'provider-proxy'}),
+            {cancel: true},
+        );
 
       });
 
@@ -172,9 +174,7 @@ describe('Firefox declarative dataset runtime', function() {
           ['provider-direct', 'http://alpha.test/'],
           ['provider-miss', 'http://ordinary.test/'],
         ]) {
-          Assert.deepStrictEqual(adapter.onProxyRequest({requestId, url}), {
-            type: 'direct',
-          });
+          Assert.strictEqual(adapter.onProxyRequest({requestId, url}), null);
           Assert.deepStrictEqual(adapter.onBeforeRequest({requestId}), {
             cancel: false,
           });
@@ -206,10 +206,10 @@ describe('Firefox declarative dataset runtime', function() {
         await runtime.initialize();
         const adapter = adapterForRuntime(runtime);
 
-        Assert.deepStrictEqual(adapter.onProxyRequest({
+        Assert.strictEqual(adapter.onProxyRequest({
           requestId: 'direct-rule',
           url: 'http://direct.override/',
-        }), {type: 'direct'});
+        }), null);
         Assert.deepStrictEqual(adapter.onProxyRequest({
           requestId: 'proxy-rule',
           url: 'http://proxy.test/',

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/routing-adapter.test.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/routing-adapter.test.js
@@ -60,19 +60,37 @@ describe('Firefox fail-closed routing adapter', function() {
 
   });
 
-  it('authorizes exactly one callback for an intentional Direct route', function() {
+  it('distinguishes OFF from a true top-level-null Direct route', function() {
 
     const adapter = adapterForDecision(DIRECT_DECISION);
 
-    Assert.deepStrictEqual(adapter.onProxyRequest({requestId: 'direct'}), {
-      type: 'direct',
-    });
+    Assert.strictEqual(adapter.onProxyRequest({requestId: 'direct'}), null);
+    Assert.strictEqual(adapter.authorizationCount(), 1);
     Assert.deepStrictEqual(adapter.onBeforeRequest({requestId: 'direct'}), {
       cancel: false,
     });
+    Assert.strictEqual(adapter.authorizationCount(), 0);
     Assert.deepStrictEqual(adapter.onBeforeRequest({requestId: 'direct'}), {
       cancel: true,
     });
+
+  });
+
+  it('maps an ordinary provider Direct decision to top-level null', function() {
+
+    const adapter = adapterForDecision({
+      kind: Routing.KINDS.DIRECT,
+      source: Routing.SOURCES.PROVIDER_DEFAULT,
+    });
+
+    Assert.strictEqual(
+        adapter.onProxyRequest({requestId: 'provider-direct'}),
+        null,
+    );
+    Assert.deepStrictEqual(
+        adapter.onBeforeRequest({requestId: 'provider-direct'}),
+        {cancel: false},
+    );
 
   });
 
@@ -127,24 +145,21 @@ describe('Firefox fail-closed routing adapter', function() {
 
   });
 
-  it('includes an intentional Direct fallback in the callback budget', function() {
+  it('rejects proxy-plus-Direct fallback without authorization', function() {
 
-    const adapter = adapterForDecision(proxyDecision([
+    const decision = proxyDecision([
       candidate('one', 'HTTP', 'proxy-one.test', 8080),
       candidate('two', 'SOCKS4', '127.0.0.1', 9150),
-    ], Routing.FALLBACKS.DIRECT));
+    ], Routing.FALLBACKS.DIRECT);
+    const adapter = adapterForDecision(decision);
 
-    Assert.deepStrictEqual(adapter.onProxyRequest({requestId: 'fallback'}), [
-      {type: 'http', host: 'proxy-one.test', port: 8080},
-      {type: 'socks4', host: '127.0.0.1', port: 9150, proxyDNS: true},
-      {type: 'direct'},
-    ]);
-    for (let index = 0; index < 3; index += 1) {
-      Assert.deepStrictEqual(
-          adapter.onBeforeRequest({requestId: 'fallback'}),
-          {cancel: false},
-      );
-    }
+    Assert.deepStrictEqual(Adapter.convertDecision(decision), {
+      errorCode: Adapter.ERROR_CODES.UNSUPPORTED_PROXY_DIRECT_FALLBACK,
+    });
+    Assert.deepStrictEqual(adapter.onProxyRequest({requestId: 'fallback'}), {
+      type: 'direct',
+    });
+    Assert.strictEqual(adapter.authorizationCount(), 0);
     Assert.deepStrictEqual(adapter.onBeforeRequest({requestId: 'fallback'}), {
       cancel: true,
     });


### PR DESCRIPTION
## Summary

- maps browser-neutral `DIRECT` to top-level `null`, Firefox's true Direct primitive
- keeps durable `OFF` distinct by returning no proxy override (`undefined`)
- maps `PROXY + FAIL_CLOSED` to `[...proxyInfos, null]` and budgets only proxy callbacks
- rejects `PROXY + DIRECT` as `UNSUPPORTED_PROXY_DIRECT_FALLBACK`, creates no authorization, and fails closed through the guard
- documents that `{type: "direct"}` falls through browser/global proxy settings and that trailing array `null` terminates fallback rather than providing Direct

The shared routing contract remains unchanged. The shipped Firefox package remains durable `OFF`; activation, global `proxy.settings` floor, ownership/Clear, provider data/updater, authentication, health, UI, and release work are not added.

## Verification

- supply-chain tests: 11/11
- Chromium PAC: 26/26
- Chromium MV3: 428/428
- Firefox deterministic: 79/79
- aggregate: 524/524
- lint: Chromium MV3 and Firefox pass
- MV2, Chromium MV3, and Firefox MV3 builds pass
- Firefox package verification: 10 allowlisted files
- Firefox 154.0.1 instrumented browser smoke: 7/7 scenarios pass
  - top-level-null Direct and provider Direct reached the origin intentionally
  - valid Proxy and closed-A/working-B failover reached the expected proxy marker
  - fail-closed Proxy, unsupported Proxy+Direct, and listener rejection reached no origin
  - unexpected protected-origin contacts: 0
- production-package lifecycle smoke: installs and remains `OFF`, survives genuine event-page recreation with a new boot ID, and leaves a pre-existing manual proxy unchanged
- Chromium runtime comparison: 70/70 files, added 0, missing 0, SHA-256 differences 0
- dependencies and lockfile: unchanged

## Security boundary

- true Direct cannot be confused with OFF/no override
- unsupported or invalid routes never receive an authorization marker
- fail-closed proxy budgets exclude the trailing-null terminator
- no network ownership path or activation path is introduced
