### PR TITLE
Add request-scoped Firefox proxy authentication

### DIFF
--- a/docs/development/FIREFOX_MV3_SKELETON.md
+++ b/docs/development/FIREFOX_MV3_SKELETON.md
@@ -74,8 +74,33 @@ reconciliation очищает его даже при denied private access и о
 OFF. RPC `firefox.activation.clear` предоставляет только этот безопасный Clear;
 он не вызывает `proxy.settings.set`.
 
-Реальный provider dataset, updater, активация, аутентификация и health-проверки
-ещё не реализованы. Ownership primitives не делают routing доступным. Команда
+Firefox-specific proxy authentication регистрируется синхронно через
+блокирующий `webRequest.onAuthRequired`, но shipped OFF-only event page
+использует пустой in-memory credential resolver. `authRef` остаётся непрозрачной
+routing metadata: он хранится только в bounded request-scoped map и никогда не
+попадает в Firefox `ProxyInfo`. Username/password не являются полями routing
+decision, не сохраняются, не логируются, не выдаются через RPC и diagnostics.
+
+Auth handler возвращает credentials только при одновременном совпадении
+активного `requestId`, выбранного в `onBeforeRequest.details.proxyInfo` proxy и
+challenger host/port с одним validated route candidate и его `authRef`. Origin
+authentication при активной защите отменяется; в `OFF` listener возвращает no
+override и не вмешивается в постороннюю browser auth. Missing credentials,
+mismatch, malformed state и внутренний failure отменяют challenge, не открывая
+Firefox proxy-auth prompt.
+
+Firefox 154 повторно вызывает `onBeforeRequest` с тем же `requestId` после
+каждого credential response. Поэтому routing и auth используют раздельные
+budgets: непосредственно перед возвратом credentials auth разрешает ровно один
+дополнительный guard callback. На request/challenger допускается максимум два
+credential response. Terminal event, Clear и event-page recreation очищают как
+route-auth, так и attempt state. Отмена исчерпанного auth challenge завершает
+request вместо перехода к следующему proxy candidate; это известное Firefox
+availability-отличие, а не Direct fallback или утечка.
+
+Реальный provider dataset, updater, активация, production credential
+configuration/UI и health-проверки ещё не реализованы. Ownership/auth
+primitives не делают routing доступным. Команда
 активации всегда отвечает
 `ACTIVATION_NOT_IMPLEMENTED`; наличие широких сетевых разрешений не делает
 маршрутизацию доступной пользователю.

--- a/extensions/chromium/runet-censorship-bypass/gulpfile.js
+++ b/extensions/chromium/runet-censorship-bypass/gulpfile.js
@@ -92,6 +92,7 @@ const firefoxMv3RuntimeSrc = [
   './src/extension-firefox-mv3/background/provider-lookup.js',
   './src/extension-firefox-mv3/background/dataset-runtime.js',
   './src/extension-firefox-mv3/background/routing-adapter.js',
+  './src/extension-firefox-mv3/background/proxy-auth.js',
   './src/extension-firefox-mv3/background/event-page.js',
 ];
 const firefoxMv3CommonSrc = [

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/background/event-page.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/background/event-page.js
@@ -4,6 +4,7 @@
 
   const offState = root.rucbFirefoxOffState;
   const proxyControlApi = root.rucbFirefoxProxyControl;
+  const proxyAuthApi = root.rucbFirefoxProxyAuth;
   const routing = root.rucbFirefoxRoutingAdapter;
   const datasetRuntime = root.rucbFirefoxDatasetRuntime.createRuntime({
     protectionIntended: false,
@@ -13,12 +14,23 @@
     runtimeStateForRequest: datasetRuntime.getState,
     routingInputForRequest: datasetRuntime.routingInputForRequest,
   });
+  const proxyAuth = proxyAuthApi.createHandler({
+    routingAdapter,
+    // Production credential state and activation are deliberately absent.
+    resolveCredentials: () => null,
+  });
+  function clearEphemeralState() {
+
+    routingAdapter.clearAllAuthorizations();
+    proxyAuth.clearAllAttempts();
+
+  }
   const proxyControl = proxyControlApi.createController({
     proxySettings: browser.proxy.settings,
     storageArea: browser.storage.local,
     isPrivateAccessAllowed: () =>
       browser.extension.isAllowedIncognitoAccess(),
-    clearEphemeralState: routingAdapter.clearAllAuthorizations,
+    clearEphemeralState,
   });
   const durableIntent = offState.OFF;
   const bootId = root.crypto && typeof root.crypto.randomUUID === 'function' ?
@@ -91,12 +103,23 @@
       {urls: ['<all_urls>']},
       ['blocking'],
   );
