### PR TITLE
Add Firefox fail-closed proxy ownership and Clear

### DIFF
--- a/docs/development/FIREFOX_MV3_SKELETON.md
+++ b/docs/development/FIREFOX_MV3_SKELETON.md
@@ -38,11 +38,45 @@ Firefox routing adapter фиксирует проверенную в Firefox 154
 Обычный provider Direct остаётся поддержанным, если shared routing core уже
 свёл решение к `{kind: 'DIRECT'}`. Default provider Auto больше не блокируется
 до первой proxy-попытки, но полная routing parity с Chromium не заявляется.
-Global fail-closed floor, private-access revocation и ownership/Clear остаются
-отдельной последующей архитектурной работой.
+Firefox-specific control plane теперь содержит узкие primitives для global
+fail-closed floor и Clear, но не содержит production activation path. Canonical
+floor — manual SOCKS5 `127.0.0.1:<persisted-high-port>` с `proxyDNS: true`,
+пустыми HTTP/SSL/auto-config/passthrough и `httpProxyAll: false`. Port `0`,
+well-known и другие low ports невалидны. Кандидат high port создаётся только
+через `crypto.getRandomValues`, но WebExtension API не может надёжно доказать,
+что произвольный локальный процесс не владеет портом. Поэтому acquisition
+primitive требует внешне prevalidated identity и не вызывается ни startup, ни
+RPC. Остаточный риск local-port collision сохраняется.
 
-Реальный provider dataset, updater, активация, proxy ownership, аутентификация
-и health-проверки ещё не реализованы. Команда активации всегда отвечает
+Durable OFF state имеет schema v2:
+
+```json
+{"schemaVersion":2,"intent":"OFF","floorIdentity":null}
+```
+
+`floorIdentity` может содержать только точный canonical floor, нужный для
+cleanup после interruption. Schema v1 OFF мигрирует в v2 OFF; malformed и
+future state нормализуются в OFF без floor identity. Ownership признаётся
+только при одновременных exact identity match и
+`levelOfControl === "controlled_by_this_extension"`. Clear сначала сохраняет
+OFF, очищает ephemeral requestId budgets, затем освобождает только точный
+owned floor и удаляет identity лишь после подтверждения release. Mismatch не
+перезаписывается и не очищается.
+
+Firefox 154 добавляет к live `proxy.settings.get()` нормализованное
+`autoLogin: false`. Оно не хранится в durable identity, но exact live comparison
+явно требует `false`, если поле присутствует; другие дополнительные поля и
+`autoLogin: true` считаются mismatch.
+
+На каждом event-page boot OFF reconciliation никогда не приобретает floor. Если
+Firefox после disable/re-enable восстановил точный extension-owned floor,
+reconciliation очищает его даже при denied private access и оставляет runtime
+OFF. RPC `firefox.activation.clear` предоставляет только этот безопасный Clear;
+он не вызывает `proxy.settings.set`.
+
+Реальный provider dataset, updater, активация, аутентификация и health-проверки
+ещё не реализованы. Ownership primitives не делают routing доступным. Команда
+активации всегда отвечает
 `ACTIVATION_NOT_IMPLEMENTED`; наличие широких сетевых разрешений не делает
 маршрутизацию доступной пользователю.
 

