### PR TITLE
Safely degrade Firefox proxy Direct fallback

### DIFF
--- a/docs/development/FIREFOX_MV3_SKELETON.md
+++ b/docs/development/FIREFOX_MV3_SKELETON.md
@@ -25,14 +25,19 @@ Firefox routing adapter фиксирует проверенную в Firefox 154
 - `PROXY + FAIL_CLOSED` преобразуется в `[...proxyInfos, null]`, где последний
   `null` завершает proxy fallback и не создаёт дополнительный
   `webRequest.onBeforeRequest` callback;
-- browser-neutral `PROXY + DIRECT` пока не имеет безопасного эквивалента в
-  Firefox fail-closed architecture, поэтому adapter отклоняет его с внутренним
-  кодом `UNSUPPORTED_PROXY_DIRECT_FALLBACK`, не создаёт authorization и
-  полагается на default-cancel guard.
+- Chromium provider chain может заканчиваться `DIRECT`. Firefox намеренно
+  удаляет только этот terminal Direct fallback: browser-neutral
+  `PROXY + DIRECT` преобразуется в тот же упорядоченный
+  `[...proxyInfos, null]`, с budget только для proxy-кандидатов и diagnostic
+  `PROXY_DIRECT_FALLBACK_STRIPPED`;
+- успешный выбор proxy и failover между proxy-кандидатами остаются
+  эквивалентными. Если все кандидаты недоступны, Chromium может перейти к
+  Direct, а Firefox завершает запрос fail-closed. Это намеренное различие
+  safety/availability, которое не создаёт Direct route.
 
 Обычный provider Direct остаётся поддержанным, если shared routing core уже
-свёл решение к `{kind: 'DIRECT'}`. Это ограничение относится только к Proxy
-chain с Direct fallback; полная routing parity с Chromium пока не заявляется.
+свёл решение к `{kind: 'DIRECT'}`. Default provider Auto больше не блокируется
+до первой proxy-попытки, но полная routing parity с Chromium не заявляется.
 Global fail-closed floor, private-access revocation и ownership/Clear остаются
 отдельной последующей архитектурной работой.
 

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/background/routing-adapter.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/background/routing-adapter.js
@@ -26,8 +26,8 @@
   const ALLOW = Object.freeze({cancel: false});
   const CANCEL = Object.freeze({cancel: true});
   const DEFAULT_ROUTE = Object.freeze({type: 'direct'});