+  browser.webRequest.onAuthRequired.addListener(
+      proxyAuth.onAuthRequired,
+      {urls: ['<all_urls>']},
+      ['blocking'],
+  );
+  function onRequestTerminal(details) {
+
+    routingAdapter.onRequestTerminal(details);
+    proxyAuth.onRequestTerminal(details);
+
+  }
   browser.webRequest.onCompleted.addListener(
-      routingAdapter.onRequestTerminal,
+      onRequestTerminal,
       {urls: ['<all_urls>']},
   );
   browser.webRequest.onErrorOccurred.addListener(
-      routingAdapter.onRequestTerminal,
+      onRequestTerminal,
       {urls: ['<all_urls>']},
   );
   browser.runtime.onMessage.addListener(handleMessage);

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/background/proxy-auth.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/background/proxy-auth.js
@@ -1,0 +1,170 @@
+'use strict';
+
+(function publishFirefoxProxyAuth(root, factory) {
+
+  const api = factory();
+  if (typeof module === 'object' && module.exports) {
+    module.exports = api;
+    return;
+  }
+  root.rucbFirefoxProxyAuth = api;
+
+})(typeof globalThis === 'object' ? globalThis : this, function() {
+
+  const MAX_AUTH_ATTEMPTS_PER_REQUEST_CHALLENGER = 2;
+  const MAX_AUTH_ATTEMPT_ENTRIES = 256;
+  const CANCEL = Object.freeze({cancel: true});
+  const STATES = Object.freeze({
+    OFF: 'OFF',
+    INITIALIZING: 'INITIALIZING',
+    READY: 'READY',
+    FAILED: 'FAILED',
+  });
+
+  function isRequestId(value) {
+
+    return (typeof value === 'string' || typeof value === 'number') &&
+      String(value).length > 0;
+
+  }
+
+  function validCredentials(value) {
+
+    return Boolean(value) && typeof value === 'object' &&
+      !Array.isArray(value) && typeof value.username === 'string' &&
+      typeof value.password === 'string' &&
+      !(value && typeof value.then === 'function');
+
+  }
+
+  function createHandler(options = {}) {
+
+    const routingAdapter = options.routingAdapter;
+    const resolveCredentials = options.resolveCredentials;
+    let attempts = options.attempts || new Map();
+    if (!routingAdapter ||
+        typeof routingAdapter.currentRuntimeState !== 'function' ||
+        typeof routingAdapter.authenticationForChallenge !== 'function' ||
+        typeof routingAdapter.authorizeAuthenticationRetry !== 'function' ||
+        typeof resolveCredentials !== 'function') {
+      throw new TypeError('INVALID_FIREFOX_PROXY_AUTH_OPTIONS');
+    }
+
+    function resetAttempts() {
+
+      attempts = new Map();
+
+    }
+
+    function clearAllAttempts() {
+
+      resetAttempts();
+
+    }
+
+    function clearRequest(details) {
+
+      const requestId = details && details.requestId;
+      try {
+        if (!isRequestId(requestId)) {
+          return;
+        }
+        const prefix = `${String(requestId)}\u0000`;
+        for (const key of attempts.keys()) {
+          if (key.startsWith(prefix)) {
+            attempts.delete(key);
+          }
+        }
+      } catch (_error) {
+        resetAttempts();
+      }
+
+    }
+
+    function onAuthRequired(details) {
+
+      try {
+        const state = routingAdapter.currentRuntimeState();
+        if (state === STATES.OFF) {
+          return undefined;
+        }
+        if (state !== STATES.READY || !details ||
+            details.isProxy !== true || !isRequestId(details.requestId)) {
+          return CANCEL;
+        }
+        const authentication =
+          routingAdapter.authenticationForChallenge(details);
+        if (!authentication || typeof authentication.authRef !== 'string' ||
+            typeof authentication.endpointKey !== 'string') {
+          return CANCEL;
+        }
+        const attemptKey =
+          `${String(details.requestId)}\u0000${authentication.endpointKey}`;
+        const current = attempts.get(attemptKey);
+        const count = current === undefined ? 0 : current;
+        if (!Number.isSafeInteger(count) || count < 0 ||
+            count >= MAX_AUTH_ATTEMPTS_PER_REQUEST_CHALLENGER) {
+          return CANCEL;
+        }
+        const credentials = resolveCredentials(authentication.authRef);
+        if (!validCredentials(credentials)) {
+          return CANCEL;
+        }
+        if (!attempts.has(attemptKey) &&
+            attempts.size >= MAX_AUTH_ATTEMPT_ENTRIES) {
+          return CANCEL;
+        }
+        const response = {
+          authCredentials: {
+            username: credentials.username,
+            password: credentials.password,
+          },
+        };
+        attempts.set(attemptKey, count + 1);
+        if (!routingAdapter.authorizeAuthenticationRetry(
+            details,
+            authentication.authRef,
+        )) {
+          if (count === 0) {
+            attempts.delete(attemptKey);
+          } else {
+            attempts.set(attemptKey, count);
+          }
+          return CANCEL;
+        }
+        return response;
+      } catch (_error) {
+        return CANCEL;
+      }
+
+    }
+
+    function attemptCount() {
+
+      try {
+        return attempts.size;
+      } catch (_error) {
+        resetAttempts();
+        return 0;
+      }
+
+    }
+
+    return Object.freeze({
+      attemptCount,
+      clearAllAttempts,
+      onAuthRequired,
+      onRequestTerminal: clearRequest,
+    });
+
+  }
+
+  return Object.freeze({
+    CANCEL,
+    MAX_AUTH_ATTEMPTS_PER_REQUEST_CHALLENGER,
+    MAX_AUTH_ATTEMPT_ENTRIES,
+    createHandler,
+    validCredentials,
+  });
+
+});

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/background/routing-adapter.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/background/routing-adapter.js
@@ -23,6 +23,7 @@
   });
   const MAX_AUTHORIZATIONS = 256;
   const MAX_CALLBACK_BUDGET = 256;
+  const AUTH_REF_PATTERN = /^[A-Za-z0-9._:-]{1,128}$/;
   const ALLOW = Object.freeze({cancel: false});
   const CANCEL = Object.freeze({cancel: true});
   const DEFAULT_ROUTE = Object.freeze({type: 'direct'});
@@ -51,6 +52,40 @@
 
   }
 