--- a/extensions/chromium/runet-censorship-bypass/gulpfile.js
+++ b/extensions/chromium/runet-censorship-bypass/gulpfile.js
@@ -87,6 +87,7 @@ const chromiumMv3Src = './src/extension-chromium-mv3/**/*';
 const firefoxMv3RuntimeSrc = [
   './src/extension-firefox-mv3/manifest.json',
   './src/extension-firefox-mv3/background/off-state.js',
+  './src/extension-firefox-mv3/background/proxy-control.js',
   './src/extension-firefox-mv3/background/dataset-store.js',
   './src/extension-firefox-mv3/background/provider-lookup.js',
   './src/extension-firefox-mv3/background/dataset-runtime.js',

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/background/event-page.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/background/event-page.js
@@ -3,6 +3,7 @@
 (function startFirefoxEventPage(root) {
 
   const offState = root.rucbFirefoxOffState;
+  const proxyControlApi = root.rucbFirefoxProxyControl;
   const routing = root.rucbFirefoxRoutingAdapter;
   const datasetRuntime = root.rucbFirefoxDatasetRuntime.createRuntime({
     protectionIntended: false,
@@ -11,6 +12,13 @@
   const routingAdapter = routing.createAdapter({
     runtimeStateForRequest: datasetRuntime.getState,
     routingInputForRequest: datasetRuntime.routingInputForRequest,
+  });
+  const proxyControl = proxyControlApi.createController({
+    proxySettings: browser.proxy.settings,
+    storageArea: browser.storage.local,
+    isPrivateAccessAllowed: () =>
+      browser.extension.isAllowedIncognitoAccess(),
+    clearEphemeralState: routingAdapter.clearAllAuthorizations,
   });
   const durableIntent = offState.OFF;
   const bootId = root.crypto && typeof root.crypto.randomUUID === 'function' ?
@@ -60,6 +68,16 @@
     if (type === 'firefox.activation.apply') {
       return errorResponse('ACTIVATION_NOT_IMPLEMENTED');
     }
+    if (type === 'firefox.activation.clear') {
+      const cleared = await proxyControl.clearFloor();
+      if (!cleared.ok) {
+        return errorResponse(cleared.error.code);
+      }
+      return {
+        ok: true,
+        result: {intent: offState.OFF, status: cleared.status},
+      };
+    }
     return errorResponse('UNKNOWN_RPC');
 
   }
@@ -83,12 +101,12 @@
   );
   browser.runtime.onMessage.addListener(handleMessage);
 
-  const initialization = offState.initialize(browser.storage.local)
-      .catch(() => offState.normalizeDurableState(null))
-      .then(async (state) => {
+  const initialization = proxyControl.reconcileOffOnStartup()
+      .then(async (reconciliation) => {
         await datasetRuntime.initialize();
-        return state;
-      });
+        return reconciliation.durableState || offState.canonicalState();
+      })
+      .catch(() => offState.canonicalState());
 
   root.rucbFirefoxSkeletonRuntime = Object.freeze({
     bootId,

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/background/off-state.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/background/off-state.js
@@ -12,40 +12,113 @@
 })(typeof globalThis === 'object' ? globalThis : this, function() {
 
   const STORAGE_KEY = 'firefoxMv3InertState';
-  const SCHEMA_VERSION = 1;
+  const SCHEMA_VERSION = 2;
   const OFF = 'OFF';
+  const MIN_FLOOR_PORT = 49152;
+  const MAX_FLOOR_PORT = 65535;
+  const STATE_KEYS = Object.freeze([
+    'schemaVersion',
+    'intent',
+    'floorIdentity',
+  ]);
+  const FLOOR_KEYS = Object.freeze([
+    'proxyType',
+    'http',
+    'httpProxyAll',
+    'ssl',
+    'socks',
+    'socksVersion',
+    'proxyDNS',
+    'passthrough',
+    'autoConfigUrl',
+  ]);
 
-  function canonicalState() {
+  function hasExactKeys(value, keys) {
 
-    return {schemaVersion: SCHEMA_VERSION, intent: OFF};
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+      return false;
+    }
+    const actual = Object.keys(value).sort();
+    const expected = [...keys].sort();
+    return actual.length === expected.length &&
+      actual.every((key, index) => key === expected[index]);
+
+  }
+
+  function canonicalizeFloorIdentity(value) {
+
+    if (!hasExactKeys(value, FLOOR_KEYS) ||
+        value.proxyType !== 'manual' ||
+        value.http !== '' || value.httpProxyAll !== false ||
+        value.ssl !== '' || value.socksVersion !== 5 ||
+        value.proxyDNS !== true || value.passthrough !== '' ||
+        value.autoConfigUrl !== '' || typeof value.socks !== 'string') {
+      return null;
+    }
+    const match = /^127\.0\.0\.1:([1-9][0-9]{0,4})$/.exec(value.socks);
+    const port = match ? Number(match[1]) : 0;
+    if (!Number.isSafeInteger(port) || port < MIN_FLOOR_PORT ||
+        port > MAX_FLOOR_PORT) {
+      return null;
+    }
+    return {
+      proxyType: 'manual',
+      http: '',
+      httpProxyAll: false,
+      ssl: '',
+      socks: `127.0.0.1:${port}`,
+      socksVersion: 5,
+      proxyDNS: true,
+      passthrough: '',
+      autoConfigUrl: '',
+    };
+
+  }
+
+  function canonicalState(floorIdentity = null) {
+
+    const floor = floorIdentity === null ? null :
+      canonicalizeFloorIdentity(floorIdentity);
+    if (floorIdentity !== null && !floor) {
+      throw new TypeError('INVALID_FIREFOX_FLOOR_IDENTITY');
+    }
+    return {schemaVersion: SCHEMA_VERSION, intent: OFF, floorIdentity: floor};
 
   }
 
   function isCanonicalState(value) {
 
     return Boolean(
-        value &&
-        typeof value === 'object' &&
-        !Array.isArray(value) &&
-        Object.keys(value).length === 2 &&
+        hasExactKeys(value, STATE_KEYS) &&
         value.schemaVersion === SCHEMA_VERSION &&
-        value.intent === OFF,
+        value.intent === OFF &&
+        (value.floorIdentity === null ||
+          canonicalizeFloorIdentity(value.floorIdentity) !== null),
     );
 
   }
 
-  function normalizeDurableState(_value) {
+  function normalizeDurableState(value) {
 
+    if (isCanonicalState(value)) {
+      return canonicalState(value.floorIdentity);
+    }
     return canonicalState();
 
   }
 
-  async function initialize(storageArea) {
+  function requireStorage(storageArea) {
 
     if (!storageArea || typeof storageArea.get !== 'function' ||
         typeof storageArea.set !== 'function') {
       throw new TypeError('FIREFOX_STORAGE_UNAVAILABLE');
     }
+
+  }
+
+  async function initialize(storageArea) {
+
+    requireStorage(storageArea);
     const stored = await storageArea.get(STORAGE_KEY);
     const current = stored && stored[STORAGE_KEY];
     const normalized = normalizeDurableState(current);
@@ -56,13 +129,28 @@
 
   }
 
+  async function writeOffState(storageArea, floorIdentity) {
+
+    requireStorage(storageArea);
+    const state = canonicalState(floorIdentity);
+    await storageArea.set({[STORAGE_KEY]: state});
+    return state;
+
+  }
+
   return Object.freeze({
+    FLOOR_KEYS,
+    MAX_FLOOR_PORT,
+    MIN_FLOOR_PORT,
     OFF,
     SCHEMA_VERSION,
     STORAGE_KEY,
+    canonicalState,
+    canonicalizeFloorIdentity,
     initialize,
     isCanonicalState,
     normalizeDurableState,
+    writeOffState,
   });
 
 });

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/background/proxy-control.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/background/proxy-control.js
@@ -1,0 +1,322 @@
+'use strict';
+/* global require */
+
+(function publishFirefoxProxyControl(root, factory) {
+
+  const offState = typeof module === 'object' && module.exports ?
+    require('./off-state') : root.rucbFirefoxOffState;
+  const api = factory(offState, root.crypto);
+  if (typeof module === 'object' && module.exports) {
+    module.exports = api;
+    return;
+  }
+  root.rucbFirefoxProxyControl = api;
+
+})(typeof globalThis === 'object' ? globalThis : this,
+    function(OffState, defaultCrypto) {
+
+      const CONTROLLED_BY_THIS_EXTENSION = 'controlled_by_this_extension';
+      const RESULTS = Object.freeze({
+        ACQUIRED: 'ACQUIRED',
+        ALREADY_CLEAR: 'ALREADY_CLEAR',
+        CLEARED: 'CLEARED',
+      });
+      const ERRORS = Object.freeze({
+        EPHEMERAL_CLEAR_FAILED: 'EPHEMERAL_CLEAR_FAILED',
+        FLOOR_IDENTITY_PERSIST_FAILED: 'FLOOR_IDENTITY_PERSIST_FAILED',
+        INVALID_FLOOR_IDENTITY: 'INVALID_FLOOR_IDENTITY',
+        OWNERSHIP_MISMATCH: 'OWNERSHIP_MISMATCH',
+        PORT_PREVALIDATION_REQUIRED: 'PORT_PREVALIDATION_REQUIRED',
+        PRIVATE_ACCESS_CHECK_FAILED: 'PRIVATE_ACCESS_CHECK_FAILED',
+        PRIVATE_ACCESS_REQUIRED: 'PRIVATE_ACCESS_REQUIRED',
+        PROXY_CLEAR_FAILED: 'PROXY_CLEAR_FAILED',
+        PROXY_READ_FAILED: 'PROXY_READ_FAILED',
+        PROXY_SET_FAILED: 'PROXY_SET_FAILED',
+        RELEASE_NOT_CONFIRMED: 'RELEASE_NOT_CONFIRMED',
+        STORAGE_UNAVAILABLE: 'STORAGE_UNAVAILABLE',
+      });
+
+      function errorResult(code, durableState) {
+
+        const result = {ok: false, error: {code}};
+        if (durableState) {
+          result.durableState = durableState;
+        }
+        return result;
+
+      }
+
+      function successResult(status, durableState) {
+
+        return {ok: true, status, durableState};
+
+      }
+
+      function canonicalizeFloorIdentity(value) {
+
+        return OffState.canonicalizeFloorIdentity(value);
+
+      }
+
+      function sameFloorIdentity(left, right) {
+
+        const canonicalLeft = canonicalizeFloorIdentity(left);
+        const canonicalRight = canonicalizeFloorIdentity(right);
+        if (!canonicalLeft || !canonicalRight) {
+          return false;
+        }
+        return OffState.FLOOR_KEYS.every((key) =>
+          canonicalLeft[key] === canonicalRight[key]);
+
+      }
+
+      function canonicalizeLiveFloorIdentity(value) {
+
+        const direct = canonicalizeFloorIdentity(value);
+        if (direct) {
+          return direct;
+        }
+        if (!value || typeof value !== 'object' || Array.isArray(value) ||
+            value.autoLogin !== false ||
+            Object.keys(value).length !== OffState.FLOOR_KEYS.length + 1) {
+          return null;
+        }
+        const withoutAutoLogin = {};
+        for (const key of OffState.FLOOR_KEYS) {
+          if (!Object.prototype.hasOwnProperty.call(value, key)) {
+            return null;
+          }
+          withoutAutoLogin[key] = value[key];
+        }
+        return canonicalizeFloorIdentity(withoutAutoLogin);
+
+      }
+
+      function isExactOwnedFloor(liveSettings, persistedFloorIdentity) {
+
+        return Boolean(
+            liveSettings && typeof liveSettings === 'object' &&
+            !Array.isArray(liveSettings) &&
+            liveSettings.levelOfControl === CONTROLLED_BY_THIS_EXTENSION &&
+            sameFloorIdentity(
+                canonicalizeLiveFloorIdentity(liveSettings.value),
+                persistedFloorIdentity,
+            ),
+        );
+
+      }
+
+      function generateHighPortCandidate(cryptoSource = defaultCrypto) {
+
+        if (!cryptoSource || typeof cryptoSource.getRandomValues !== 'function') {
+          throw new TypeError('CRYPTO_RANDOM_UNAVAILABLE');
+        }
+        const words = new Uint16Array(1);
+        cryptoSource.getRandomValues(words);
+        const span = OffState.MAX_FLOOR_PORT - OffState.MIN_FLOOR_PORT + 1;
+        return OffState.MIN_FLOOR_PORT + (words[0] % span);
+
+      }
+
+      function createController(options = {}) {
+
+        const proxySettings = options.proxySettings;
+        const storageArea = options.storageArea;
+        const isPrivateAccessAllowed = options.isPrivateAccessAllowed;
+        const clearEphemeralState = options.clearEphemeralState || (() => {});
+        let operationQueue = Promise.resolve();
+
+        function enqueue(operation) {
+
+          const result = operationQueue.then(operation, operation);
+          operationQueue = result.catch(() => {});
+          return result;
+
+        }
+
+        function validDependencies() {
+
+          return Boolean(
+              proxySettings && typeof proxySettings.get === 'function' &&
+              typeof proxySettings.set === 'function' &&
+              typeof proxySettings.clear === 'function' &&
+              storageArea && typeof storageArea.get === 'function' &&
+              typeof storageArea.set === 'function',
+          );
+
+        }
+
+        async function initializeState() {
+
+          if (!validDependencies()) {
+            return errorResult(ERRORS.STORAGE_UNAVAILABLE,
+                OffState.canonicalState());
+          }
+          try {
+            const durableState = await OffState.initialize(storageArea);
+            return {ok: true, durableState};
+          } catch (_error) {
+            return errorResult(ERRORS.STORAGE_UNAVAILABLE,
+                OffState.canonicalState());
+          }
+
+        }
+
+        async function persistFloorIdentity(floorIdentity) {
+
+          try {
+            return await OffState.writeOffState(storageArea, floorIdentity);
+          } catch (_error) {
+            return null;
+          }
+
+        }
+
+        function clearEphemeral() {
+
+          try {
+            clearEphemeralState();
+            return true;
+          } catch (_error) {
+            return false;
+          }
+
+        }
+
+        async function readLiveSettings(durableState) {
+
+          try {
+            return {ok: true, live: await proxySettings.get({})};
+          } catch (_error) {
+            return errorResult(ERRORS.PROXY_READ_FAILED, durableState);
+          }
+
+        }
+
+        async function acquirePrevalidatedFloorNow(request) {
+
+          const floorIdentity = canonicalizeFloorIdentity(
+              request && request.floorIdentity,
+          );
+          if (!floorIdentity) {
+            return errorResult(ERRORS.INVALID_FLOOR_IDENTITY);
+          }
+          if (!request || request.portPrevalidated !== true) {
+            return errorResult(ERRORS.PORT_PREVALIDATION_REQUIRED);
+          }
+          if (typeof isPrivateAccessAllowed !== 'function') {
+            return errorResult(ERRORS.PRIVATE_ACCESS_CHECK_FAILED);
+          }
+          let privateAccess;
+          try {
+            privateAccess = await isPrivateAccessAllowed();
+          } catch (_error) {
+            return errorResult(ERRORS.PRIVATE_ACCESS_CHECK_FAILED);
+          }
+          if (privateAccess !== true) {
+            return errorResult(ERRORS.PRIVATE_ACCESS_REQUIRED);
+          }
+          const durableState = await persistFloorIdentity(floorIdentity);
+          if (!durableState) {
+            return errorResult(ERRORS.FLOOR_IDENTITY_PERSIST_FAILED);
+          }
+          if (!clearEphemeral()) {
+            return errorResult(ERRORS.EPHEMERAL_CLEAR_FAILED, durableState);
+          }
+          try {
+            await proxySettings.set({value: floorIdentity});
+          } catch (_error) {
+            return errorResult(ERRORS.PROXY_SET_FAILED, durableState);
+          }
+          const liveResult = await readLiveSettings(durableState);
+          if (!liveResult.ok) {
+            return liveResult;
+          }
+          if (!isExactOwnedFloor(liveResult.live, floorIdentity)) {
+            return errorResult(ERRORS.OWNERSHIP_MISMATCH, durableState);
+          }
+          return successResult(RESULTS.ACQUIRED, durableState);
+
+        }
+
+        async function clearFloorNow() {
+
+          const initialized = await initializeState();
+          if (!initialized.ok) {
+            clearEphemeral();
+            return initialized;
+          }
+          const persisted = initialized.durableState.floorIdentity;
+          const durableState = await persistFloorIdentity(persisted);
+          if (!durableState) {
+            clearEphemeral();
+            return errorResult(ERRORS.FLOOR_IDENTITY_PERSIST_FAILED,
+                initialized.durableState);
+          }
+          if (!clearEphemeral()) {
+            return errorResult(ERRORS.EPHEMERAL_CLEAR_FAILED, durableState);
+          }
+          if (persisted === null) {
+            return successResult(RESULTS.ALREADY_CLEAR, durableState);
+          }
+          const liveResult = await readLiveSettings(durableState);
+          if (!liveResult.ok) {
+            return liveResult;
+          }
+          if (!isExactOwnedFloor(liveResult.live, persisted)) {
+            return errorResult(ERRORS.OWNERSHIP_MISMATCH, durableState);
+          }
+          try {
+            await proxySettings.clear({});
+          } catch (_error) {
+            return errorResult(ERRORS.PROXY_CLEAR_FAILED, durableState);
+          }
+          const confirmed = await readLiveSettings(durableState);
+          if (!confirmed.ok) {
+            return confirmed;
+          }
+          if (isExactOwnedFloor(confirmed.live, persisted)) {
+            return errorResult(ERRORS.RELEASE_NOT_CONFIRMED, durableState);
+          }
+          const clearedState = await persistFloorIdentity(null);
+          if (!clearedState) {
+            return errorResult(ERRORS.FLOOR_IDENTITY_PERSIST_FAILED,
+                durableState);
+          }
+          return successResult(RESULTS.CLEARED, clearedState);
+
+        }
+
+        return Object.freeze({
+          acquirePrevalidatedFloor(request) {
+
+            return enqueue(() => acquirePrevalidatedFloorNow(request));
+
+          },
+          clearFloor() {
+
+            return enqueue(clearFloorNow);
+
+          },
+          reconcileOffOnStartup() {
+
+            return enqueue(clearFloorNow);
+
+          },
+        });
+
+      }
+
+      return Object.freeze({
+        CONTROLLED_BY_THIS_EXTENSION,
+        ERRORS,
+        RESULTS,
+        canonicalizeFloorIdentity,
+        canonicalizeLiveFloorIdentity,
+        createController,
+        generateHighPortCandidate,
+        isExactOwnedFloor,
+        sameFloorIdentity,
+      });
+
+    });

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/background/routing-adapter.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/background/routing-adapter.js
@@ -161,6 +161,12 @@
 
     }
 
+    function clearAllAuthorizations() {
+
+      resetAuthorizations();
+
+    }
+
     function clearAuthorization(requestId) {
 
       try {
@@ -268,6 +274,7 @@
 
     const api = {
       authorizationCount,
+      clearAllAuthorizations,
       currentRuntimeState,
       onBeforeRequest,
       onProxyRequest,

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/manifest.json
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/manifest.json
@@ -18,6 +18,7 @@
       "background/common/provider-dataset.js",
       "background/common/provider-dataset-state.js",
       "background/off-state.js",
+      "background/proxy-control.js",
       "background/dataset-store.js",
       "background/provider-lookup.js",
       "background/dataset-runtime.js",

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/firefox-lifecycle-smoke.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/firefox-lifecycle-smoke.js
@@ -507,7 +507,11 @@ async function main() {
       temporary: true,
     });
     const first = await waitForBoot(bootEvents, () => true, 15000);
-    Assert.deepStrictEqual(first.state, {schemaVersion: 1, intent: 'OFF'});
+    Assert.deepStrictEqual(first.state, {
+      schemaVersion: 2,
+      intent: 'OFF',
+      floorIdentity: null,
+    });
     const origin = await extensionOrigin(client);
     const firstRpc = await readCapabilities(client, origin);
     Assert.strictEqual(firstRpc.bootId, first.bootId);
@@ -522,7 +526,11 @@ async function main() {
         (event) => event.bootId !== first.bootId,
         105000,
     );
-    Assert.deepStrictEqual(second.state, {schemaVersion: 1, intent: 'OFF'});
+    Assert.deepStrictEqual(second.state, {
+      schemaVersion: 2,
+      intent: 'OFF',
+      floorIdentity: null,
+    });
     const secondRpc = await readCapabilities(client, origin);
     Assert.strictEqual(secondRpc.bootId, second.bootId);
     Assert.strictEqual(secondRpc.capabilities.result.runtimeState, 'OFF');
@@ -583,3 +591,20 @@ if (require.main === module) {
     process.exitCode = 1;
   });
 }
+
+module.exports = Object.freeze({
+  bodyText,
+  closeServer,
+  connectMarionette,
+  delay,
+  extensionOrigin,
+  firefoxVersion,
+  listen,
+  navigate,
+  profilePreferences,
+  resolveFirefox,
+  safeRemoveTemporary,
+  unusedPort,
+  waitForExit,
+  webdriverValue,
+});

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/firefox-proxy-control-smoke.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/firefox-proxy-control-smoke.js
@@ -1,0 +1,629 @@
+'use strict';
+
+const Assert = require('node:assert');
+const ChildProcess = require('node:child_process');
+const Fs = require('node:fs');
+const Http = require('node:http');
+const Os = require('node:os');
+const Path = require('node:path');
+const Smoke = require('./firefox-lifecycle-smoke');
+
+const EXTENSION_ID = 'firefox-mv3-skeleton@runet-censorship-bypass.invalid';
+const MANUAL_PROXY_MARKER = 'FIREFOX_PROXY_CONTROL_PREVIOUS_MANUAL';
+const projectRoot = Path.resolve(__dirname, '..', '..', '..');
+const packageRoot = Path.join(projectRoot, 'build', 'extension-firefox-mv3');
+
+function localIpv4() {
+
+  for (const addresses of Object.values(Os.networkInterfaces())) {
+    for (const address of addresses || []) {
+      if (address.family === 'IPv4' && !address.internal) {
+        return address.address;
+      }
+    }
+  }
+  throw new Error('A local non-loopback IPv4 address is required.');
+
+}
+
+function floor(port) {
+
+  return {
+    proxyType: 'manual',
+    http: '',
+    httpProxyAll: false,
+    ssl: '',
+    socks: `127.0.0.1:${port}`,
+    socksVersion: 5,
+    proxyDNS: true,
+    passthrough: '',
+    autoConfigUrl: '',
+  };
+
+}
+
+async function highUnusedPort() {
+
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    const port = await Smoke.unusedPort();
+    if (port >= 49152) {
+      return port;
+    }
+  }
+  throw new Error('Could not obtain a high externally prevalidated port.');
+
+}
+
+function makeInstrumentedExtension() {
+
+  const directory = Fs.mkdtempSync(
+      Path.join(Os.tmpdir(), 'rucb-firefox-control-extension-'),
+  );
+  Fs.cpSync(packageRoot, directory, {recursive: true});
+  Fs.writeFileSync(Path.join(directory, 'control.html'), [
+    '<!doctype html>',
+    '<meta charset="utf-8">',
+    '<title>Firefox proxy control smoke</title>',
+    '<body></body>',
+    '<script src="control.js"></script>',
+  ].join('\n'));
+  Fs.writeFileSync(Path.join(directory, 'control.js'), [
+    '\'use strict\';',
+    '(async () => {',
+    '  const parameters = new URLSearchParams(location.search);',
+    '  const action = parameters.get(\'action\');',
+    '  const background = browser.extension.getBackgroundPage();',
+    '  await background.rucbFirefoxSkeletonRuntime.whenReady();',
+    '  const OffState = background.rucbFirefoxOffState;',
+    '  const ProxyControl = background.rucbFirefoxProxyControl;',
+    '  const counters = {clear: 0, get: 0, set: 0};',
+    '  const proxySettings = {',
+    '    clear(value) {',
+    '      counters.clear += 1;',
+    '      return browser.proxy.settings.clear(value);',
+    '    },',
+    '    get(value) {',
+    '      counters.get += 1;',
+    '      return browser.proxy.settings.get(value);',
+    '    },',
+    '    set(value) {',
+    '      counters.set += 1;',
+    '      return browser.proxy.settings.set(value);',
+    '    },',
+    '  };',
+    '  const controller = ProxyControl.createController({',
+    '    proxySettings,',
+    '    storageArea: browser.storage.local,',
+    '    isPrivateAccessAllowed: () =>',
+    '      browser.extension.isAllowedIncognitoAccess(),',
+    '  });',
+    '  const port = Number(parameters.get(\'port\'));',
+    '  const floorIdentity = {',
+    '    proxyType: \'manual\',',
+    '    http: \'\',',
+    '    httpProxyAll: false,',
+    '    ssl: \'\',',
+    '    socks: `127.0.0.1:${port}`,',
+    '    socksVersion: 5,',
+    '    proxyDNS: true,',
+    '    passthrough: \'\',',
+    '    autoConfigUrl: \'\',',
+    '  };',
+    '  let result;',
+    '  if (action === \'status\') {',
+    '    const stored = await browser.storage.local.get(OffState.STORAGE_KEY);',
+    '    result = {',
+    '      durable: stored[OffState.STORAGE_KEY],',
+    '      live: await browser.proxy.settings.get({}),',
+    '      privateAccess: await browser.extension.isAllowedIncognitoAccess(),',
+    '    };',
+    '  } else if (action === \'persist-v1\') {',
+    '    await browser.storage.local.set({',
+    '      [OffState.STORAGE_KEY]: {schemaVersion: 1, intent: \'OFF\'},',
+    '    });',
+    '    result = {persisted: true};',
+    '  } else if (action === \'acquire\') {',
+    '    result = await controller.acquirePrevalidatedFloor({',
+    '      floorIdentity,',
+    '      portPrevalidated: true,',
+    '    });',
+    '  } else if (action === \'clear-rpc\') {',
+    '    result = await browser.runtime.sendMessage({',
+    '      type: \'firefox.activation.clear\',',
+    '    });',
+    '  } else if (action === \'set-unrelated\') {',
+    '    await proxySettings.set({value: {',
+    '      proxyType: \'manual\',',
+    '      http: `127.0.0.1:${Number(parameters.get(\'manualPort\'))}`,',
+    '      httpProxyAll: true,',
+    '      ssl: \'\',',
+    '      socks: \'\',',
+    '      socksVersion: 5,',
+    '      proxyDNS: false,',
+    '      passthrough: \'\',',
+    '      autoConfigUrl: \'\',',
+    '    }});',
+    '    result = {set: true};',
+    '  } else if (action === \'restore-floor\') {',
+    '    await proxySettings.set({value: floorIdentity});',
+    '    result = {set: true};',
+    '  } else {',
+    '    throw new Error(`Unknown action: ${action}`);',
+    '  }',
+    '  document.body.textContent = JSON.stringify({counters, result});',
+    '})().catch((error) => {',
+    '  document.body.textContent = JSON.stringify({error: String(error)});',
+    '});',
+  ].join('\n'));
+  return directory;
+
+}
+
+async function execute(client, script, args = [], context = 'content') {
+
+  await client.command('Marionette:SetContext', {value: context});
+  return Smoke.webdriverValue(await client.command('WebDriver:ExecuteScript', {
+    args,
+    filename: 'firefox-proxy-control-smoke.js',
+    line: 1,
+    newSandbox: false,
+    script,
+  }));
+
+}
+
+async function executeAsync(client, script, args = [], context = 'content') {
+
+  await client.command('Marionette:SetContext', {value: context});
+  return Smoke.webdriverValue(
+      await client.command('WebDriver:ExecuteAsyncScript', {
+        args,
+        filename: 'firefox-proxy-control-smoke.js',
+        line: 1,
+        newSandbox: false,
+        script,
+      }),
+  );
+
+}
+
+function allInPageScript() {
+
+  return [
+    'const all = selector => {',
+    '  const matches = [];',
+    '  const visit = root => {',
+    '    matches.push(...root.querySelectorAll(selector));',
+    '    for (const element of root.querySelectorAll(\'*\')) {',
+    '      if (element.shadowRoot) visit(element.shadowRoot);',
+    '    }',
+    '  };',
+    '  visit(document);',
+    '  return matches;',
+    '};',
+  ].join('\n');
+
+}
+
+async function openAddonDetails(client, handle) {
+
+  await client.command('WebDriver:SwitchToWindow', {handle});
+  await client.command('Marionette:SetContext', {value: 'content'});
+  try {
+    await client.command('WebDriver:Navigate', {url: 'about:addons'});
+  } catch (error) {
+    if (!/navigation timed out/i.test(error.message)) {
+      throw error;
+    }
+  }
+  const deadline = Date.now() + 10000;
+  while (Date.now() < deadline) {
+    const result = await execute(client, [
+      allInPageScript(),
+      'const card = all(\'addon-card\').find(item =>',
+      '  item.getAttribute(\'addon-id\') === arguments[0]);',
+      'if (!card) {',
+      '  const category = all(\'button\').find(item =>',
+      '    /extensions|расширения/i.test(',
+      '      (item.getAttribute(\'title\') || \'\') + \' \' +',
+      '      (item.textContent || \'\')',
+      '    )',
+      '  );',
+      '  if (category) category.click();',
+      '  return false;',
+      '}',
+      'const queue = [card];',
+      'let link = null;',
+      'while (queue.length && !link) {',
+      '  const root = queue.shift();',
+      '  link = root.querySelector?.(\'.addon-name-link\') ||',
+      '    root.querySelector?.(\'[action="expand"]\');',
+      '  for (const element of root.querySelectorAll?.(\'*\') || []) {',
+      '    if (element.shadowRoot) queue.push(element.shadowRoot);',
+      '  }',
+      '}',
+      '(link || card).click();',
+      'return true;',
+    ].join('\n'), [EXTENSION_ID]);
+    if (result) {
+      await Smoke.delay(300);
+      return;
+    }
+    await Smoke.delay(100);
+  }
+  throw new Error('Add-on details were not available.');
+
+}
+
+async function setPrivateAccess(client, handle, granted) {
+
+  await openAddonDetails(client, handle);
+  const result = await execute(client, [
+    allInPageScript(),
+    'const target = all(\'input[name="private-browsing"]\').find(input =>',
+    '  input.value === (arguments[0] ? \'1\' : \'0\'));',
+    'if (!target) return false;',
+    'target.click();',
+    'return true;',
+  ].join('\n'), [granted]);
+  Assert.strictEqual(result, true, 'Private-access control unavailable.');
+  await Smoke.delay(800);
+
+}
+
+async function addonState(client) {
+
+  const state = await executeAsync(client, [
+    'const done = arguments[arguments.length - 1];',
+    'const {AddonManager} = ChromeUtils.importESModule(',
+    '  \'resource://gre/modules/AddonManager.sys.mjs\'',
+    ');',
+    'AddonManager.getAddonByID(arguments[0]).then(addon => done({',
+    '  exists: Boolean(addon),',
+    '  isActive: addon?.isActive === true,',
+    '  userDisabled: addon?.userDisabled === true,',
+    '}), error => done({error: String(error)}));',
+  ].join('\n'), [EXTENSION_ID], 'chrome');
+  await client.command('Marionette:SetContext', {value: 'content'});
+  return state;
+
+}
+
+async function setAddonEnabled(client, handle, enabled) {
+
+  await openAddonDetails(client, handle);
+  const before = await addonState(client);
+  if (before.isActive === enabled) {
+    return;
+  }
+  const clicked = await execute(client, [
+    allInPageScript(),
+    'const target = all(\'[action="toggle-disabled"]\')[0] ||',
+    '  all(\'[role="switch"]\')[0] || all(\'.toggle-button\')[0];',
+    'if (!target) return false;',
+    'target.click();',
+    'return true;',
+  ].join('\n'));
+  Assert.strictEqual(clicked, true, 'Add-on enable control unavailable.');
+  await Smoke.delay(1000);
+  Assert.strictEqual((await addonState(client)).isActive, enabled);
+
+}
+
+async function control(client, handle, origin, action, parameters = {}) {
+
+  await client.command('WebDriver:SwitchToWindow', {handle});
+  const query = new URLSearchParams(Object.assign({
+    action,
+    nonce: String(Date.now()),
+  }, parameters));
+  await Smoke.navigate(client, `${origin}/control.html?${query}`);
+  const deadline = Date.now() + 15000;
+  while (Date.now() < deadline) {
+    const text = String(await Smoke.bodyText(client) || '').trim();
+    if (text) {
+      const result = JSON.parse(text);
+      Assert.strictEqual('error' in result, false, result.error);
+      return result;
+    }
+    await Smoke.delay(100);
+  }
+  throw new Error(`Timed out waiting for control action ${action}.`);
+
+}
+
+async function expectManualProxy(client, handle, targetUrl, proxyRequests,
+    originRequests, phase) {
+
+  const beforeOrigin = originRequests.length;
+  await client.command('WebDriver:SwitchToWindow', {handle});
+  await Smoke.navigate(client, `${targetUrl}/${phase}?nonce=${Date.now()}`);
+  Assert.strictEqual(await Smoke.bodyText(client), MANUAL_PROXY_MARKER);
+  Assert.ok(
+      proxyRequests.some((url) => url.includes(`/${phase}?`)),
+      phase,
+  );
+  Assert.strictEqual(originRequests.length, beforeOrigin, phase);
+
+}
+
+async function expectFloorBlocked(client, handle, targetUrl, proxyRequests,
+    originRequests, phase) {
+
+  const beforeOrigin = originRequests.length;
+  await client.command('WebDriver:SwitchToWindow', {handle});
+  try {
+    await Smoke.navigate(client, `${targetUrl}/${phase}?nonce=${Date.now()}`);
+  } catch (_error) {
+    // A network error is expected from the closed SOCKS endpoint.
+  }
+  await Smoke.delay(200);
+  Assert.strictEqual(
+      proxyRequests.some((url) => url.includes(`/${phase}?`)),
+      false,
+      phase,
+  );
+  Assert.strictEqual(originRequests.length, beforeOrigin, phase);
+
+}
+
+async function main() {
+
+  Assert.strictEqual(Fs.existsSync(packageRoot), true, 'Run build:firefox first.');
+  const firefox = Smoke.resolveFirefox();
+  const localAddress = localIpv4();
+  const originRequests = [];
+  const proxyRequests = [];
+  const origin = Http.createServer((request, response) => {
+    originRequests.push(request.url);
+    response.writeHead(200, {'content-type': 'text/plain'});
+    response.end('UNEXPECTED_PROTECTED_ORIGIN');
+  });
+  const previousProxy = Http.createServer((request, response) => {
+    proxyRequests.push(request.url);
+    response.writeHead(200, {'content-type': 'text/plain'});
+    response.end(MANUAL_PROXY_MARKER);
+  });
+  await new Promise((resolve, reject) => {
+    origin.once('error', reject);
+    origin.listen(0, '0.0.0.0', resolve);
+  });
+  await Smoke.listen(previousProxy);
+  const targetUrl = `http://${localAddress}:${origin.address().port}`;
+  const extensionDirectory = makeInstrumentedExtension();
+  const profileDirectory = Fs.mkdtempSync(
+      Path.join(Os.tmpdir(), 'rucb-firefox-control-profile-'),
+  );
+  const marionettePort = await Smoke.unusedPort();
+  Fs.writeFileSync(
+      Path.join(profileDirectory, 'user.js'),
+      Smoke.profilePreferences(marionettePort, previousProxy.address().port),
+  );
+  const child = ChildProcess.spawn(firefox, [
+    '-headless',
+    '-no-remote',
+    '-profile',
+    profileDirectory,
+    '-marionette',
+    '-remote-allow-system-access',
+    'about:blank',
+  ], {
+    env: Object.assign({}, process.env, {
+      MOZ_CRASHREPORTER_DISABLE: '1',
+      MOZ_DISABLE_NONLOCAL_CONNECTIONS: '1',
+      MOZ_NO_REMOTE: '1',
+    }),
+    stdio: ['ignore', 'ignore', 'pipe'],
+    windowsHide: true,
+  });
+  let client;
+  let stderr = '';
+  child.stderr.on('data', (chunk) => {
+    stderr = `${stderr}${chunk}`.slice(-8000);
+  });
+  const checks = [];
+  function checked(name) {
+
+    checks.push(name);
+
+  }
+  try {
+    client = await Smoke.connectMarionette(marionettePort);
+    await client.command('WebDriver:NewSession', {
+      capabilities: {
+        alwaysMatch: {pageLoadStrategy: 'normal'},
+        firstMatch: [{}],
+      },
+    });
+    const handles = Smoke.webdriverValue(
+        await client.command('WebDriver:GetWindowHandles'),
+    );
+    const handle = handles[handles.length - 1];
+    await client.command('WebDriver:SwitchToWindow', {handle});
+    await client.command('WebDriver:SetTimeouts', {
+      implicit: 0,
+      pageLoad: 15000,
+      script: 15000,
+    });
+
+    await expectManualProxy(
+        client, handle, targetUrl, proxyRequests, originRequests, 'before',
+    );
+    await client.command('Addon:Install', {
+      allowPrivateBrowsing: false,
+      path: packageRoot,
+      temporary: true,
+    });
+    await expectManualProxy(
+        client, handle, targetUrl, proxyRequests, originRequests,
+        'production-off',
+    );
+    checked('production package starts OFF without proxy acquisition');
+    await client.command('Addon:Uninstall', {id: EXTENSION_ID});
+    await client.command('Addon:Install', {
+      allowPrivateBrowsing: false,
+      path: extensionDirectory,
+      temporary: true,
+    });
+    const extension = await Smoke.extensionOrigin(client);
+    const port = await highUnusedPort();
+
+    await control(client, handle, extension, 'persist-v1');
+    await setAddonEnabled(client, handle, false);
+    await setAddonEnabled(client, handle, true);
+    let status = await control(client, handle, extension, 'status');
+    Assert.deepStrictEqual(status.result.durable, {
+      schemaVersion: 2,
+      intent: 'OFF',
+      floorIdentity: null,
+    });
+    checked('schema v1 OFF migrates to schema v2 OFF');
+
+    const denied = await control(client, handle, extension, 'acquire', {port});
+    Assert.strictEqual(denied.result.error.code, 'PRIVATE_ACCESS_REQUIRED');
+    Assert.strictEqual(denied.counters.set, 0);
+    await expectManualProxy(
+        client, handle, targetUrl, proxyRequests, originRequests,
+        'denied-acquire',
+    );
+    checked('private denial prevents proxy.settings.set');
+
+    await setPrivateAccess(client, handle, true);
+    const acquired = await control(client, handle, extension, 'acquire', {port});
+    if (!acquired.result.ok) {
+      const acquisitionStatus = await control(
+          client,
+          handle,
+          extension,
+          'status',
+      );
+      throw new Error(JSON.stringify({acquired, acquisitionStatus}));
+    }
+    Assert.strictEqual(
+        acquired.result.status,
+        'ACQUIRED',
+        JSON.stringify(acquired),
+    );
+    Assert.strictEqual(acquired.counters.set, 1);
+    await expectFloorBlocked(
+        client, handle, targetUrl, proxyRequests, originRequests,
+        'acquired-floor',
+    );
+    checked('test-only prevalidated acquisition owns exact floor');
+
+    await control(client, handle, extension, 'set-unrelated', {
+      manualPort: previousProxy.address().port,
+      port,
+    });
+    const mismatch = await control(
+        client, handle, extension, 'clear-rpc', {port},
+    );
+    Assert.strictEqual(mismatch.result.error.code, 'OWNERSHIP_MISMATCH');
+    await expectManualProxy(
+        client, handle, targetUrl, proxyRequests, originRequests,
+        'mismatch-not-cleared',
+    );
+    checked('ownership mismatch does not clear unrelated manual setting');
+    await control(client, handle, extension, 'restore-floor', {port});
+    const restoredClear = await control(
+        client, handle, extension, 'clear-rpc', {port},
+    );
+    Assert.strictEqual(restoredClear.result.result.status, 'CLEARED');
+    await expectManualProxy(
+        client, handle, targetUrl, proxyRequests, originRequests,
+        'exact-clear',
+    );
+    checked('exact Clear restores previous manual proxy');
+
+    const acquiredForRevoke = await control(
+        client, handle, extension, 'acquire', {port},
+    );
+    Assert.strictEqual(acquiredForRevoke.result.status, 'ACQUIRED');
+    await setPrivateAccess(client, handle, false);
+    const revokedClear = await control(
+        client, handle, extension, 'clear-rpc', {port},
+    );
+    Assert.ok(
+        ['CLEARED', 'ALREADY_CLEAR'].includes(
+            revokedClear.result.result.status,
+        ),
+        JSON.stringify(revokedClear),
+    );
+    await expectManualProxy(
+        client, handle, targetUrl, proxyRequests, originRequests,
+        'clear-after-revoke',
+    );
+    checked('Clear succeeds after private-access revocation');
+
+    await setPrivateAccess(client, handle, true);
+    const acquiredForRestart = await control(
+        client, handle, extension, 'acquire', {port},
+    );
+    Assert.strictEqual(acquiredForRestart.result.status, 'ACQUIRED');
+    await setAddonEnabled(client, handle, false);
+    await expectManualProxy(
+        client, handle, targetUrl, proxyRequests, originRequests,
+        'disabled-restores-manual',
+    );
+    checked('disable restores previous manual proxy');
+    await setPrivateAccess(client, handle, false);
+    await setAddonEnabled(client, handle, true);
+    status = await control(client, handle, extension, 'status');
+    Assert.deepStrictEqual(status.result.durable, {
+      schemaVersion: 2,
+      intent: 'OFF',
+      floorIdentity: null,
+    });
+    Assert.strictEqual(status.result.privateAccess, false);
+    await expectManualProxy(
+        client, handle, targetUrl, proxyRequests, originRequests,
+        'reenable-reconciled-off',
+    );
+    checked('OFF startup clears resurrected exact floor while private denied');
+
+    Assert.strictEqual(originRequests.length, 0);
+    checked('protected origin contacts remain zero');
+    Assert.strictEqual(checks.length, 10);
+    console.log(JSON.stringify({
+      checks,
+      firefox: Smoke.firefoxVersion(firefox),
+      floorIdentity: floor(port),
+      install: 'temporary instrumented copy of exact tracked package sources',
+      manualProxyMarkerRequests: proxyRequests.length,
+      protectedOriginContacts: originRequests.length,
+      privateRevocationCycles: 2,
+    }, null, 2));
+  } catch (error) {
+    throw new Error(`${error && error.stack ? error.stack : error}\n${stderr}`);
+  } finally {
+    if (client) {
+      try {
+        await client.command('Marionette:Quit', {flags: ['eForceQuit']});
+      } catch (_error) {
+        // Firefox normally closes Marionette before replying.
+      }
+      client.close();
+    }
+    try {
+      await Smoke.waitForExit(child, 10000);
+    } catch (_error) {
+      child.kill();
+      await Smoke.waitForExit(child, 5000).catch(() => {});
+    }
+    await Smoke.closeServer(origin);
+    await Smoke.closeServer(previousProxy);
+    Smoke.safeRemoveTemporary(
+        extensionDirectory,
+        'rucb-firefox-control-extension-',
+    );
+    Smoke.safeRemoveTemporary(profileDirectory, 'rucb-firefox-control-profile-');
+  }
+
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(error && error.stack ? error.stack : error);
+    process.exitCode = 1;
+  });
+}

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/proxy-control.test.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/proxy-control.test.js
@@ -1,0 +1,550 @@
+'use strict';
+
+const Assert = require('node:assert');
+const OffState = require('../background/off-state');
+const ProxyControl = require('../background/proxy-control');
+
+function floor(port = 55001) {
+
+  return {
+    proxyType: 'manual',
+    http: '',
+    httpProxyAll: false,
+    ssl: '',
+    socks: `127.0.0.1:${port}`,
+    socksVersion: 5,
+    proxyDNS: true,
+    passthrough: '',
+    autoConfigUrl: '',
+  };
+
+}
+
+function durable(floorIdentity = null) {
+
+  return {schemaVersion: 2, intent: 'OFF', floorIdentity};
+
+}
+
+function makeStorage(initialValue, events = []) {
+
+  const values = initialValue === undefined ? {} : {
+    [OffState.STORAGE_KEY]: initialValue,
+  };
+  return {
+    values,
+    async get(key) {
+
+      events.push('storage-get');
+      return key in values ? {[key]: values[key]} : {};
+
+    },
+    async set(update) {
+
+      events.push('storage-set');
+      Object.assign(values, JSON.parse(JSON.stringify(update)));
+
+    },
+  };
+
+}
+
+function makeProxySettings(initialLive, options = {}, events = []) {
+
+  let live = initialLive;
+  const calls = {clear: 0, get: 0, set: 0};
+  return {
+    calls,
+    get live() {
+
+      return live;
+
+    },
+    api: {
+      async clear() {
+
+        calls.clear += 1;
+        events.push('proxy-clear');
+        if (options.clearError) {
+          throw options.clearError;
+        }
+        live = options.afterClear || {
+          levelOfControl: 'controllable_by_this_extension',
+          value: {proxyType: 'none'},
+        };
+
+      },
+      async get() {
+
+        calls.get += 1;
+        events.push('proxy-get');
+        if (options.getError) {
+          throw options.getError;
+        }
+        return live;
+
+      },
+      async set(update) {
+
+        calls.set += 1;
+        events.push('proxy-set');
+        if (options.setError) {
+          throw options.setError;
+        }
+        live = options.afterSet || {
+          levelOfControl: 'controlled_by_this_extension',
+          value: JSON.parse(JSON.stringify(update.value)),
+        };
+
+      },
+    },
+  };
+
+}
+
+function makeController(options = {}) {
+
+  const events = options.events || [];
+  const storage = options.storage || makeStorage(durable(), events);
+  const proxy = options.proxy || makeProxySettings({
+    levelOfControl: 'controllable_by_this_extension',
+    value: {proxyType: 'none'},
+  }, {}, events);
+  let ephemeralClears = 0;
+  const controller = ProxyControl.createController({
+    proxySettings: proxy.api,
+    storageArea: storage,
+    isPrivateAccessAllowed: async () => {
+      events.push('private-access');
+      if (options.privateAccessError) {
+        throw options.privateAccessError;
+      }
+      return options.privateAccess !== false;
+    },
+    clearEphemeralState() {
+
+      events.push('ephemeral-clear');
+      ephemeralClears += 1;
+      if (options.ephemeralError) {
+        throw options.ephemeralError;
+      }
+
+    },
+  });
+  return {
+    controller,
+    events,
+    get ephemeralClears() {
+
+      return ephemeralClears;
+
+    },
+    proxy,
+    storage,
+  };
+
+}
+
+describe('Firefox fail-closed proxy control', function() {
+
+  it('accepts only the exact canonical high-port floor identity', function() {
+
+    Assert.deepStrictEqual(
+        ProxyControl.canonicalizeFloorIdentity(floor(49152)),
+        floor(49152),
+    );
+    for (const invalid of [
+      null,
+      floor(49151),
+      floor(65536),
+      Object.assign(floor(), {socks: '127.0.0.1:0'}),
+      Object.assign(floor(), {socks: '127.0.0.1:1080'}),
+      Object.assign(floor(), {socks: 'localhost:55001'}),
+      Object.assign(floor(), {proxyDNS: false}),
+      Object.assign(floor(), {extra: true}),
+    ]) {
+      Assert.strictEqual(
+          ProxyControl.canonicalizeFloorIdentity(invalid),
+          null,
+      );
+    }
+
+  });
+
+  it('generates a candidate only through cryptographic random bytes', function() {
+
+    let calls = 0;
+    const cryptoSource = {
+      getRandomValues(words) {
+
+        calls += 1;
+        words[0] = 16383;
+        return words;
+
+      },
+    };
+    Assert.strictEqual(
+        ProxyControl.generateHighPortCandidate(cryptoSource),
+        65535,
+    );
+    Assert.strictEqual(calls, 1);
+    Assert.throws(
+        () => ProxyControl.generateHighPortCandidate({}),
+        /CRYPTO_RANDOM_UNAVAILABLE/,
+    );
+
+  });
+
+  it('requires control level and exact live floor identity for ownership',
+      function() {
+
+        const identity = floor();
+        Assert.strictEqual(ProxyControl.isExactOwnedFloor({
+          levelOfControl: 'controlled_by_this_extension',
+          value: Object.assign({autoLogin: false}, identity),
+        }, identity), true);
+        Assert.strictEqual(ProxyControl.isExactOwnedFloor({
+          levelOfControl: 'controllable_by_this_extension',
+          value: identity,
+        }, identity), false);
+        Assert.strictEqual(ProxyControl.isExactOwnedFloor({
+          levelOfControl: 'controlled_by_this_extension',
+          value: floor(55002),
+        }, identity), false);
+        Assert.strictEqual(ProxyControl.isExactOwnedFloor({
+          levelOfControl: 'controlled_by_this_extension',
+          value: Object.assign({autoLogin: true}, identity),
+        }, identity), false);
+
+      });
+
+  it('acquires only a caller-prevalidated floor after private access',
+      async function() {
+
+        const fixture = makeController({events: []});
+        const result = await fixture.controller.acquirePrevalidatedFloor({
+          floorIdentity: floor(),
+          portPrevalidated: true,
+        });
+
+        Assert.strictEqual(result.ok, true);
+        Assert.strictEqual(result.status, 'ACQUIRED');
+        Assert.deepStrictEqual(fixture.events, [
+          'private-access',
+          'storage-set',
+          'ephemeral-clear',
+          'proxy-set',
+          'proxy-get',
+        ]);
+        Assert.deepStrictEqual(
+            fixture.storage.values[OffState.STORAGE_KEY],
+            durable(floor()),
+        );
+        Assert.strictEqual(fixture.proxy.calls.set, 1);
+
+      });
+
+  it('rejects acquisition without explicit external port prevalidation',
+      async function() {
+
+        const fixture = makeController();
+        const result = await fixture.controller.acquirePrevalidatedFloor({
+          floorIdentity: floor(),
+        });
+
+        Assert.deepStrictEqual(result, {
+          ok: false,
+          error: {code: 'PORT_PREVALIDATION_REQUIRED'},
+        });
+        Assert.strictEqual(fixture.proxy.calls.set, 0);
+        Assert.deepStrictEqual(fixture.events, []);
+
+      });
+
+  it('denies acquisition without private access before storage or proxy writes',
+      async function() {
+
+        const fixture = makeController({privateAccess: false});
+        const result = await fixture.controller.acquirePrevalidatedFloor({
+          floorIdentity: floor(),
+          portPrevalidated: true,
+        });
+
+        Assert.deepStrictEqual(result, {
+          ok: false,
+          error: {code: 'PRIVATE_ACCESS_REQUIRED'},
+        });
+        Assert.deepStrictEqual(fixture.events, ['private-access']);
+        Assert.strictEqual(fixture.proxy.calls.set, 0);
+
+      });
+
+  it('retains cleanup identity when the proxy write fails', async function() {
+
+    const events = [];
+    const proxy = makeProxySettings({
+      levelOfControl: 'controllable_by_this_extension',
+      value: {proxyType: 'none'},
+    }, {setError: new Error('set failed')}, events);
+    const fixture = makeController({events, proxy});
+    const result = await fixture.controller.acquirePrevalidatedFloor({
+      floorIdentity: floor(),
+      portPrevalidated: true,
+    });
+
+    Assert.strictEqual(result.error.code, 'PROXY_SET_FAILED');
+    Assert.deepStrictEqual(
+        fixture.storage.values[OffState.STORAGE_KEY],
+        durable(floor()),
+    );
+
+  });
+
+  it('clears an exact owned floor and removes identity only after confirmation',
+      async function() {
+
+        const events = [];
+        const identity = floor();
+        const previous = {
+          levelOfControl: 'controllable_by_this_extension',
+          value: {proxyType: 'manual', http: '127.0.0.1:58001'},
+        };
+        const storage = makeStorage(durable(identity), events);
+        const proxy = makeProxySettings({
+          levelOfControl: 'controlled_by_this_extension',
+          value: identity,
+        }, {afterClear: previous}, events);
+        const fixture = makeController({events, proxy, storage});
+        const result = await fixture.controller.clearFloor();
+
+        Assert.strictEqual(result.ok, true);
+        Assert.strictEqual(result.status, 'CLEARED');
+        Assert.deepStrictEqual(fixture.events, [
+          'storage-get',
+          'storage-set',
+          'ephemeral-clear',
+          'proxy-get',
+          'proxy-clear',
+          'proxy-get',
+          'storage-set',
+        ]);
+        Assert.deepStrictEqual(
+            fixture.storage.values[OffState.STORAGE_KEY],
+            durable(),
+        );
+        Assert.strictEqual(fixture.proxy.live, previous);
+
+      });
+
+  it('does not clear an exact value without extension ownership',
+      async function() {
+
+        const identity = floor();
+        const events = [];
+        const storage = makeStorage(durable(identity), events);
+        const proxy = makeProxySettings({
+          levelOfControl: 'controllable_by_this_extension',
+          value: identity,
+        }, {}, events);
+        const fixture = makeController({events, proxy, storage});
+        const result = await fixture.controller.clearFloor();
+
+        Assert.strictEqual(result.error.code, 'OWNERSHIP_MISMATCH');
+        Assert.strictEqual(proxy.calls.clear, 0);
+        Assert.deepStrictEqual(
+            storage.values[OffState.STORAGE_KEY],
+            durable(identity),
+        );
+
+      });
+
+  it('does not clear a different extension-controlled setting', async function() {
+
+    const identity = floor();
+    const events = [];
+    const storage = makeStorage(durable(identity), events);
+    const proxy = makeProxySettings({
+      levelOfControl: 'controlled_by_this_extension',
+      value: floor(55002),
+    }, {}, events);
+    const fixture = makeController({events, proxy, storage});
+    const result = await fixture.controller.clearFloor();
+
+    Assert.strictEqual(result.error.code, 'OWNERSHIP_MISMATCH');
+    Assert.strictEqual(proxy.calls.clear, 0);
+
+  });
+
+  it('does not clear an unrelated manual proxy', async function() {
+
+    const identity = floor();
+    const events = [];
+    const storage = makeStorage(durable(identity), events);
+    const proxy = makeProxySettings({
+      levelOfControl: 'controlled_by_this_extension',
+      value: {
+        proxyType: 'manual',
+        http: '127.0.0.1:58001',
+        httpProxyAll: true,
+        ssl: '',
+        socks: '',
+        socksVersion: 5,
+        proxyDNS: false,
+        passthrough: '',
+        autoConfigUrl: '',
+      },
+    }, {}, events);
+    const fixture = makeController({events, proxy, storage});
+    const result = await fixture.controller.clearFloor();
+
+    Assert.strictEqual(result.error.code, 'OWNERSHIP_MISMATCH');
+    Assert.strictEqual(proxy.calls.clear, 0);
+
+  });
+
+  it('Clear never consults private access and remains available after revoke',
+      async function() {
+
+        const identity = floor();
+        const events = [];
+        const storage = makeStorage(durable(identity), events);
+        const proxy = makeProxySettings({
+          levelOfControl: 'controlled_by_this_extension',
+          value: identity,
+        }, {}, events);
+        const fixture = makeController({
+          events,
+          privateAccessError: new Error('private denied'),
+          proxy,
+          storage,
+        });
+        const result = await fixture.controller.clearFloor();
+
+        Assert.strictEqual(result.status, 'CLEARED');
+        Assert.strictEqual(events.includes('private-access'), false);
+        Assert.strictEqual(proxy.calls.clear, 1);
+
+      });
+
+  it('startup OFF reconciliation clears a resurrected exact floor',
+      async function() {
+
+        const identity = floor();
+        const events = [];
+        const storage = makeStorage(durable(identity), events);
+        const proxy = makeProxySettings({
+          levelOfControl: 'controlled_by_this_extension',
+          value: identity,
+        }, {}, events);
+        const fixture = makeController({events, proxy, storage});
+        const result = await fixture.controller.reconcileOffOnStartup();
+
+        Assert.strictEqual(result.status, 'CLEARED');
+        Assert.strictEqual(proxy.calls.set, 0);
+        Assert.strictEqual(proxy.calls.clear, 1);
+        Assert.deepStrictEqual(storage.values[OffState.STORAGE_KEY], durable());
+
+      });
+
+  it('startup OFF reconciliation never reacquires from persisted identity',
+      async function() {
+
+        const identity = floor();
+        const events = [];
+        const storage = makeStorage(durable(identity), events);
+        const proxy = makeProxySettings({
+          levelOfControl: 'controllable_by_this_extension',
+          value: {proxyType: 'manual', http: '127.0.0.1:58001'},
+        }, {}, events);
+        const fixture = makeController({events, proxy, storage});
+        const result = await fixture.controller.reconcileOffOnStartup();
+
+        Assert.strictEqual(result.error.code, 'OWNERSHIP_MISMATCH');
+        Assert.strictEqual(proxy.calls.set, 0);
+        Assert.strictEqual(proxy.calls.clear, 0);
+        Assert.deepStrictEqual(
+            storage.values[OffState.STORAGE_KEY],
+            durable(identity),
+        );
+
+      });
+
+  it('normalizes malformed persisted identity without touching live settings',
+      async function() {
+
+        const malformed = durable(Object.assign(
+            floor(),
+            {socks: '127.0.0.1:1'},
+        ));
+        const events = [];
+        const storage = makeStorage(malformed, events);
+        const proxy = makeProxySettings({
+          levelOfControl: 'controlled_by_this_extension',
+          value: floor(),
+        }, {}, events);
+        const fixture = makeController({events, proxy, storage});
+        const result = await fixture.controller.reconcileOffOnStartup();
+
+        Assert.strictEqual(result.status, 'ALREADY_CLEAR');
+        Assert.strictEqual(proxy.calls.get, 0);
+        Assert.strictEqual(proxy.calls.clear, 0);
+        Assert.deepStrictEqual(storage.values[OffState.STORAGE_KEY], durable());
+
+      });
+
+  it('retains identity when Clear fails so a later boot can reconcile',
+      async function() {
+
+        const identity = floor();
+        const events = [];
+        const storage = makeStorage(durable(identity), events);
+        const proxy = makeProxySettings({
+          levelOfControl: 'controlled_by_this_extension',
+          value: identity,
+        }, {clearError: new Error('clear failed')}, events);
+        const fixture = makeController({events, proxy, storage});
+        const result = await fixture.controller.clearFloor();
+
+        Assert.strictEqual(result.error.code, 'PROXY_CLEAR_FAILED');
+        Assert.deepStrictEqual(
+            storage.values[OffState.STORAGE_KEY],
+            durable(identity),
+        );
+
+      });
+
+  it('reconciles a crash after persistence and proxy set on the next context',
+      async function() {
+
+        const identity = floor();
+        const events = [];
+        const storage = makeStorage(durable(identity), events);
+        const proxy = makeProxySettings({
+          levelOfControl: 'controlled_by_this_extension',
+          value: identity,
+        }, {}, events);
+        const recreated = makeController({events, proxy, storage});
+        const result = await recreated.controller.reconcileOffOnStartup();
+
+        Assert.strictEqual(result.status, 'CLEARED');
+        Assert.strictEqual(recreated.ephemeralClears, 1);
+        Assert.deepStrictEqual(storage.values[OffState.STORAGE_KEY], durable());
+
+      });
+
+  it('serializes concurrent control operations', async function() {
+
+    const fixture = makeController();
+    const first = fixture.controller.clearFloor();
+    const second = fixture.controller.clearFloor();
+    const results = await Promise.all([first, second]);
+
+    Assert.deepStrictEqual(results.map((result) => result.status), [
+      'ALREADY_CLEAR',
+      'ALREADY_CLEAR',
+    ]);
+    Assert.strictEqual(fixture.ephemeralClears, 2);
+
+  });
+
+});

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/routing-adapter.test.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/routing-adapter.test.js
@@ -475,4 +475,22 @@ describe('Firefox fail-closed routing adapter', function() {
 
   });
 
+  it('clears every ephemeral authorization for OFF/Clear reconciliation',
+      function() {
+
+        const adapter = adapterForDecision(DIRECT_DECISION);
+        adapter.onProxyRequest({requestId: 'first'});
+        adapter.onProxyRequest({requestId: 'second'});
+        Assert.strictEqual(adapter.authorizationCount(), 2);
+
+        adapter.clearAllAuthorizations();
+
+        Assert.strictEqual(adapter.authorizationCount(), 0);
+        Assert.deepStrictEqual(
+            adapter.onBeforeRequest({requestId: 'first'}),
+            {cancel: true},
+        );
+
+      });
+
 });

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/skeleton.test.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/skeleton.test.js
@@ -15,6 +15,10 @@ const offStateSource = Fs.readFileSync(
     Path.join(sourceRoot, 'background', 'off-state.js'),
     'utf8',
 );