-  const ERROR_CODES = Object.freeze({
-    UNSUPPORTED_PROXY_DIRECT_FALLBACK: 'UNSUPPORTED_PROXY_DIRECT_FALLBACK',
+  const DEGRADATION_CODES = Object.freeze({
+    PROXY_DIRECT_FALLBACK_STRIPPED: 'PROXY_DIRECT_FALLBACK_STRIPPED',
   });
   const FIREFOX_TYPES = Object.freeze({
     HTTP: 'http',
@@ -114,18 +114,22 @@
       }
       proxies.push(proxyInfo);
     }
-    if (decision.fallback === Routing.FALLBACKS.DIRECT) {
-      return {
-        errorCode: ERROR_CODES.UNSUPPORTED_PROXY_DIRECT_FALLBACK,
-      };
-    }
     // A trailing null terminates Firefox proxy fallback and does not produce
     // another webRequest callback, so it is intentionally outside the budget.
     proxies.push(null);
-    return {
+    const converted = {
       proxyResult: proxies,
       callbackBudget: proxies.length - 1,
     };
+    if (decision.fallback === Routing.FALLBACKS.DIRECT) {
+      // Firefox arrays cannot express a true terminal Direct route. Preserve
+      // every validated proxy candidate but deliberately fail closed after
+      // exhaustion, and keep the availability degradation observable to the
+      // pure conversion caller without mutable global diagnostics.
+      converted.degradationCode =
+        DEGRADATION_CODES.PROXY_DIRECT_FALLBACK_STRIPPED;
+    }
+    return converted;
 
   }
 
@@ -203,8 +207,7 @@
         }
         const decision = decideRoute(routingInputForRequest(details));
         const converted = convertDecision(decision);
-        if (!converted || converted.errorCode ||
-            !authorize(requestId, converted.callbackBudget)) {
+        if (!converted || !authorize(requestId, converted.callbackBudget)) {
           clearAuthorization(requestId);
           return DEFAULT_ROUTE;
         }
@@ -281,7 +284,7 @@
   return Object.freeze({
     ALLOW,
     CANCEL,
-    ERROR_CODES,
+    DEGRADATION_CODES,
     MAX_AUTHORIZATIONS,
     MAX_CALLBACK_BUDGET,
     STATES,

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/dataset-runtime.test.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/dataset-runtime.test.js
@@ -142,7 +142,7 @@ describe('Firefox declarative dataset runtime', function() {
 
       });
 
-  it('fails closed for a provider Proxy decision with Direct fallback',
+  it('routes a provider Proxy and strips only its Direct fallback',
       async function() {
 
         const {runtime, store} = createStoredRuntime();
@@ -153,7 +153,15 @@ describe('Firefox declarative dataset runtime', function() {
         Assert.deepStrictEqual(adapter.onProxyRequest({
           requestId: 'provider-proxy',
           url: 'http://proxy.test/path',
-        }), {type: 'direct'});
+        }), [
+          {type: 'http', host: '127.0.0.1', port: 8080},
+          null,
+        ]);
+        Assert.strictEqual(adapter.authorizationCount(), 1);
+        Assert.deepStrictEqual(
+            adapter.onBeforeRequest({requestId: 'provider-proxy'}),
+            {cancel: false},
+        );
         Assert.strictEqual(adapter.authorizationCount(), 0);
         Assert.deepStrictEqual(
             adapter.onBeforeRequest({requestId: 'provider-proxy'}),

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/routing-adapter.test.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/routing-adapter.test.js
@@ -96,14 +96,22 @@ describe('Firefox fail-closed routing adapter', function() {
 
   it('does not authorize Direct after a fail-closed proxy candidate', function() {
 
-    const adapter = adapterForDecision(proxyDecision([
+    const decision = proxyDecision([
       candidate('one', 'HTTPS', 'proxy-one.test', 443),
-    ]));
-
-    Assert.deepStrictEqual(adapter.onProxyRequest({requestId: 'proxy'}), [
-      {type: 'https', host: 'proxy-one.test', port: 443},
-      null,
     ]);
+    const adapter = adapterForDecision(decision);
+
+    Assert.deepStrictEqual(Adapter.convertDecision(decision), {
+      proxyResult: [
+        {type: 'https', host: 'proxy-one.test', port: 443},
+        null,
+      ],
+      callbackBudget: 1,
+    });
+    Assert.deepStrictEqual(
+        adapter.onProxyRequest({requestId: 'proxy'}),
+        [{type: 'https', host: 'proxy-one.test', port: 443}, null],
+    );
     Assert.deepStrictEqual(adapter.onBeforeRequest({requestId: 'proxy'}), {
       cancel: false,
     });
@@ -145,22 +153,78 @@ describe('Firefox fail-closed routing adapter', function() {
 
   });
 
-  it('rejects proxy-plus-Direct fallback without authorization', function() {
+  it('strips only proxy Direct fallback after validating every candidate',
+      function() {
 
-    const decision = proxyDecision([
-      candidate('one', 'HTTP', 'proxy-one.test', 8080),
-      candidate('two', 'SOCKS4', '127.0.0.1', 9150),
-    ], Routing.FALLBACKS.DIRECT);
+        const decision = proxyDecision([
+          candidate('one', 'HTTP', 'proxy-one.test', 8080),
+          candidate('two', 'SOCKS4', '127.0.0.1', 9150),
+        ], Routing.FALLBACKS.DIRECT);
+        const adapter = adapterForDecision(decision);
+
+        Assert.deepStrictEqual(Adapter.convertDecision(decision), {
+          proxyResult: [
+            {type: 'http', host: 'proxy-one.test', port: 8080},
+            {type: 'socks4', host: '127.0.0.1', port: 9150, proxyDNS: true},
+            null,
+          ],
+          callbackBudget: 2,
+          degradationCode:
+            Adapter.DEGRADATION_CODES.PROXY_DIRECT_FALLBACK_STRIPPED,
+        });
+        Assert.deepStrictEqual(
+            adapter.onProxyRequest({requestId: 'fallback'}),
+            [
+              {type: 'http', host: 'proxy-one.test', port: 8080},
+              {type: 'socks4', host: '127.0.0.1', port: 9150, proxyDNS: true},
+              null,
+            ],
+        );
+        Assert.strictEqual(adapter.authorizationCount(), 1);
+        Assert.deepStrictEqual(
+            adapter.onBeforeRequest({requestId: 'fallback'}),
+            {cancel: false},
+        );
+        Assert.deepStrictEqual(
+            adapter.onBeforeRequest({requestId: 'fallback'}),
+            {cancel: false},
+        );
+        Assert.strictEqual(adapter.authorizationCount(), 0);
+        Assert.deepStrictEqual(
+            adapter.onBeforeRequest({requestId: 'fallback'}),
+            {cancel: true},
+        );
+
+      });
+
+  it('gives one provider proxy one callback without terminal Direct', function() {
+
+    const decision = {
+      kind: Routing.KINDS.PROXY,
+      source: Routing.SOURCES.PROVIDER_DEFAULT,
+      candidates: [candidate('provider', 'HTTPS', 'provider.test', 443)],
+      fallback: Routing.FALLBACKS.DIRECT,
+    };
     const adapter = adapterForDecision(decision);
 
     Assert.deepStrictEqual(Adapter.convertDecision(decision), {
-      errorCode: Adapter.ERROR_CODES.UNSUPPORTED_PROXY_DIRECT_FALLBACK,
+      proxyResult: [
+        {type: 'https', host: 'provider.test', port: 443},
+        null,
+      ],
+      callbackBudget: 1,
+      degradationCode:
+        Adapter.DEGRADATION_CODES.PROXY_DIRECT_FALLBACK_STRIPPED,
     });
-    Assert.deepStrictEqual(adapter.onProxyRequest({requestId: 'fallback'}), {
-      type: 'direct',
+    Assert.deepStrictEqual(adapter.onProxyRequest({requestId: 'provider'}), [
+      {type: 'https', host: 'provider.test', port: 443},
+      null,
+    ]);
+    Assert.deepStrictEqual(adapter.onBeforeRequest({requestId: 'provider'}), {
+      cancel: false,
     });
     Assert.strictEqual(adapter.authorizationCount(), 0);
-    Assert.deepStrictEqual(adapter.onBeforeRequest({requestId: 'fallback'}), {
+    Assert.deepStrictEqual(adapter.onBeforeRequest({requestId: 'provider'}), {
       cancel: true,
     });
 
@@ -229,7 +293,10 @@ describe('Firefox fail-closed routing adapter', function() {
           {password: 'x'},
       ),
     ]) {
-      const adapter = adapterForDecision(proxyDecision([invalid]));
+      const adapter = adapterForDecision(proxyDecision(
+          [invalid],
+          Routing.FALLBACKS.DIRECT,
+      ));
       Assert.deepStrictEqual(adapter.onProxyRequest({requestId: invalid.id}), {
         type: 'direct',
       });
@@ -241,26 +308,36 @@ describe('Firefox fail-closed routing adapter', function() {
 
   });
 
-  it('fails closed for empty Proxy and core FAIL_CLOSED decisions', function() {
+  it('fails closed for empty, malformed, and core FAIL_CLOSED decisions',
+      function() {
 
-    for (const decision of [
-      proxyDecision([]),
-      {
-        kind: Routing.KINDS.FAIL_CLOSED,
-        source: Routing.SOURCES.ROUTING_INPUT,
-        code: 'NO_VALID_ROUTE',
-      },
-    ]) {
-      const adapter = adapterForDecision(decision);
-      Assert.deepStrictEqual(adapter.onProxyRequest({requestId: 'closed'}), {
-        type: 'direct',
-      });
-      Assert.deepStrictEqual(adapter.onBeforeRequest({requestId: 'closed'}), {
-        cancel: true,
-      });
-    }
+        for (const decision of [
+          proxyDecision([], Routing.FALLBACKS.DIRECT),
+          {
+            kind: Routing.KINDS.PROXY,
+            source: Routing.SOURCES.PROVIDER_DEFAULT,
+            candidates: 'not-an-array',
+            fallback: Routing.FALLBACKS.DIRECT,
+          },
+          {
+            kind: Routing.KINDS.FAIL_CLOSED,
+            source: Routing.SOURCES.ROUTING_INPUT,
+            code: 'NO_VALID_ROUTE',
+          },
+        ]) {
+          const adapter = adapterForDecision(decision);
+          Assert.deepStrictEqual(
+              adapter.onProxyRequest({requestId: 'closed'}),
+              {type: 'direct'},
+          );
+          Assert.deepStrictEqual(
+              adapter.onBeforeRequest({requestId: 'closed'}),
+              {cancel: true},
+          );
+          Assert.strictEqual(adapter.authorizationCount(), 0);
+        }
 
-  });
+      });
 
   it('fails closed when route selection throws or returns async state', function() {
 


### PR DESCRIPTION
## Summary

- change Firefox `PROXY + DIRECT` conversion from pre-route rejection to the complete ordered proxy chain plus a trailing `null` failover terminator
- strip only the terminal Direct fallback and expose the pure diagnostic `PROXY_DIRECT_FALLBACK_STRIPPED`
- budget exactly one `webRequest.onBeforeRequest` callback per proxy candidate; the trailing `null` is excluded
- keep invalid, malformed, and empty Proxy decisions fail-closed with zero authorization

Before this change, the adapter rejected 100% of default provider matches before attempting any provider proxy because those shared decisions end in Direct. The new behavior preserves successful proxy selection and proxy-to-proxy failover. Only the all-candidates-failed outcome differs: Chromium may continue Direct, while Firefox deliberately fails closed.

## Scope

- the production Firefox package remains durable `OFF`; activation is still unavailable
- no global fail-closed floor or proxy ownership/Clear behavior is added
- no provider dataset, updater, authentication, health, UI, or release work is added
- the shared routing contract and Chromium PAC behavior are unchanged
- dependencies and lockfiles are unchanged

## Verification

- supply-chain: 11/11
- PAC: 26/26
- Chromium MV3: 428/428
- Firefox deterministic: 80/80
- aggregate: 525/525
- Firefox 154.0.1 tracked-source smoke:
  - working provider A -> A marker
  - closed A -> working B -> B marker
  - all provider candidates closed -> request failure, origin 0
  - explicit Proxy unchanged
  - provider Direct, provider MISS, and explicit Direct -> intentional origin
  - concurrent degraded provider Proxy + Direct -> isolated request IDs and correct routes
  - callback counts matched proxy counts exactly; no terminal-null callback
- unexpected protected-origin contacts: 0
- production OFF-package lifecycle smoke: genuine event-page recreation remained OFF and left the manual proxy unchanged
- Firefox package: 10 allowlisted files
- Chromium runtime: 70/70 files, added 0, missing 0, SHA-256 differences 0

An untracked seven-candidate compatibility check produced seven ordered proxy entries plus trailing `null`, callback budget 7. Mapping the legacy generic `SOCKS` provider token remains separate future work.