+  function normalizeHost(value) {
+
+    return String(value || '').trim().replace(/^\[|\]$/g, '').toLowerCase();
+
+  }
+
+  function normalizeProxyType(value) {
+
+    const type = String(value || '').trim().toLowerCase();
+    if (type === 'socks5') {
+      return 'socks';
+    }
+    return Object.values(FIREFOX_TYPES).includes(type) ? type : null;
+
+  }
+
+  function validAuthRef(value) {
+
+    return value === null ||
+      (typeof value === 'string' && AUTH_REF_PATTERN.test(value));
+
+  }
+
+  function endpointKey(host, port) {
+
+    const normalizedHost = normalizeHost(host);
+    const normalizedPort = Number(port);
+    return normalizedHost && Number.isSafeInteger(normalizedPort) &&
+      normalizedPort >= 1 && normalizedPort <= 65535 ?
+      `${normalizedHost}:${normalizedPort}` :
+      null;
+
+  }
+
   function candidateToProxyInfo(candidate) {
 
     if (!candidate || typeof candidate !== 'object' ||
@@ -62,7 +97,7 @@
         !Number.isSafeInteger(candidate.port) ||
         candidate.port < 1 || candidate.port > 65535 ||
         typeof candidate.proxyDNS !== 'boolean' ||
-        candidate.authRef !== null ||
+        !validAuthRef(candidate.authRef) ||
         typeof candidate.id !== 'string' || !candidate.id) {
       return null;
     }
@@ -86,15 +121,13 @@
 
   }
 
-  function convertDecision(decision) {
+  function convertDecisionDetails(decision) {
 
     if (!decision || typeof decision !== 'object' || Array.isArray(decision)) {
       return null;
     }
     if (decision.kind === Routing.KINDS.DIRECT) {
-      // Firefox treats only top-level null as true Direct. A ProxyInfo Direct
-      // continues through browser/global proxy settings.
-      return {proxyResult: null, callbackBudget: 1};
+      return {proxyResult: null, callbackBudget: 1, authCandidates: []};
     }
     if (decision.kind === Routing.KINDS.FAIL_CLOSED) {
       return null;
@@ -107,12 +140,27 @@
       return null;
     }
     const proxies = [];
+    const authCandidates = [];
+    const authRefsByEndpoint = new Map();
     for (const candidate of decision.candidates) {
       const proxyInfo = candidateToProxyInfo(candidate);
-      if (!proxyInfo) {
+      const key = endpointKey(candidate && candidate.host, candidate && candidate.port);
+      if (!proxyInfo || !key) {
         return null;
       }
+      if (authRefsByEndpoint.has(key) &&
+          authRefsByEndpoint.get(key) !== candidate.authRef) {
+        return null;
+      }
+      authRefsByEndpoint.set(key, candidate.authRef);
       proxies.push(proxyInfo);
+      authCandidates.push(Object.freeze({
+        type: proxyInfo.type,
+        host: normalizeHost(proxyInfo.host),
+        port: proxyInfo.port,
+        endpointKey: key,
+        authRef: candidate.authRef,
+      }));
     }
     // A trailing null terminates Firefox proxy fallback and does not produce
     // another webRequest callback, so it is intentionally outside the budget.
@@ -120,6 +168,7 @@
     const converted = {
       proxyResult: proxies,
       callbackBudget: proxies.length - 1,
+      authCandidates: Object.freeze(authCandidates),
     };
     if (decision.fallback === Routing.FALLBACKS.DIRECT) {
       // Firefox arrays cannot express a true terminal Direct route. Preserve
@@ -130,6 +179,23 @@
         DEGRADATION_CODES.PROXY_DIRECT_FALLBACK_STRIPPED;
     }
     return converted;
+
+  }
+
+  function convertDecision(decision) {
+
+    const converted = convertDecisionDetails(decision);
+    if (!converted) {
+      return null;
+    }
+    const result = {
+      proxyResult: converted.proxyResult,
+      callbackBudget: converted.callbackBudget,
+    };
+    if (converted.degradationCode) {
+      result.degradationCode = converted.degradationCode;
+    }
+    return result;
 
   }
 
@@ -144,6 +210,7 @@
     const decideRoute = options.decideRoute || Routing.decideRoute;
     const routingInputForRequest = options.routingInputForRequest;
     let authorizations = options.authorizations || new Map();
+    let requestAuthContexts = options.requestAuthContexts || new Map();
 
     function currentRuntimeState() {
 
@@ -155,15 +222,16 @@
 
     }
 
-    function resetAuthorizations() {
+    function resetEphemeralState() {
 
       authorizations = new Map();
+      requestAuthContexts = new Map();
 
     }
 
     function clearAllAuthorizations() {
 
-      resetAuthorizations();
+      resetEphemeralState();
 
     }
 
@@ -171,28 +239,39 @@
 
       try {
         authorizations.delete(requestId);
+        requestAuthContexts.delete(requestId);
       } catch (_error) {
-        resetAuthorizations();
+        resetEphemeralState();
       }
 
     }
 
-    function authorize(requestId, callbackBudget) {
+    function authorize(requestId, callbackBudget, authCandidates) {
 
       if (!isRequestId(requestId) ||
           !Number.isSafeInteger(callbackBudget) || callbackBudget < 1 ||
-          callbackBudget > MAX_CALLBACK_BUDGET) {
+          callbackBudget > MAX_CALLBACK_BUDGET ||
+          !Array.isArray(authCandidates)) {
         return false;
       }
       try {
         authorizations.delete(requestId);
-        if (authorizations.size >= MAX_AUTHORIZATIONS) {
+        requestAuthContexts.delete(requestId);
+        if (authorizations.size >= MAX_AUTHORIZATIONS ||
+            requestAuthContexts.size >= MAX_AUTHORIZATIONS) {
           return false;
         }
         authorizations.set(requestId, callbackBudget);
-        return authorizations.size <= MAX_AUTHORIZATIONS;
+        if (authCandidates.length) {
+          requestAuthContexts.set(requestId, {
+            candidates: authCandidates,
+            selected: null,
+          });
+        }
+        return authorizations.size <= MAX_AUTHORIZATIONS &&
+          requestAuthContexts.size <= MAX_AUTHORIZATIONS;
       } catch (_error) {
-        resetAuthorizations();
+        resetEphemeralState();
         return false;
       }
 
@@ -212,8 +291,12 @@
           return DEFAULT_ROUTE;
         }
         const decision = decideRoute(routingInputForRequest(details));
-        const converted = convertDecision(decision);
-        if (!converted || !authorize(requestId, converted.callbackBudget)) {
+        const converted = convertDecisionDetails(decision);
+        if (!converted || !authorize(
+            requestId,
+            converted.callbackBudget,
+            converted.authCandidates,
+        )) {
           clearAuthorization(requestId);
           return DEFAULT_ROUTE;
         }
@@ -222,6 +305,27 @@
         clearAuthorization(requestId);
         return DEFAULT_ROUTE;
       }
+
+    }
+
+    function observeSelectedProxy(details) {
+
+      const requestId = details && details.requestId;
+      const context = requestAuthContexts.get(requestId);
+      if (!context) {
+        return;
+      }
+      const proxyInfo = details && details.proxyInfo;
+      const key = endpointKey(
+          proxyInfo && proxyInfo.host,
+          proxyInfo && proxyInfo.port,
+      );
+      const type = normalizeProxyType(proxyInfo && proxyInfo.type);
+      context.selected = key && type ?
+        context.candidates.find((candidate) =>
+          candidate.endpointKey === key && candidate.type === type,
+        ) || null :
+        null;
 
     }
 
@@ -236,6 +340,7 @@
           return CANCEL;
         }
         const requestId = details.requestId;
+        observeSelectedProxy(details);
         const remaining = authorizations.get(requestId);
         if (!Number.isSafeInteger(remaining) || remaining < 1 ||
             remaining > MAX_CALLBACK_BUDGET) {
@@ -249,8 +354,64 @@
         }
         return ALLOW;
       } catch (_error) {
-        resetAuthorizations();
+        resetEphemeralState();
         return CANCEL;
+      }
+
+    }
+
+    function authenticationForChallenge(details) {
+
+      try {
+        if (currentRuntimeState() !== STATES.READY ||
+            !details || details.isProxy !== true ||
+            !isRequestId(details.requestId)) {
+          return null;
+        }
+        const context = requestAuthContexts.get(details.requestId);
+        const selected = context && context.selected;
+        const challenger = details.challenger;
+        const key = endpointKey(
+            challenger && challenger.host,
+            challenger && challenger.port,
+        );
+        if (!selected || !Array.isArray(context.candidates) ||
+            !context.candidates.includes(selected) ||
+            !validAuthRef(selected.authRef) || selected.authRef === null ||
+            typeof selected.endpointKey !== 'string' ||
+            key !== selected.endpointKey) {
+          return null;
+        }
+        return Object.freeze({
+          authRef: selected.authRef,
+          endpointKey: selected.endpointKey,
+        });
+      } catch (_error) {
+        resetEphemeralState();
+        return null;
+      }
+
+    }
+
+    function authorizeAuthenticationRetry(details, expectedAuthRef) {
+
+      try {
+        const authentication = authenticationForChallenge(details);
+        if (!authentication || authentication.authRef !== expectedAuthRef) {
+          return false;
+        }
+        const current = authorizations.get(details.requestId);
+        const remaining = current === undefined ? 0 : current;
+        if (!Number.isSafeInteger(remaining) || remaining < 0 ||
+            remaining >= MAX_CALLBACK_BUDGET) {
+          resetEphemeralState();
+          return false;
+        }
+        authorizations.set(details.requestId, remaining + 1);
+        return true;
+      } catch (_error) {
+        resetEphemeralState();
+        return false;
       }
 
     }