+const proxyControlSource = Fs.readFileSync(
+    Path.join(sourceRoot, 'background', 'proxy-control.js'),
+    'utf8',
+);
 const routingContractSource = Fs.readFileSync(
     Path.resolve(sourceRoot, '..', 'extension-mv3-common', 'routing-contract.js'),
     'utf8',
@@ -83,6 +87,11 @@ function startEventPage(options = {}) {
 
   const events = [];
   const storage = options.storage || makeStorage();
+  const proxySettingsCalls = {clear: 0, get: 0, set: 0};
+  let liveProxySettings = options.liveProxySettings || {
+    levelOfControl: 'controllable_by_this_extension',
+    value: {proxyType: 'none'},
+  };
   let messageListener;
   const networkListeners = {};
   const browser = {
@@ -115,6 +124,35 @@ function startEventPage(options = {}) {
 
           events.push('proxy-listener-registered');
           networkListeners.proxy = {filter, listener};
+
+        },
+      },
+      settings: {
+        async clear() {
+
+          proxySettingsCalls.clear += 1;
+          events.push('proxy-settings-clear');
+          liveProxySettings = options.afterClearProxySettings || {
+            levelOfControl: 'controllable_by_this_extension',
+            value: {proxyType: 'none'},
+          };
+
+        },
+        async get() {
+
+          proxySettingsCalls.get += 1;
+          events.push('proxy-settings-get');
+          return liveProxySettings;
+
+        },
+        async set(update) {
+
+          proxySettingsCalls.set += 1;
+          events.push('proxy-settings-set');
+          liveProxySettings = {
+            levelOfControl: 'controlled_by_this_extension',
+            value: update.value,
+          };
 
         },
       },
@@ -176,6 +214,7 @@ function startEventPage(options = {}) {
     filename: 'provider-dataset-state.js',
   });
   Vm.runInContext(offStateSource, context, {filename: 'off-state.js'});
+  Vm.runInContext(proxyControlSource, context, {filename: 'proxy-control.js'});
   Vm.runInContext(datasetStoreSource, context, {filename: 'dataset-store.js'});
   Vm.runInContext(providerLookupSource, context, {
     filename: 'provider-lookup.js',
@@ -191,6 +230,7 @@ function startEventPage(options = {}) {
     context,
     events,
     networkListeners,
+    proxySettingsCalls,
     storage,
     async ready() {
 
@@ -219,6 +259,7 @@ describe('Firefox MV3 inert skeleton', function() {
         'background/common/provider-dataset.js',
         'background/common/provider-dataset-state.js',
         'background/off-state.js',
+        'background/proxy-control.js',
         'background/dataset-store.js',
         'background/provider-lookup.js',
         'background/dataset-runtime.js',
@@ -261,11 +302,14 @@ describe('Firefox MV3 inert skeleton', function() {
       'OFF',
       {schemaVersion: 1, intent: 'ON'},
       {schemaVersion: 2, intent: 'OFF'},
+      {schemaVersion: 2, intent: 'OFF', floorIdentity: {invalid: true}},
+      {schemaVersion: 2, intent: 'OFF', floorIdentity: null, extra: true},
       {schemaVersion: 1, intent: 'OFF', extra: true},
     ]) {
       Assert.deepStrictEqual(OffState.normalizeDurableState(value), {
-        schemaVersion: 1,
+        schemaVersion: 2,
         intent: 'OFF',
+        floorIdentity: null,
       });
     }
 
@@ -276,9 +320,17 @@ describe('Firefox MV3 inert skeleton', function() {
     const storage = makeStorage();
     const state = await OffState.initialize(storage.area);
 
-    Assert.deepStrictEqual(state, {schemaVersion: 1, intent: 'OFF'});
+    Assert.deepStrictEqual(state, {
+      schemaVersion: 2,
+      intent: 'OFF',
+      floorIdentity: null,
+    });
     Assert.deepStrictEqual(storage.writes, [{
-      [OffState.STORAGE_KEY]: {schemaVersion: 1, intent: 'OFF'},
+      [OffState.STORAGE_KEY]: {
+        schemaVersion: 2,
+        intent: 'OFF',
+        floorIdentity: null,
+      },
     }]);
 
   });
@@ -290,15 +342,35 @@ describe('Firefox MV3 inert skeleton', function() {
 
     Assert.deepStrictEqual(
         JSON.parse(JSON.stringify(storage.values[OffState.STORAGE_KEY])), {
-          schemaVersion: 1,
+          schemaVersion: 2,
           intent: 'OFF',
+          floorIdentity: null,
         });
 
   });
 
-  it('does not rewrite canonical durable OFF', async function() {
+  it('migrates schema v1 OFF to schema v2 OFF', async function() {
 
     const storage = makeStorage({schemaVersion: 1, intent: 'OFF'});
+    await OffState.initialize(storage.area);
+
+    Assert.deepStrictEqual(storage.writes, [{
+      [OffState.STORAGE_KEY]: {
+        schemaVersion: 2,
+        intent: 'OFF',
+        floorIdentity: null,
+      },
+    }]);
+
+  });
+
+  it('does not rewrite canonical schema v2 durable OFF', async function() {
+
+    const storage = makeStorage({
+      schemaVersion: 2,
+      intent: 'OFF',
+      floorIdentity: null,
+    });
     await OffState.initialize(storage.area);
 
     Assert.deepStrictEqual(storage.writes, []);
@@ -396,6 +468,20 @@ describe('Firefox MV3 inert skeleton', function() {
 
   });
 
+  it('exposes exact-match Clear but never acquisition through RPC', async function() {
+
+    const eventPage = startEventPage();
+    const cleared = await eventPage.send({type: 'firefox.activation.clear'});
+
+    Assert.deepStrictEqual(cleared, {
+      ok: true,
+      result: {intent: 'OFF', status: 'ALREADY_CLEAR'},
+    });
+    Assert.strictEqual(eventPage.proxySettingsCalls.set, 0);
+    Assert.strictEqual(eventPage.proxySettingsCalls.clear, 0);
+
+  });
+
   it('recreates an event page with a fresh boot and the same OFF intent', async function() {
 
     const storage = makeStorage();
@@ -410,16 +496,18 @@ describe('Firefox MV3 inert skeleton', function() {
     Assert.strictEqual(capabilities.result.runtimeState, 'OFF');
     Assert.deepStrictEqual(
         JSON.parse(JSON.stringify(storage.values[OffState.STORAGE_KEY])), {
-          schemaVersion: 1,
+          schemaVersion: 2,
           intent: 'OFF',
+          floorIdentity: null,
         });
 
   });
 
-  it('contains no ownership, remote-fetch, or Chromium-state path', function() {
+  it('contains no activation, remote-fetch, or Chromium-state path', function() {
 
     const runtimeSource = [
       offStateSource,
+      proxyControlSource,
       datasetStoreSource,
       providerLookupSource,
       datasetRuntimeSource,
@@ -427,7 +515,6 @@ describe('Firefox MV3 inert skeleton', function() {
       eventPageSource,
     ].join('\n');
     for (const forbidden of [
-      'proxy.settings',
       'XMLHttpRequest',
       'fetch(',
       'extension-chromium-mv3',
@@ -436,6 +523,11 @@ describe('Firefox MV3 inert skeleton', function() {
     ]) {
       Assert.strictEqual(runtimeSource.includes(forbidden), false, forbidden);
     }
+    Assert.strictEqual(
+        eventPageSource.includes('acquirePrevalidatedFloor('),
+        false,
+    );
+    Assert.strictEqual(eventPageSource.includes('proxy.settings.set'), false);
 
   });
 

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/verify-package.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/verify-package.js
@@ -13,11 +13,11 @@ const EXPECTED_FILES = Object.freeze([
   'background/event-page.js',
   'background/off-state.js',
   'background/provider-lookup.js',
+  'background/proxy-control.js',
   'background/routing-adapter.js',
   'manifest.json',
 ]);
 const FORBIDDEN_RUNTIME_TEXT = Object.freeze([
-  'proxy.settings',
   'XMLHttpRequest',
   'fetch(',
   'BEGIN PRIVATE KEY',
@@ -88,6 +88,7 @@ function verifyPackage(packageRoot, sourceRoot) {
     'background/common/provider-dataset.js',
     'background/common/provider-dataset-state.js',
     'background/off-state.js',
+    'background/proxy-control.js',
     'background/dataset-store.js',
     'background/provider-lookup.js',
     'background/dataset-runtime.js',
@@ -104,6 +105,20 @@ function verifyPackage(packageRoot, sourceRoot) {
   for (const forbidden of FORBIDDEN_RUNTIME_TEXT) {
     Assert.strictEqual(runtimeText.includes(forbidden), false, forbidden);
   }
+  const eventPageText = Fs.readFileSync(
+      Path.join(packageRoot, 'background', 'event-page.js'),
+      'utf8',
+  );
+  Assert.strictEqual(eventPageText.includes('proxy.settings.set'), false);
+  Assert.strictEqual(eventPageText.includes('acquirePrevalidatedFloor('), false);
+  Assert.strictEqual(
+      eventPageText.includes('type === \'firefox.activation.apply\''),
+      true,
+  );
+  Assert.strictEqual(
+      eventPageText.includes('errorResponse(\'ACTIVATION_NOT_IMPLEMENTED\')'),
+      true,
+  );
 
   return Object.freeze({files});
 
@@ -116,7 +131,7 @@ if (require.main === module) {
       Path.join(projectRoot, 'src', 'extension-firefox-mv3'),
   );
   console.log(
-      `Verified OFF-only Firefox MV3 dataset package: ${result.files.length} files.`,
+      `Verified OFF-only Firefox MV3 control package: ${result.files.length} files.`,
   );
 }
 


### PR DESCRIPTION
## Summary

- adds Firefox-only fail-closed proxy ownership and Clear primitives while the shipped package remains durable `OFF`
- evolves the durable state to schema v2: `{ schemaVersion: 2, intent: "OFF", floorIdentity }`, with safe schema-v1 migration and malformed/future-state normalization to OFF without an identity
- validates only the canonical manual SOCKS5 floor at a persisted random high `127.0.0.1` port, with empty HTTP/SSL/auto-config/passthrough fields, `httpProxyAll: false`, and `proxyDNS: true`
- requires both `controlled_by_this_extension` and an exact normalized identity match before Clear; Firefox's normalized `autoLogin: false` is checked explicitly and is not persisted
- provides a test/future-only `acquirePrevalidatedFloor` primitive gated on granted private access and an explicit external port-prevalidation assertion
- persists cleanup identity before `proxy.settings.set`, confirms exact ownership afterward, and retains identity across interrupted or failed reconciliation
- adds `firefox.activation.clear`; `firefox.activation.apply` still returns `ACTIVATION_NOT_IMPLEMENTED`

## Safety and lifecycle

- production startup never acquires or sets a floor
- OFF startup clears only an exact resurrected extension-owned floor, including when private-window access has been revoked
- Clear persists OFF first, drops ephemeral requestId budgets, clears only an exact owned floor, confirms release, and only then removes cleanup identity
- ownership mismatch returns `OWNERSHIP_MISMATCH` without overwriting or clearing the live setting
- there is no provider data, updater, authentication, health, UI, remote traffic, or release code in this PR
- WebExtension APIs cannot conclusively prove that no local process owns a port; production acquisition remains unwired and future callers must externally prevalidate a randomly generated high-port candidate. Local-port collision remains a documented residual assumption.

## Verification

- supply-chain verifier: 11 exact direct pins; focused tests 11/11
- PAC regression: 26/26
- Chromium MV3: 428/428
- Firefox deterministic: 101/101
- aggregate: 546/546
- Firefox 154.0.1 production-package lifecycle smoke: genuine idle event-page recreation, OFF v2 retained, previous manual proxy unchanged
- Firefox 154.0.1 proxy-control smoke: production OFF, v1 migration, granted/denied acquisition, exact/mismatch Clear, permission revoke, disable/re-enable resurrection reconciliation, and previous-manual-proxy network markers all passed
- unexpected protected-origin contacts: 0
- Firefox package: 11 allowlisted files; no test fixture/profile/result is packaged
- Chromium runtime: 70 vs 70 files; added 0; missing 0; SHA-256 differences 0
- dependencies and lockfile: unchanged

This PR does not implement activation and does not publish or release a Firefox package.