@@ -266,14 +427,28 @@
       try {
         return authorizations.size;
       } catch (_error) {
-        resetAuthorizations();
+        resetEphemeralState();
+        return 0;
+      }
+
+    }
+
+    function authContextCount() {
+
+      try {
+        return requestAuthContexts.size;
+      } catch (_error) {
+        resetEphemeralState();
         return 0;
       }
 
     }
 
     const api = {
+      authenticationForChallenge,
+      authorizeAuthenticationRetry,
       authorizationCount,
+      authContextCount,
       clearAllAuthorizations,
       currentRuntimeState,
       onBeforeRequest,
@@ -298,6 +473,7 @@
     candidateToProxyInfo,
     convertDecision,
     createAdapter,
+    validAuthRef,
   });
 
 });

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/manifest.json
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/manifest.json
@@ -23,6 +23,7 @@
       "background/provider-lookup.js",
       "background/dataset-runtime.js",
       "background/routing-adapter.js",
+      "background/proxy-auth.js",
       "background/event-page.js"
     ],
     "persistent": false

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/proxy-auth.test.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/proxy-auth.test.js
@@ -1,0 +1,379 @@
+'use strict';
+
+const Assert = require('node:assert');
+const Routing = require('../../extension-mv3-common/routing-contract');
+const Adapter = require('../background/routing-adapter');
+const ProxyAuth = require('../background/proxy-auth');
+
+const FIXTURE_CREDENTIALS = Object.freeze({
+  username: 'fixture-user',
+  password: 'fixture-password',
+});
+
+function candidate(id, host, port, authRef = null) {
+
+  return {
+    id,
+    type: 'HTTP',
+    host,
+    port,
+    proxyDNS: false,
+    authRef,
+    failoverTimeoutSeconds: null,
+  };
+
+}
+
+function decision(candidates) {
+
+  return {
+    kind: Routing.KINDS.PROXY,
+    source: Routing.SOURCES.EXPLICIT_PROXY,
+    candidates,
+    fallback: Routing.FALLBACKS.FAIL_CLOSED,
+  };
+
+}
+
+function fixture(options = {}) {
+
+  let state = options.state || Adapter.STATES.READY;
+  const decisions = options.decisions || {
+    request: decision([
+      candidate('authenticated', 'proxy.test', 8080, 'fixture-auth'),
+    ]),
+  };
+  const routingAdapter = Adapter.createAdapter({
+    runtimeStateForRequest: () => state,
+    decideRoute: (value) => value,
+    routingInputForRequest: (details) => decisions[details.requestId],
+  });
+  const proxyAuth = ProxyAuth.createHandler({
+    routingAdapter,
+    resolveCredentials: options.resolveCredentials ||
+      (() => FIXTURE_CREDENTIALS),
+    attempts: options.attempts,
+  });
+  return {
+    proxyAuth,
+    routingAdapter,
+    setState(value) {
+
+      state = value;
+
+    },
+  };
+
+}
+
+function select(fixtureValue, requestId = 'request', host = 'proxy.test',
+    port = 8080) {
+
+  fixtureValue.routingAdapter.onProxyRequest({requestId});
+  return fixtureValue.routingAdapter.onBeforeRequest({
+    requestId,
+    proxyInfo: {type: 'http', host, port},
+  });
+
+}
+
+function challenge(requestId = 'request', host = 'proxy.test', port = 8080,
+    overrides = {}) {
+
+  return Object.assign({
+    requestId,
+    isProxy: true,
+    challenger: {host, port},
+  }, overrides);
+
+}
+
+describe('Firefox request-scoped proxy authentication', function() {
+
+  it('does not interfere while the durable runtime is OFF', function() {
+
+    let resolverCalls = 0;
+    const current = fixture({
+      state: Adapter.STATES.OFF,
+      resolveCredentials() {
+
+        resolverCalls += 1;
+        return FIXTURE_CREDENTIALS;
+
+      },
+    });
+
+    Assert.strictEqual(current.proxyAuth.onAuthRequired(challenge()), undefined);
+    Assert.strictEqual(resolverCalls, 0);
+    Assert.strictEqual(current.proxyAuth.attemptCount(), 0);
+
+  });
+
+  it('cancels every challenge while INITIALIZING or FAILED', function() {
+
+    for (const state of [Adapter.STATES.INITIALIZING, Adapter.STATES.FAILED]) {
+      const current = fixture({state});
+      Assert.deepStrictEqual(
+          current.proxyAuth.onAuthRequired(challenge()),
+          {cancel: true},
+      );
+    }
+
+  });
+
+  it('never answers an origin authentication challenge while active',
+      function() {
+
+        let resolverCalls = 0;
+        const current = fixture({
+          resolveCredentials() {
+
+            resolverCalls += 1;
+            return FIXTURE_CREDENTIALS;
+
+          },
+        });
+        select(current);
+
+        Assert.deepStrictEqual(current.proxyAuth.onAuthRequired(challenge(
+            'request',
+            'origin.test',
+            80,
+            {isProxy: false},
+        )), {cancel: true});
+        Assert.strictEqual(resolverCalls, 0);
+
+      });
+
+  it('requires the exact active request, selected proxy, and challenger',
+      function() {
+
+        const current = fixture();
+        select(current);
+
+        for (const details of [
+          challenge('unknown'),
+          challenge('request', 'proxy.test', 8081),
+          challenge('request', 'other.test', 8080),
+        ]) {
+          Assert.deepStrictEqual(
+              current.proxyAuth.onAuthRequired(details),
+              {cancel: true},
+          );
+        }
+        Assert.strictEqual(current.proxyAuth.attemptCount(), 0);
+        Assert.strictEqual(current.routingAdapter.authorizationCount(), 0);
+
+      });
+
+  it('cancels missing, asynchronous, or failed credential resolution',
+      function() {
+
+        for (const resolveCredentials of [
+          () => null,
+          () => Promise.resolve(FIXTURE_CREDENTIALS),
+          () => {
+
+            throw new Error('injected resolver failure');
+
+          },
+        ]) {
+          const current = fixture({resolveCredentials});
+          select(current);
+          Assert.deepStrictEqual(
+              current.proxyAuth.onAuthRequired(challenge()),
+              {cancel: true},
+          );
+          Assert.strictEqual(current.routingAdapter.authorizationCount(), 0);
+          Assert.strictEqual(current.proxyAuth.attemptCount(), 0);
+        }
+
+      });
+
+  it('adds exactly one callback before each credential response', function() {
+
+    const current = fixture();
+    Assert.deepStrictEqual(select(current), {cancel: false});
+    Assert.strictEqual(current.routingAdapter.authorizationCount(), 0);
+
+    for (let attempt = 1; attempt <= 2; attempt += 1) {
+      Assert.deepStrictEqual(current.proxyAuth.onAuthRequired(challenge()), {
+        authCredentials: FIXTURE_CREDENTIALS,
+      });
+      Assert.strictEqual(current.routingAdapter.authorizationCount(), 1);
+      Assert.deepStrictEqual(current.routingAdapter.onBeforeRequest({
+        requestId: 'request',
+        proxyInfo: {type: 'http', host: 'proxy.test', port: 8080},
+      }), {cancel: false});
+      Assert.strictEqual(current.routingAdapter.authorizationCount(), 0);
+    }
+    Assert.strictEqual(current.proxyAuth.attemptCount(), 1);
+
+  });
+
+  it('permits wrong then correct credentials across three callbacks', function() {
+
+    let resolverCalls = 0;
+    const current = fixture({
+      resolveCredentials() {
+
+        resolverCalls += 1;
+        return resolverCalls === 1 ? {
+          username: 'fixture-wrong',
+          password: 'fixture-wrong',
+        } : FIXTURE_CREDENTIALS;
+
+      },
+    });
+    let beforeRequestCallbacks = 0;
+    Assert.deepStrictEqual(select(current), {cancel: false});
+    beforeRequestCallbacks += 1;
+
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      const result = current.proxyAuth.onAuthRequired(challenge());
+      Assert.ok(result.authCredentials);
+      Assert.deepStrictEqual(current.routingAdapter.onBeforeRequest({
+        requestId: 'request',
+        proxyInfo: {type: 'http', host: 'proxy.test', port: 8080},
+      }), {cancel: false});
+      beforeRequestCallbacks += 1;
+    }
+    Assert.strictEqual(resolverCalls, 2);
+    Assert.strictEqual(beforeRequestCallbacks, 3);
+
+  });
+
+  it('cancels attempt three without authorizing another callback', function() {
+
+    const current = fixture();
+    select(current);
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      current.proxyAuth.onAuthRequired(challenge());
+      current.routingAdapter.onBeforeRequest({
+        requestId: 'request',
+        proxyInfo: {type: 'http', host: 'proxy.test', port: 8080},
+      });
+    }
+
+    Assert.deepStrictEqual(current.proxyAuth.onAuthRequired(challenge()), {
+      cancel: true,
+    });
+    Assert.strictEqual(current.routingAdapter.authorizationCount(), 0);
+    Assert.deepStrictEqual(current.routingAdapter.onBeforeRequest({
+      requestId: 'request',
+      proxyInfo: {type: 'http', host: 'proxy.test', port: 8080},
+    }), {cancel: true});
+
+  });
+
+  it('isolates concurrent authRefs at the same endpoint by requestId',
+      function() {
+
+        const current = fixture({
+          decisions: {
+            first: decision([
+              candidate('one', 'proxy.test', 8080, 'auth-one'),
+            ]),
+            second: decision([
+              candidate('two', 'proxy.test', 8080, 'auth-two'),
+            ]),
+          },
+          resolveCredentials(authRef) {
+
+            return {
+              username: `fixture-${authRef}`,
+              password: `fixture-${authRef}`,
+            };
+
+          },
+        });
+        select(current, 'first');
+        select(current, 'second');
+
+        Assert.deepStrictEqual(
+            current.proxyAuth.onAuthRequired(challenge('second')),
+            {authCredentials: {
+              username: 'fixture-auth-two',
+              password: 'fixture-auth-two',
+            }},
+        );
+        Assert.deepStrictEqual(
+            current.proxyAuth.onAuthRequired(challenge('first')),
+            {authCredentials: {
+              username: 'fixture-auth-one',
+              password: 'fixture-auth-one',
+            }},
+        );
+
+      });
+
+  it('supports closed A followed by authenticated B with three callbacks',
+      function() {
+
+        const current = fixture({
+          decisions: {
+            request: decision([
+              candidate('closed', 'closed.test', 8001),
+              candidate('authenticated', 'proxy.test', 8080, 'fixture-auth'),
+            ]),
+          },
+        });
+        Assert.deepStrictEqual(select(current, 'request', 'closed.test', 8001), {
+          cancel: false,
+        });
+        Assert.deepStrictEqual(current.routingAdapter.onBeforeRequest({
+          requestId: 'request',
+          proxyInfo: {type: 'http', host: 'proxy.test', port: 8080},
+        }), {cancel: false});
+        Assert.deepStrictEqual(current.proxyAuth.onAuthRequired(challenge()), {
+          authCredentials: FIXTURE_CREDENTIALS,
+        });
+        Assert.deepStrictEqual(current.routingAdapter.onBeforeRequest({
+          requestId: 'request',
+          proxyInfo: {type: 'http', host: 'proxy.test', port: 8080},
+        }), {cancel: false});
+
+      });
+
+  it('cleans route and attempt metadata on terminal events and Clear', function() {
+
+    const current = fixture();
+    select(current);
+    current.proxyAuth.onAuthRequired(challenge());
+    Assert.strictEqual(current.routingAdapter.authContextCount(), 1);
+    Assert.strictEqual(current.proxyAuth.attemptCount(), 1);
+
+    current.routingAdapter.onRequestTerminal({requestId: 'request'});
+    current.proxyAuth.onRequestTerminal({requestId: 'request'});
+    Assert.strictEqual(current.routingAdapter.authorizationCount(), 0);
+    Assert.strictEqual(current.routingAdapter.authContextCount(), 0);
+    Assert.strictEqual(current.proxyAuth.attemptCount(), 0);
+
+    select(current);
+    current.proxyAuth.onAuthRequired(challenge());
+    current.routingAdapter.clearAllAuthorizations();
+    current.proxyAuth.clearAllAttempts();
+    Assert.strictEqual(current.routingAdapter.authContextCount(), 0);
+    Assert.strictEqual(current.proxyAuth.attemptCount(), 0);
+
+  });
+
+  it('starts a recreated event page with no request or auth metadata',
+      function() {
+
+        const first = fixture();
+        select(first);
+        first.proxyAuth.onAuthRequired(challenge());
+        const recreated = fixture();
+
+        Assert.strictEqual(recreated.routingAdapter.authorizationCount(), 0);
+        Assert.strictEqual(recreated.routingAdapter.authContextCount(), 0);
+        Assert.strictEqual(recreated.proxyAuth.attemptCount(), 0);
+        Assert.deepStrictEqual(
+            recreated.proxyAuth.onAuthRequired(challenge()),
+            {cancel: true},
+        );
+
+      });
+
+});

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/routing-adapter.test.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/routing-adapter.test.js
@@ -41,6 +41,7 @@ function adapterForDecision(decision, options = {}) {
     decideRoute: options.decideRoute || ((value) => value),
     routingInputForRequest: options.routingInputForRequest || (() => decision),
     authorizations: options.authorizations,
+    requestAuthContexts: options.requestAuthContexts,
   });
 
 }
@@ -282,12 +283,151 @@ describe('Firefox fail-closed routing adapter', function() {
 
   });
 
-  it('fails closed before authorization for invalid or auth-dependent candidates', function() {
+  it('strips opaque authRef while preserving a valid proxy candidate', function() {
+
+    const authenticated = candidate(
+        'authenticated',
+        'HTTPS',
+        'proxy.test',
+        443,
+        {authRef: 'fixture-auth'},
+    );
+    const proxyInfo = Adapter.candidateToProxyInfo(authenticated);
+
+    Assert.deepStrictEqual(proxyInfo, {
+      type: 'https',
+      host: 'proxy.test',
+      port: 443,
+    });
+    Assert.strictEqual(
+        Object.prototype.hasOwnProperty.call(proxyInfo, 'authRef'),
+        false,
+    );
+
+  });
+
+  it('tracks the selected authenticated proxy by request and challenger',
+      function() {
+
+        const adapter = adapterForDecision(proxyDecision([
+          candidate('auth', 'HTTP', 'Proxy.Test', 8080, {
+            authRef: 'fixture-auth',
+          }),
+        ]));
+        const challenge = {
+          requestId: 'authenticated',
+          isProxy: true,
+          challenger: {host: 'proxy.test', port: 8080},
+        };
+
+        adapter.onProxyRequest({requestId: 'authenticated'});
+        Assert.strictEqual(adapter.authContextCount(), 1);
+        Assert.deepStrictEqual(adapter.onBeforeRequest({
+          requestId: 'authenticated',
+          proxyInfo: {type: 'http', host: 'PROXY.TEST', port: 8080},
+        }), {cancel: false});
+        Assert.deepStrictEqual(adapter.authenticationForChallenge(challenge), {
+          authRef: 'fixture-auth',
+          endpointKey: 'proxy.test:8080',
+        });
+        Assert.strictEqual(
+            adapter.authorizeAuthenticationRetry(challenge, 'fixture-auth'),
+            true,
+        );
+        Assert.deepStrictEqual(adapter.onBeforeRequest({
+          requestId: 'authenticated',
+          proxyInfo: {type: 'http', host: 'proxy.test', port: 8080},
+        }), {cancel: false});
+        Assert.strictEqual(adapter.authorizationCount(), 0);
+        Assert.strictEqual(adapter.authContextCount(), 1);
+
+      });
+
+  it('does not extend a callback budget for a mismatched endpoint or request',
+      function() {
+
+        const adapter = adapterForDecision(proxyDecision([
+          candidate('auth', 'HTTP', 'proxy.test', 8080, {
+            authRef: 'fixture-auth',
+          }),
+        ]));
+        adapter.onProxyRequest({requestId: 'known'});
+        adapter.onBeforeRequest({
+          requestId: 'known',
+          proxyInfo: {type: 'http', host: 'proxy.test', port: 8080},
+        });
+
+        for (const details of [
+          {
+            requestId: 'unknown',
+            isProxy: true,
+            challenger: {host: 'proxy.test', port: 8080},
+          },
+          {
+            requestId: 'known',
+            isProxy: true,
+            challenger: {host: 'proxy.test', port: 8081},
+          },
+          {
+            requestId: 'known',
+            isProxy: false,
+            challenger: {host: 'proxy.test', port: 8080},
+          },
+        ]) {
+          Assert.strictEqual(
+              adapter.authorizeAuthenticationRetry(details, 'fixture-auth'),
+              false,
+          );
+        }
+        Assert.strictEqual(adapter.authorizationCount(), 0);
+
+      });
+
+  it('rejects ambiguous authRefs for the same proxy endpoint', function() {
+
+    const decision = proxyDecision([
+      candidate('first', 'HTTP', 'proxy.test', 8080, {authRef: 'first'}),
+      candidate('second', 'HTTPS', 'PROXY.TEST', 8080, {authRef: 'second'}),
+    ]);
+    const adapter = adapterForDecision(decision);
+
+    Assert.strictEqual(Adapter.convertDecision(decision), null);
+    Assert.deepStrictEqual(adapter.onProxyRequest({requestId: 'ambiguous'}), {
+      type: 'direct',
+    });
+    Assert.strictEqual(adapter.authorizationCount(), 0);
+    Assert.strictEqual(adapter.authContextCount(), 0);
+
+  });
+
+  it('fails closed for malformed injected route-auth state', function() {
+
+    const requestAuthContexts = new Map([['malformed', {
+      candidates: [],
+      selected: {
+        authRef: 'fixture-auth',
+        endpointKey: 'proxy.test:8080',
+      },
+    }]]);
+    const adapter = adapterForDecision(null, {requestAuthContexts});
+
+    Assert.strictEqual(adapter.authenticationForChallenge({
+      requestId: 'malformed',
+      isProxy: true,
+      challenger: {host: 'proxy.test', port: 8080},
+    }), null);
+    Assert.strictEqual(adapter.authorizationCount(), 0);
+
+  });
+
+  it('fails closed before authorization for invalid candidates', function() {
 
     for (const invalid of [
       candidate('bad-host', 'HTTP', 'https://proxy.test', 8080),
       candidate('bad-port', 'HTTP', 'proxy.test', 0),
-      candidate('needs-auth', 'HTTPS', 'proxy.test', 443, {authRef: 'secret'}),
+      candidate('bad-auth-ref', 'HTTPS', 'proxy.test', 443, {
+        authRef: 'not valid',
+      }),
       Object.assign(
           candidate('credential', 'HTTP', 'proxy.test', 8080),
           {password: 'x'},
@@ -304,6 +444,7 @@ describe('Firefox fail-closed routing adapter', function() {
         cancel: true,
       });
       Assert.strictEqual(adapter.authorizationCount(), 0);
+      Assert.strictEqual(adapter.authContextCount(), 0);
     }
 
   });
@@ -486,6 +627,7 @@ describe('Firefox fail-closed routing adapter', function() {
         adapter.clearAllAuthorizations();
 
         Assert.strictEqual(adapter.authorizationCount(), 0);
+        Assert.strictEqual(adapter.authContextCount(), 0);
         Assert.deepStrictEqual(
             adapter.onBeforeRequest({requestId: 'first'}),
             {cancel: true},

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/skeleton.test.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/skeleton.test.js
@@ -52,6 +52,10 @@ const routingAdapterSource = Fs.readFileSync(
     Path.join(sourceRoot, 'background', 'routing-adapter.js'),
     'utf8',
 );
+const proxyAuthSource = Fs.readFileSync(
+    Path.join(sourceRoot, 'background', 'proxy-auth.js'),
+    'utf8',
+);
 const eventPageSource = Fs.readFileSync(
     Path.join(sourceRoot, 'background', 'event-page.js'),
     'utf8',
@@ -182,6 +186,14 @@ function startEventPage(options = {}) {
 
         },
       },
+      onAuthRequired: {
+        addListener(listener, filter, extraInfoSpec) {
+
+          events.push('auth-listener-registered');
+          networkListeners.auth = {extraInfoSpec, filter, listener};
+
+        },
+      },
       onCompleted: {
         addListener(listener, filter) {
 
@@ -225,6 +237,7 @@ function startEventPage(options = {}) {
   Vm.runInContext(routingAdapterSource, context, {
     filename: 'routing-adapter.js',
   });
+  Vm.runInContext(proxyAuthSource, context, {filename: 'proxy-auth.js'});
   Vm.runInContext(eventPageSource, context, {filename: 'event-page.js'});
   return {
     context,
@@ -264,6 +277,7 @@ describe('Firefox MV3 inert skeleton', function() {
         'background/provider-lookup.js',
         'background/dataset-runtime.js',
         'background/routing-adapter.js',
+        'background/proxy-auth.js',
         'background/event-page.js',
       ],
       persistent: false,
@@ -383,9 +397,10 @@ describe('Firefox MV3 inert skeleton', function() {
         const eventPage = startEventPage();
         await eventPage.ready();
 
-        Assert.deepStrictEqual(eventPage.events.slice(0, 6), [
+        Assert.deepStrictEqual(eventPage.events.slice(0, 7), [
           'proxy-listener-registered',
           'guard-listener-registered',
+          'auth-listener-registered',
           'completed-listener-registered',
           'error-listener-registered',
           'listener-registered',
@@ -394,6 +409,12 @@ describe('Firefox MV3 inert skeleton', function() {
         Assert.deepStrictEqual(
             JSON.parse(JSON.stringify(
                 eventPage.networkListeners.before.extraInfoSpec,
+            )),
+            ['blocking'],
+        );
+        Assert.deepStrictEqual(
+            JSON.parse(JSON.stringify(
+                eventPage.networkListeners.auth.extraInfoSpec,
             )),
             ['blocking'],
         );
@@ -413,6 +434,14 @@ describe('Firefox MV3 inert skeleton', function() {
             eventPage.networkListeners.before.listener({requestId: 'off'}),
         )),
         {cancel: false},
+    );
+    Assert.strictEqual(
+        eventPage.networkListeners.auth.listener({
+          requestId: 'off',
+          isProxy: true,
+          challenger: {host: 'proxy.test', port: 8080},
+        }),
+        undefined,
     );
 
   });
@@ -512,6 +541,7 @@ describe('Firefox MV3 inert skeleton', function() {
       providerLookupSource,
       datasetRuntimeSource,
       routingAdapterSource,
+      proxyAuthSource,
       eventPageSource,
     ].join('\n');
     for (const forbidden of [

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/verify-package.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/verify-package.js
@@ -13,6 +13,7 @@ const EXPECTED_FILES = Object.freeze([
   'background/event-page.js',
   'background/off-state.js',
   'background/provider-lookup.js',
+  'background/proxy-auth.js',
   'background/proxy-control.js',
   'background/routing-adapter.js',
   'manifest.json',
@@ -93,6 +94,7 @@ function verifyPackage(packageRoot, sourceRoot) {
     'background/provider-lookup.js',
     'background/dataset-runtime.js',
     'background/routing-adapter.js',
+    'background/proxy-auth.js',
     'background/event-page.js',
   ]);
   Assert.strictEqual('service_worker' in manifest.background, false);


### PR DESCRIPTION
## Summary

- Adds a Firefox-only synchronous `webRequest.onAuthRequired` boundary backed by an injected in-memory credential resolver.
- Keeps proxy authorization request-scoped: `requestId` + selected `onBeforeRequest.details.proxyInfo` + exact challenger host/port + opaque `authRef`.
- Adds exactly one guard callback authorization immediately before each credential response; maximum two credential responses per request/challenger.
- Rejects origin authentication, endpoint mismatch, missing credentials, async/erroring resolvers, malformed state, ambiguous endpoint/authRef routes, and retry exhaustion with `{cancel:true}`.
- Clears route-auth and attempt metadata on terminal events, Clear, and event-page recreation.
- Registers the blocking auth listener synchronously with the existing Firefox routing listeners.

## Boundaries

- The shipped Firefox package remains durable `OFF`; its production resolver is empty and `firefox.activation.apply` remains `ACTIVATION_NOT_IMPLEMENTED`.
- No persistent credential configuration, activation, real provider data, updater, health, UI, or release work is included.
- No new permission or dependency is added. `authRef` and credentials are never serialized into Firefox `ProxyInfo`.
- Known Firefox availability difference: canceling authentication after the retry limit terminates the request, so Firefox does not continue to a later proxy candidate. It does not create a Direct fallback.

## Verification

- Supply-chain: 11/11
- PAC: 26/26
- Chromium MV3: 428/428
- Firefox deterministic: 118/118
- Aggregate: 563/563
- Firefox package: 12 allowlisted files
- Firefox 154.0.1 local smoke using exact tracked adapter/auth sources: HTTP auth 3/3; HTTPS CONNECT; wrong then correct; two-wrong retry limit; missing credentials; origin 401; challenger mismatch; concurrent same endpoint with different authRefs; closed A then authenticated B; exhausted A stops before B; private authenticated request; private-access revoke.
- Unexpected protected-origin contacts: 0
- Credential leaks: 0
- Production OFF/control smoke: 10/10, protected-origin contacts 0
- Chromium runtime comparison: 70 vs 70 files; added 0; missing 0; SHA-256 differences 0
- Dependencies and lockfile: unchanged