### PR TITLE
Add inert Firefox activation transaction

### DIFF
--- a/docs/development/FIREFOX_MV3_SKELETON.md
+++ b/docs/development/FIREFOX_MV3_SKELETON.md
@@ -105,6 +105,31 @@ primitives не делают routing доступным. Команда
 `ACTIVATION_NOT_IMPLEMENTED`; наличие широких сетевых разрешений не делает
 маршрутизацию доступной пользователю.
 
+В package присутствует inert activation controller для отдельного тестирования
+полностью подготовленной synthetic session. Его production event page создаёт,
+но не вызывает: RPC, startup и storage не имеют пути к `activatePrepared`, а
+capability `activationSupported` остаётся `false`. Prepared input имеет строгую
+форму и содержит только exact prevalidated floor identity, подтверждение
+внешней проверки порта, provider key, dataset store, synchronous routing-input
+factory и synchronous in-memory credential resolver. Credentials не
+сохраняются.
+
+Транзакция сначала полностью проверяет dataset и строит lookup index, затем
+требует `READY`, приобретает и подтверждает exact fail-closed floor, очищает
+старое request/auth ephemeral state и только последним синхронным присваиванием
+публикует immutable active session. До floor acquisition controller остаётся
+`OFF`; между acquisition и publication обычный listener не задаёт route, а
+global floor закрывает сетевой путь. Clear сначала скрывает session и очищает
+request/auth state, только затем освобождает exact floor. Ошибка после
+acquisition запускает тот же exact-match rollback; если release невозможен,
+session остаётся `OFF`, floor и durable cleanup identity остаются fail-closed
+для следующего startup reconciliation.
+
+Активная prepared session намеренно только ephemeral. После уничтожения event
+page новая production instance всегда начинает с `OFF`, не восстанавливает
+session или credentials и очищает сохранённый exact floor через существующий
+OFF reconciliation. Durable `ON` всё ещё не существует и не принимается.
+
 Для каркаса используется development-only Gecko ID
 `firefox-mv3-skeleton@runet-censorship-bypass.invalid`. Production Gecko/AMO ID
 и возможная связь с legacy-идентичностями пока не определены; этот ID нельзя

--- a/extensions/chromium/runet-censorship-bypass/gulpfile.js
+++ b/extensions/chromium/runet-censorship-bypass/gulpfile.js
@@ -93,6 +93,7 @@ const firefoxMv3RuntimeSrc = [
   './src/extension-firefox-mv3/background/dataset-runtime.js',
   './src/extension-firefox-mv3/background/routing-adapter.js',
   './src/extension-firefox-mv3/background/proxy-auth.js',
+  './src/extension-firefox-mv3/background/activation-controller.js',
   './src/extension-firefox-mv3/background/event-page.js',
 ];
 const firefoxMv3CommonSrc = [

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/background/activation-controller.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/background/activation-controller.js
@@ -1,0 +1,354 @@
+'use strict';
+/* global require */
+
+(function publishFirefoxActivationController(root, factory) {
+
+  const datasetRuntime = typeof module === 'object' && module.exports ?
+    require('./dataset-runtime') : root.rucbFirefoxDatasetRuntime;
+  const proxyControl = typeof module === 'object' && module.exports ?
+    require('./proxy-control') : root.rucbFirefoxProxyControl;
+  const api = factory(datasetRuntime, proxyControl);
+  if (typeof module === 'object' && module.exports) {
+    module.exports = api;
+    return;
+  }
+  root.rucbFirefoxActivationController = api;
+
+})(typeof globalThis === 'object' ? globalThis : this,
+    function(DatasetRuntime, ProxyControl) {
+
+      const PREPARED_KEYS = Object.freeze([
+        'datasetStore',
+        'floorIdentity',
+        'portPrevalidated',
+        'providerKey',
+        'resolveCredentials',
+        'routingBaseInputForRequest',
+      ]);
+      const PROVIDER_KEY_PATTERN = /^[a-z0-9](?:[a-z0-9._-]{0,63})$/;
+      const RESULTS = Object.freeze({ACTIVE: 'ACTIVE'});
+      const ERRORS = Object.freeze({
+        ACTIVATION_ALREADY_ACTIVE: 'ACTIVATION_ALREADY_ACTIVE',
+        ACTIVATION_INTERRUPTED: 'ACTIVATION_INTERRUPTED',
+        ACTIVATION_ROLLBACK_FAILED: 'ACTIVATION_ROLLBACK_FAILED',
+        DATASET_INITIALIZATION_FAILED: 'DATASET_INITIALIZATION_FAILED',
+        DATASET_NOT_READY: 'DATASET_NOT_READY',
+        EPHEMERAL_CLEAR_FAILED: 'EPHEMERAL_CLEAR_FAILED',
+        INVALID_CONTROLLER_DEPENDENCIES: 'INVALID_CONTROLLER_DEPENDENCIES',
+        INVALID_PREPARED_ACTIVATION: 'INVALID_PREPARED_ACTIVATION',
+      });
+
+      function hasExactKeys(value, expected) {
+
+        if (!value || typeof value !== 'object' || Array.isArray(value)) {
+          return false;
+        }
+        const actual = Object.keys(value).sort();
+        const required = [...expected].sort();
+        return actual.length === required.length &&
+          actual.every((key, index) => key === required[index]);
+
+      }
+
+      function errorResult(code, extras = null) {
+
+        return Object.assign({ok: false, error: {code}}, extras || {});
+
+      }
+
+      function isSynchronousCallable(value) {
+
+        return typeof value === 'function' &&
+          Object.prototype.toString.call(value) !== '[object AsyncFunction]';
+
+      }
+
+      function validatePreparedActivation(value) {
+
+        try {
+          if (!hasExactKeys(value, PREPARED_KEYS) ||
+              value.portPrevalidated !== true ||
+              typeof value.providerKey !== 'string' ||
+              !PROVIDER_KEY_PATTERN.test(value.providerKey) ||
+              !value.datasetStore ||
+              typeof value.datasetStore.loadVerifications !== 'function' ||
+              !isSynchronousCallable(value.routingBaseInputForRequest) ||
+              !isSynchronousCallable(value.resolveCredentials)) {
+            return null;
+          }
+          const floorIdentity = ProxyControl.canonicalizeFloorIdentity(
+              value.floorIdentity,
+          );
+          if (!floorIdentity) {
+            return null;
+          }
+          return Object.freeze({
+            datasetStore: value.datasetStore,
+            floorIdentity: Object.freeze(floorIdentity),
+            portPrevalidated: true,
+            providerKey: value.providerKey,
+            resolveCredentials: value.resolveCredentials,
+            routingBaseInputForRequest: value.routingBaseInputForRequest,
+          });
+        } catch (_error) {
+          return null;
+        }
+
+      }
+
+      function createController(options = {}) {
+
+        const floorControl = options.proxyControl;
+        const routingAdapter = options.routingAdapter;
+        const proxyAuth = options.proxyAuth;
+        const createDatasetRuntime = options.createDatasetRuntime ||
+          DatasetRuntime.createRuntime;
+        const afterFloorAcquired = options.afterFloorAcquired;
+        if (!floorControl ||
+            typeof floorControl.acquirePrevalidatedFloor !== 'function' ||
+            typeof floorControl.clearFloor !== 'function' ||
+            !routingAdapter ||
+            typeof routingAdapter.clearAllAuthorizations !== 'function' ||
+            !proxyAuth || typeof proxyAuth.clearAllAttempts !== 'function' ||
+            typeof createDatasetRuntime !== 'function' ||
+            (afterFloorAcquired !== undefined &&
+              typeof afterFloorAcquired !== 'function')) {
+          throw new TypeError(ERRORS.INVALID_CONTROLLER_DEPENDENCIES);
+        }
+
+        let activeSession = null;
+        let operationQueue = Promise.resolve();
+
+        function enqueue(operation) {
+
+          const result = operationQueue.then(operation, operation);
+          operationQueue = result.catch(() => {});
+          return result;
+
+        }
+
+        function clearEphemeralState() {
+
+          let cleared = true;
+          try {
+            routingAdapter.clearAllAuthorizations();
+          } catch (_error) {
+            cleared = false;
+          }
+          try {
+            proxyAuth.clearAllAttempts();
+          } catch (_error) {
+            cleared = false;
+          }
+          return cleared;
+
+        }
+
+        function currentRuntimeState() {
+
+          const session = activeSession;
+          if (!session) {
+            return DatasetRuntime.STATES.OFF;
+          }
+          try {
+            return session.datasetRuntime.getState() ===
+              DatasetRuntime.STATES.READY ?
+              DatasetRuntime.STATES.READY : DatasetRuntime.STATES.FAILED;
+          } catch (_error) {
+            return DatasetRuntime.STATES.FAILED;
+          }
+
+        }
+
+        function routingInputForRequest(details) {
+
+          const session = activeSession;
+          if (!session || currentRuntimeState() !== DatasetRuntime.STATES.READY) {
+            throw new TypeError('FIREFOX_ACTIVATION_SESSION_UNAVAILABLE');
+          }
+          return session.datasetRuntime.routingInputForRequest(details);
+
+        }
+
+        function resolveCredentials(authRef) {
+
+          const session = activeSession;
+          if (!session || currentRuntimeState() !== DatasetRuntime.STATES.READY) {
+            return null;
+          }
+          try {
+            return session.resolveCredentials(authRef);
+          } catch (_error) {
+            return null;
+          }
+
+        }
+
+        async function rollback(code) {
+
+          activeSession = null;
+          clearEphemeralState();
+          let cleared;
+          try {
+            cleared = await floorControl.clearFloor();
+          } catch (_error) {
+            cleared = null;
+          }
+          if (!cleared || cleared.ok !== true) {
+            return errorResult(ERRORS.ACTIVATION_ROLLBACK_FAILED, {
+              cause: {code},
+              floorRetained: true,
+            });
+          }
+          return errorResult(code, {
+            rollback: {ok: true, status: cleared.status},
+          });
+
+        }
+
+        async function activatePreparedNow(input) {
+
+          if (activeSession) {
+            return errorResult(ERRORS.ACTIVATION_ALREADY_ACTIVE);
+          }
+          const prepared = validatePreparedActivation(input);
+          if (!prepared) {
+            return errorResult(ERRORS.INVALID_PREPARED_ACTIVATION);
+          }
+
+          let runtime;
+          try {
+            runtime = createDatasetRuntime({
+              protectionIntended: true,
+              providerKey: prepared.providerKey,
+              store: prepared.datasetStore,
+              baseInputForRequest: prepared.routingBaseInputForRequest,
+            });
+          } catch (_error) {
+            return errorResult(ERRORS.DATASET_INITIALIZATION_FAILED);
+          }
+          if (!runtime || typeof runtime.initialize !== 'function' ||
+              typeof runtime.getState !== 'function' ||
+              typeof runtime.routingInputForRequest !== 'function') {
+            return errorResult(ERRORS.DATASET_INITIALIZATION_FAILED);
+          }
+
+          let initialized;
+          try {
+            initialized = await runtime.initialize();
+          } catch (_error) {
+            return errorResult(ERRORS.DATASET_INITIALIZATION_FAILED);
+          }
+          let initializedReady = false;
+          try {
+            initializedReady = Boolean(initialized) &&
+              initialized.state === DatasetRuntime.STATES.READY &&
+              runtime.getState() === DatasetRuntime.STATES.READY;
+          } catch (_error) {
+            initializedReady = false;
+          }
+          if (!initializedReady) {
+            const code = initialized && initialized.failureCode ?
+              initialized.failureCode : ERRORS.DATASET_NOT_READY;
+            return errorResult(code);
+          }
+
+          let acquired;
+          try {
+            acquired = await floorControl.acquirePrevalidatedFloor({
+              floorIdentity: prepared.floorIdentity,
+              portPrevalidated: true,
+            });
+          } catch (_error) {
+            return errorResult(ProxyControl.ERRORS.PROXY_SET_FAILED);
+          }
+          if (!acquired || acquired.ok !== true) {
+            const code = acquired && acquired.error && acquired.error.code ?
+              acquired.error.code : ProxyControl.ERRORS.PROXY_SET_FAILED;
+            return errorResult(code);
+          }
+
+          try {
+            if (afterFloorAcquired) {
+              await afterFloorAcquired();
+            }
+            if (runtime.getState() !== DatasetRuntime.STATES.READY) {
+              return rollback(ERRORS.DATASET_NOT_READY);
+            }
+            if (!clearEphemeralState()) {
+              return rollback(ERRORS.EPHEMERAL_CLEAR_FAILED);
+            }
+            activeSession = Object.freeze({
+              datasetRuntime: runtime,
+              resolveCredentials: prepared.resolveCredentials,
+            });
+            return {
+              ok: true,
+              status: RESULTS.ACTIVE,
+              dataset: initialized.selected || null,
+            };
+          } catch (_error) {
+            return rollback(ERRORS.ACTIVATION_INTERRUPTED);
+          }
+
+        }
+
+        async function clearNow() {
+
+          activeSession = null;
+          const ephemeralCleared = clearEphemeralState();
+          let cleared;
+          try {
+            cleared = await floorControl.clearFloor();
+          } catch (_error) {
+            cleared = null;
+          }
+          if (!cleared || cleared.ok !== true) {
+            const code = cleared && cleared.error && cleared.error.code ?
+              cleared.error.code : ProxyControl.ERRORS.PROXY_CLEAR_FAILED;
+            return errorResult(code, {floorRetained: true});
+          }
+          if (!ephemeralCleared) {
+            return errorResult(ERRORS.EPHEMERAL_CLEAR_FAILED);
+          }
+          return {ok: true, status: cleared.status};
+
+        }
+
+        function snapshot() {
+
+          return Object.freeze({
+            runtimeState: currentRuntimeState(),
+            active: activeSession !== null,
+          });
+
+        }
+
+        return Object.freeze({
+          activatePrepared(input) {
+
+            return enqueue(() => activatePreparedNow(input));
+
+          },
+          clear() {
+
+            return enqueue(clearNow);
+
+          },
+          currentRuntimeState,
+          resolveCredentials,
+          routingInputForRequest,
+          snapshot,
+        });
+
+      }
+
+      return Object.freeze({
+        ERRORS,
+        PREPARED_KEYS,
+        RESULTS,
+        createController,
+        validatePreparedActivation,
+      });
+
+    });

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/background/event-page.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/background/event-page.js
@@ -6,18 +6,18 @@
   const proxyControlApi = root.rucbFirefoxProxyControl;
   const proxyAuthApi = root.rucbFirefoxProxyAuth;
   const routing = root.rucbFirefoxRoutingAdapter;
-  const datasetRuntime = root.rucbFirefoxDatasetRuntime.createRuntime({
-    protectionIntended: false,
-    providerKey: 'anticensority',
-  });
+  const activationApi = root.rucbFirefoxActivationController;
+  let activationController = null;
   const routingAdapter = routing.createAdapter({
-    runtimeStateForRequest: datasetRuntime.getState,
-    routingInputForRequest: datasetRuntime.routingInputForRequest,
+    runtimeStateForRequest: () => activationController ?
+      activationController.currentRuntimeState() : routing.STATES.OFF,
+    routingInputForRequest: (details) =>
+      activationController.routingInputForRequest(details),
   });
   const proxyAuth = proxyAuthApi.createHandler({
     routingAdapter,
-    // Production credential state and activation are deliberately absent.
-    resolveCredentials: () => null,
+    resolveCredentials: (authRef) => activationController ?
+      activationController.resolveCredentials(authRef) : null,
   });
   function clearEphemeralState() {
 
@@ -31,6 +31,11 @@
     isPrivateAccessAllowed: () =>
       browser.extension.isAllowedIncognitoAccess(),
     clearEphemeralState,
+  });
+  activationController = activationApi.createController({
+    proxyControl,
+    routingAdapter,
+    proxyAuth,
   });
   const durableIntent = offState.OFF;
   const bootId = root.crypto && typeof root.crypto.randomUUID === 'function' ?
@@ -67,7 +72,7 @@
           browser: 'FIREFOX',
           manifestVersion: manifest.manifest_version,
           runtimeModel: 'BACKGROUND_EVENT_PAGE',
-          runtimeState: routingAdapter.runtimeState,
+          runtimeState: activationController.currentRuntimeState(),
           durableIntent,
           privateWindowAccess: await readPrivateWindowAccess(),
           routingImplemented: true,
@@ -81,7 +86,7 @@
       return errorResponse('ACTIVATION_NOT_IMPLEMENTED');
     }
     if (type === 'firefox.activation.clear') {
-      const cleared = await proxyControl.clearFloor();
+      const cleared = await activationController.clear();
       if (!cleared.ok) {
         return errorResponse(cleared.error.code);
       }
@@ -125,10 +130,8 @@
   browser.runtime.onMessage.addListener(handleMessage);
 
   const initialization = proxyControl.reconcileOffOnStartup()
-      .then(async (reconciliation) => {
-        await datasetRuntime.initialize();
-        return reconciliation.durableState || offState.canonicalState();
-      })
+      .then((reconciliation) =>
+        reconciliation.durableState || offState.canonicalState())
       .catch(() => offState.canonicalState());
 
   root.rucbFirefoxSkeletonRuntime = Object.freeze({

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/manifest.json
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/manifest.json
@@ -24,6 +24,7 @@
       "background/dataset-runtime.js",
       "background/routing-adapter.js",
       "background/proxy-auth.js",
+      "background/activation-controller.js",
       "background/event-page.js"
     ],
     "persistent": false

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/activation-controller.test.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/activation-controller.test.js
@@ -1,0 +1,642 @@
+'use strict';
+
+const Assert = require('node:assert');
+const Activation = require('../background/activation-controller');
+const DatasetRuntime = require('../background/dataset-runtime');
+const DatasetStore = require('../background/dataset-store');
+const ProxyAuth = require('../background/proxy-auth');
+const ProxyControl = require('../background/proxy-control');
+const Routing = require('../../extension-mv3-common/routing-contract');
+const RoutingAdapter = require('../background/routing-adapter');
+const Helpers = require('./dataset-test-helpers');
+
+function floor(port = 55011) {
+
+  return {
+    proxyType: 'manual',
+    http: '',
+    httpProxyAll: false,
+    ssl: '',
+    socks: `127.0.0.1:${port}`,
+    socksVersion: 5,
+    proxyDNS: true,
+    passthrough: '',
+    autoConfigUrl: '',
+  };
+
+}
+
+function candidate(overrides = {}) {
+
+  return Object.assign({
+    id: 'synthetic-proxy',
+    type: 'HTTP',
+    host: '127.0.0.1',
+    port: 18080,
+    proxyDNS: false,
+    authRef: null,
+    failoverTimeoutSeconds: null,
+  }, overrides);
+
+}
+
+async function verifiedStore(options = {}) {
+
+  const backend = Helpers.memoryBackend();
+  const store = DatasetStore.createStore({
+    backend,
+    sha256: async (bytes) => Helpers.sha256(Buffer.from(bytes)),
+  });
+  if (options.empty !== true) {
+    const committed = await store.commitPackagedBaseline(Helpers.artifact(
+        options.artifactOptions,
+    ));
+    Assert.strictEqual(committed.ok, true);
+  }
+  return store;
+
+}
+
+function baseInputForRequest(proxyCandidate = candidate()) {
+
+  return (details) => ({
+    hostname: new URL(details.url).hostname,
+    rules: {},
+    candidateGroups: {},
+    flags: {},
+    providerCandidates: [proxyCandidate],
+    providerFallback: Routing.FALLBACKS.DIRECT,
+  });
+
+}
+
+function prepared(datasetStore, overrides = {}) {
+
+  return Object.assign({
+    datasetStore,
+    floorIdentity: floor(),
+    portPrevalidated: true,
+    providerKey: Helpers.PROVIDER_KEY,
+    resolveCredentials: () => null,
+    routingBaseInputForRequest: baseInputForRequest(),
+  }, overrides);
+
+}
+
+function createHarness(options = {}) {
+
+  const events = [];
+  const floorControl = options.proxyControl || {
+    async acquirePrevalidatedFloor(request) {
+
+      events.push(['floor-acquire', request]);
+      return options.acquireResult || {
+        ok: true,
+        status: ProxyControl.RESULTS.ACQUIRED,
+      };
+
+    },
+    async clearFloor() {
+
+      events.push(['floor-clear']);
+      return options.clearResult || {
+        ok: true,
+        status: ProxyControl.RESULTS.CLEARED,
+      };
+
+    },
+  };
+  let controller = null;
+  const routingAdapter = RoutingAdapter.createAdapter({
+    runtimeStateForRequest: () => controller ?
+      controller.currentRuntimeState() : RoutingAdapter.STATES.OFF,
+    routingInputForRequest: (details) =>
+      controller.routingInputForRequest(details),
+  });
+  const proxyAuth = ProxyAuth.createHandler({
+    routingAdapter,
+    resolveCredentials: (authRef) => controller ?
+      controller.resolveCredentials(authRef) : null,
+  });
+  controller = Activation.createController({
+    proxyControl: floorControl,
+    routingAdapter,
+    proxyAuth,
+    createDatasetRuntime: options.createDatasetRuntime,
+    afterFloorAcquired: options.afterFloorAcquired,
+  });
+  return {controller, events, floorControl, proxyAuth, routingAdapter};
+
+}
+
+describe('Firefox inert activation transaction', function() {
+
+  it('accepts only the exact prevalidated prepared contract', async function() {
+
+    const store = await verifiedStore();
+    const valid = prepared(store);
+
+    Assert.ok(Activation.validatePreparedActivation(valid));
+    for (const invalid of [
+      null,
+      Object.assign({}, valid, {extra: true}),
+      Object.assign({}, valid, {portPrevalidated: false}),
+      Object.assign({}, valid, {floorIdentity: floor(1)}),
+      Object.assign({}, valid, {providerKey: 'INVALID'}),
+      Object.assign({}, valid, {datasetStore: {}}),
+      Object.assign({}, valid, {routingBaseInputForRequest: null}),
+      Object.assign({}, valid, {resolveCredentials: null}),
+      Object.assign({}, valid, {routingBaseInputForRequest: async () => ({})}),
+      Object.assign({}, valid, {resolveCredentials: async () => null}),
+      new Proxy({}, {
+        ownKeys() {
+
+          throw new Error('synthetic prepared-state failure');
+
+        },
+      }),
+    ]) {
+      Assert.strictEqual(Activation.validatePreparedActivation(invalid), null);
+    }
+
+  });
+
+  it('rejects invalid prepared input before acquiring the floor', async function() {
+
+    const harness = createHarness();
+    const result = await harness.controller.activatePrepared({});
+
+    Assert.deepStrictEqual(result, {
+      ok: false,
+      error: {code: Activation.ERRORS.INVALID_PREPARED_ACTIVATION},
+    });
+    Assert.deepStrictEqual(harness.events, []);
+    Assert.deepStrictEqual(harness.controller.snapshot(), {
+      runtimeState: DatasetRuntime.STATES.OFF,
+      active: false,
+    });
+
+  });
+
+  it('initializes a verified dataset before floor acquisition and publication',
+      async function() {
+
+        const order = [];
+        const store = await verifiedStore();
+        const wrappedStore = {
+          async loadVerifications(...args) {
+
+            order.push('dataset-load');
+            const result = await store.loadVerifications(...args);
+            order.push('dataset-ready');
+            return result;
+
+          },
+        };
+        const harness = createHarness({
+          proxyControl: {
+            async acquirePrevalidatedFloor() {
+
+              order.push('floor-acquire');
+              return {ok: true, status: ProxyControl.RESULTS.ACQUIRED};
+
+            },
+            async clearFloor() {
+
+              order.push('floor-clear');
+              return {ok: true, status: ProxyControl.RESULTS.CLEARED};
+
+            },
+          },
+          afterFloorAcquired() {
+
+            order.push('floor-confirmed');
+
+          },
+        });
+
+        Assert.strictEqual(harness.controller.currentRuntimeState(), 'OFF');
+        const result = await harness.controller.activatePrepared(
+            prepared(wrappedStore),
+        );
+
+        Assert.strictEqual(result.ok, true);
+        Assert.strictEqual(result.status, Activation.RESULTS.ACTIVE);
+        Assert.deepStrictEqual(order, [
+          'dataset-load',
+          'dataset-ready',
+          'floor-acquire',
+          'floor-confirmed',
+        ]);
+        Assert.deepStrictEqual(harness.controller.snapshot(), {
+          runtimeState: DatasetRuntime.STATES.READY,
+          active: true,
+        });
+
+      });
+
+  it('routes through the published verified provider session', async function() {
+
+    const store = await verifiedStore();
+    const harness = createHarness();
+    await harness.controller.activatePrepared(prepared(store));
+
+    Assert.deepStrictEqual(harness.routingAdapter.onProxyRequest({
+      requestId: 'provider-proxy',
+      url: 'http://beta.example/path',
+    }), [
+      {type: 'http', host: '127.0.0.1', port: 18080},
+      null,
+    ]);
+    Assert.deepStrictEqual(harness.routingAdapter.onBeforeRequest({
+      requestId: 'provider-proxy',
+      proxyInfo: {type: 'http', host: '127.0.0.1', port: 18080},
+    }), {cancel: false});
+
+  });
+
+  it('does not acquire a floor when the dataset is missing', async function() {
+
+    const store = await verifiedStore({empty: true});
+    const harness = createHarness();
+    const result = await harness.controller.activatePrepared(prepared(store));
+
+    Assert.strictEqual(result.ok, false);
+    Assert.strictEqual(result.error.code, 'NO_USABLE_PROVIDER_DATASET');
+    Assert.deepStrictEqual(harness.events, []);
+    Assert.strictEqual(harness.controller.currentRuntimeState(), 'OFF');
+
+  });
+
+  it('does not acquire a floor when dataset initialization throws', async function() {
+
+    const harness = createHarness();
+    const result = await harness.controller.activatePrepared(prepared({
+      async loadVerifications() {
+
+        throw new Error('synthetic unreadable store');
+
+      },
+    }));
+
+    Assert.strictEqual(result.ok, false);
+    Assert.strictEqual(result.error.code, 'DATASET_INITIALIZATION_FAILED');
+    Assert.deepStrictEqual(harness.events, []);
+
+  });
+
+  it('propagates private-access and floor acquisition failures without a session',
+      async function() {
+
+        const store = await verifiedStore();
+        for (const code of [
+          ProxyControl.ERRORS.PRIVATE_ACCESS_REQUIRED,
+          ProxyControl.ERRORS.PROXY_SET_FAILED,
+          ProxyControl.ERRORS.OWNERSHIP_MISMATCH,
+        ]) {
+          const harness = createHarness({
+            acquireResult: {ok: false, error: {code}},
+          });
+          const result = await harness.controller.activatePrepared(
+              prepared(store),
+          );
+
+          Assert.deepStrictEqual(result, {ok: false, error: {code}});
+          Assert.strictEqual(harness.controller.currentRuntimeState(), 'OFF');
+          Assert.strictEqual(harness.routingAdapter.authorizationCount(), 0);
+        }
+
+      });
+
+  it('keeps listeners OFF while paused after the floor is acquired', async function() {
+
+    const store = await verifiedStore();
+    let releasePause;
+    let reportFloor;
+    const floorReached = new Promise((resolve) => {
+      reportFloor = resolve;
+    });
+    const harness = createHarness({
+      afterFloorAcquired() {
+
+        reportFloor();
+        return new Promise((resolve) => {
+          releasePause = resolve;
+        });
+
+      },
+    });
+    const activation = harness.controller.activatePrepared(prepared(store));
+    await floorReached;
+
+    Assert.strictEqual(harness.controller.currentRuntimeState(), 'OFF');
+    Assert.strictEqual(
+        harness.routingAdapter.onProxyRequest({requestId: 'paused'}),
+        undefined,
+    );
+    Assert.deepStrictEqual(
+        harness.routingAdapter.onBeforeRequest({requestId: 'paused'}),
+        {cancel: false},
+    );
+
+    releasePause();
+    Assert.strictEqual((await activation).ok, true);
+    Assert.strictEqual(harness.controller.currentRuntimeState(), 'READY');
+
+  });
+
+  it('rolls back an interruption after floor acquisition without publication',
+      async function() {
+
+        const store = await verifiedStore();
+        const harness = createHarness({
+          afterFloorAcquired() {
+
+            throw new Error('synthetic interruption');
+
+          },
+        });
+        const result = await harness.controller.activatePrepared(prepared(store));
+
+        Assert.strictEqual(result.ok, false);
+        Assert.strictEqual(
+            result.error.code,
+            Activation.ERRORS.ACTIVATION_INTERRUPTED,
+        );
+        Assert.strictEqual(result.rollback.ok, true);
+        Assert.deepStrictEqual(
+            harness.events.map(([name]) => name),
+            ['floor-acquire', 'floor-clear'],
+        );
+        Assert.strictEqual(harness.controller.currentRuntimeState(), 'OFF');
+
+      });
+
+  it('reports a retained fail-closed floor when rollback cannot clear it',
+      async function() {
+
+        const store = await verifiedStore();
+        const harness = createHarness({
+          clearResult: {
+            ok: false,
+            error: {code: ProxyControl.ERRORS.PROXY_CLEAR_FAILED},
+          },
+          afterFloorAcquired() {
+
+            throw new Error('synthetic interruption');
+
+          },
+        });
+        const result = await harness.controller.activatePrepared(prepared(store));
+
+        Assert.deepStrictEqual(result, {
+          ok: false,
+          error: {code: Activation.ERRORS.ACTIVATION_ROLLBACK_FAILED},
+          cause: {code: Activation.ERRORS.ACTIVATION_INTERRUPTED},
+          floorRetained: true,
+        });
+        Assert.strictEqual(harness.controller.currentRuntimeState(), 'OFF');
+
+      });
+
+  it('withdraws the session and clears ephemerals before releasing the floor',
+      async function() {
+
+        const store = await verifiedStore();
+        const holder = {};
+        const observations = [];
+        const control = {
+          async acquirePrevalidatedFloor() {
+
+            return {ok: true, status: ProxyControl.RESULTS.ACQUIRED};
+
+          },
+          async clearFloor() {
+
+            observations.push(holder.harness.controller.currentRuntimeState());
+            observations.push(
+                holder.harness.routingAdapter.authorizationCount(),
+            );
+            observations.push(holder.harness.proxyAuth.attemptCount());
+            return {ok: true, status: ProxyControl.RESULTS.CLEARED};
+
+          },
+        };
+        const harness = createHarness({proxyControl: control});
+        holder.harness = harness;
+        await harness.controller.activatePrepared(prepared(store));
+        harness.routingAdapter.onProxyRequest({
+          requestId: 'stale',
+          url: 'http://beta.example/',
+        });
+        Assert.strictEqual(harness.routingAdapter.authorizationCount(), 1);
+
+        const result = await harness.controller.clear();
+
+        Assert.deepStrictEqual(result, {
+          ok: true,
+          status: ProxyControl.RESULTS.CLEARED,
+        });
+        Assert.deepStrictEqual(observations, ['OFF', 0, 0]);
+        Assert.strictEqual(harness.routingAdapter.authorizationCount(), 0);
+        Assert.strictEqual(harness.controller.currentRuntimeState(), 'OFF');
+
+      });
+
+  it('stays OFF with a retained floor when Clear fails', async function() {
+
+    const store = await verifiedStore();
+    const harness = createHarness({
+      clearResult: {
+        ok: false,
+        error: {code: ProxyControl.ERRORS.PROXY_CLEAR_FAILED},
+      },
+    });
+    await harness.controller.activatePrepared(prepared(store));
+
+    const result = await harness.controller.clear();
+
+    Assert.deepStrictEqual(result, {
+      ok: false,
+      error: {code: ProxyControl.ERRORS.PROXY_CLEAR_FAILED},
+      floorRetained: true,
+    });
+    Assert.strictEqual(harness.controller.currentRuntimeState(), 'OFF');
+    Assert.strictEqual(harness.routingAdapter.authorizationCount(), 0);
+
+  });
+
+  it('attempts both ephemeral cleanups when one cleanup operation fails',
+      async function() {
+
+        let authClears = 0;
+        let floorClears = 0;
+        const controller = Activation.createController({
+          proxyControl: {
+            async acquirePrevalidatedFloor() {
+
+              return {ok: true, status: ProxyControl.RESULTS.ACQUIRED};
+
+            },
+            async clearFloor() {
+
+              floorClears += 1;
+              return {ok: true, status: ProxyControl.RESULTS.ALREADY_CLEAR};
+
+            },
+          },
+          routingAdapter: {
+            clearAllAuthorizations() {
+
+              throw new Error('synthetic routing cleanup failure');
+
+            },
+          },
+          proxyAuth: {
+            clearAllAttempts() {
+
+              authClears += 1;
+
+            },
+          },
+        });
+
+        Assert.deepStrictEqual(await controller.clear(), {
+          ok: false,
+          error: {code: Activation.ERRORS.EPHEMERAL_CLEAR_FAILED},
+        });
+        Assert.strictEqual(authClears, 1);
+        Assert.strictEqual(floorClears, 1);
+        Assert.strictEqual(controller.currentRuntimeState(), 'OFF');
+
+      });
+
+  it('binds credentials to only the exact active session and request',
+      async function() {
+
+        const store = await verifiedStore();
+        const authenticated = candidate({authRef: 'synthetic-auth'});
+        const harness = createHarness();
+        await harness.controller.activatePrepared(prepared(store, {
+          routingBaseInputForRequest: baseInputForRequest(authenticated),
+          resolveCredentials(authRef) {
+
+            return authRef === 'synthetic-auth' ? {
+              username: 'fixture-user',
+              password: 'fixture-password',
+            } : null;
+
+          },
+        }));
+        const details = {
+          requestId: 'auth-request',
+          url: 'http://beta.example/',
+        };
+        harness.routingAdapter.onProxyRequest(details);
+        harness.routingAdapter.onBeforeRequest({
+          requestId: details.requestId,
+          proxyInfo: {type: 'http', host: '127.0.0.1', port: 18080},
+        });
+
+        const response = harness.proxyAuth.onAuthRequired({
+          requestId: details.requestId,
+          isProxy: true,
+          challenger: {host: '127.0.0.1', port: 18080},
+        });
+
+        Assert.deepStrictEqual(response, {
+          authCredentials: {
+            username: 'fixture-user',
+            password: 'fixture-password',
+          },
+        });
+        Assert.deepStrictEqual(harness.routingAdapter.onBeforeRequest({
+          requestId: details.requestId,
+          proxyInfo: {type: 'http', host: '127.0.0.1', port: 18080},
+        }), {cancel: false});
+        await harness.controller.clear();
+        Assert.strictEqual(
+            harness.controller.resolveCredentials('synthetic-auth'),
+            null,
+        );
+
+      });
+
+  it('fails closed when a synchronous-shaped resolver returns async state',
+      async function() {
+
+        const store = await verifiedStore();
+        const authenticated = candidate({authRef: 'synthetic-auth'});
+        const harness = createHarness();
+        await harness.controller.activatePrepared(prepared(store, {
+          routingBaseInputForRequest: baseInputForRequest(authenticated),
+          resolveCredentials: () => Promise.resolve({
+            username: 'fixture-user',
+            password: 'fixture-password',
+          }),
+        }));
+        harness.routingAdapter.onProxyRequest({
+          requestId: 'async-auth',
+          url: 'http://beta.example/',
+        });
+        harness.routingAdapter.onBeforeRequest({
+          requestId: 'async-auth',
+          proxyInfo: {type: 'http', host: '127.0.0.1', port: 18080},
+        });
+
+        Assert.deepStrictEqual(harness.proxyAuth.onAuthRequired({
+          requestId: 'async-auth',
+          isProxy: true,
+          challenger: {host: '127.0.0.1', port: 18080},
+        }), {cancel: true});
+
+      });
+
+  it('refuses a second activation and never replaces an active session',
+      async function() {
+
+        const store = await verifiedStore();
+        const harness = createHarness();
+        Assert.strictEqual(
+            (await harness.controller.activatePrepared(prepared(store))).ok,
+            true,
+        );
+
+        Assert.deepStrictEqual(
+            await harness.controller.activatePrepared(prepared(store)),
+            {
+              ok: false,
+              error: {code: Activation.ERRORS.ACTIVATION_ALREADY_ACTIVE},
+            },
+        );
+        Assert.strictEqual(
+            harness.events.filter(([name]) => name === 'floor-acquire').length,
+            1,
+        );
+
+      });
+
+  it('starts a recreated controller OFF with no authorization or auth state',
+      async function() {
+
+        const store = await verifiedStore();
+        const first = createHarness();
+        await first.controller.activatePrepared(prepared(store));
+        first.routingAdapter.onProxyRequest({
+          requestId: 'old-request',
+          url: 'http://beta.example/',
+        });
+        const recreated = createHarness();
+
+        Assert.strictEqual(recreated.controller.currentRuntimeState(), 'OFF');
+        Assert.strictEqual(recreated.routingAdapter.authorizationCount(), 0);
+        Assert.strictEqual(recreated.routingAdapter.authContextCount(), 0);
+        Assert.strictEqual(recreated.proxyAuth.attemptCount(), 0);
+        Assert.strictEqual(
+            recreated.routingAdapter.onProxyRequest({requestId: 'old-request'}),
+            undefined,
+        );
+
+      });
+
+});

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/package.test.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/package.test.js
@@ -41,7 +41,7 @@ describe('Firefox MV3 package verifier', function() {
 
   });
 
-  it('accepts only the exact OFF-only dataset-capable routing package',
+  it('accepts only the exact OFF-only activation-capable package',
       function() {
 
         packageRoot = makePackage();

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/skeleton.test.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/skeleton.test.js
@@ -56,6 +56,10 @@ const proxyAuthSource = Fs.readFileSync(
     Path.join(sourceRoot, 'background', 'proxy-auth.js'),
     'utf8',
 );
+const activationControllerSource = Fs.readFileSync(
+    Path.join(sourceRoot, 'background', 'activation-controller.js'),
+    'utf8',
+);
 const eventPageSource = Fs.readFileSync(
     Path.join(sourceRoot, 'background', 'event-page.js'),
     'utf8',
@@ -238,6 +242,9 @@ function startEventPage(options = {}) {
     filename: 'routing-adapter.js',
   });
   Vm.runInContext(proxyAuthSource, context, {filename: 'proxy-auth.js'});
+  Vm.runInContext(activationControllerSource, context, {
+    filename: 'activation-controller.js',
+  });
   Vm.runInContext(eventPageSource, context, {filename: 'event-page.js'});
   return {
     context,
@@ -278,6 +285,7 @@ describe('Firefox MV3 inert skeleton', function() {
         'background/dataset-runtime.js',
         'background/routing-adapter.js',
         'background/proxy-auth.js',
+        'background/activation-controller.js',
         'background/event-page.js',
       ],
       persistent: false,
@@ -532,33 +540,36 @@ describe('Firefox MV3 inert skeleton', function() {
 
   });
 
-  it('contains no activation, remote-fetch, or Chromium-state path', function() {
+  it('contains no production activation call or remote execution path',
+      function() {
 
-    const runtimeSource = [
-      offStateSource,
-      proxyControlSource,
-      datasetStoreSource,
-      providerLookupSource,
-      datasetRuntimeSource,
-      routingAdapterSource,
-      proxyAuthSource,
-      eventPageSource,
-    ].join('\n');
-    for (const forbidden of [
-      'XMLHttpRequest',
-      'fetch(',
-      'extension-chromium-mv3',
-      'eval(',
-      'Function(',
-    ]) {
-      Assert.strictEqual(runtimeSource.includes(forbidden), false, forbidden);
-    }
-    Assert.strictEqual(
-        eventPageSource.includes('acquirePrevalidatedFloor('),
-        false,
-    );
-    Assert.strictEqual(eventPageSource.includes('proxy.settings.set'), false);
+        const runtimeSource = [
+          offStateSource,
+          proxyControlSource,
+          datasetStoreSource,
+          providerLookupSource,
+          datasetRuntimeSource,
+          routingAdapterSource,
+          proxyAuthSource,
+          activationControllerSource,
+          eventPageSource,
+        ].join('\n');
+        for (const forbidden of [
+          'XMLHttpRequest',
+          'fetch(',
+          'extension-chromium-mv3',
+          'eval(',
+          'Function(',
+        ]) {
+          Assert.strictEqual(runtimeSource.includes(forbidden), false, forbidden);
+        }
+        Assert.strictEqual(
+            eventPageSource.includes('acquirePrevalidatedFloor('),
+            false,
+        );
+        Assert.strictEqual(eventPageSource.includes('activatePrepared('), false);
+        Assert.strictEqual(eventPageSource.includes('proxy.settings.set'), false);
 
-  });
+      });
 
 });

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/verify-package.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/verify-package.js
@@ -5,6 +5,7 @@ const Fs = require('node:fs');
 const Path = require('node:path');
 
 const EXPECTED_FILES = Object.freeze([
+  'background/activation-controller.js',
   'background/common/provider-dataset-state.js',
   'background/common/provider-dataset.js',
   'background/common/routing-contract.js',
@@ -95,6 +96,7 @@ function verifyPackage(packageRoot, sourceRoot) {
     'background/dataset-runtime.js',
     'background/routing-adapter.js',
     'background/proxy-auth.js',
+    'background/activation-controller.js',
     'background/event-page.js',
   ]);
   Assert.strictEqual('service_worker' in manifest.background, false);
@@ -113,6 +115,7 @@ function verifyPackage(packageRoot, sourceRoot) {
   );
   Assert.strictEqual(eventPageText.includes('proxy.settings.set'), false);
   Assert.strictEqual(eventPageText.includes('acquirePrevalidatedFloor('), false);
+  Assert.strictEqual(eventPageText.includes('activatePrepared('), false);
   Assert.strictEqual(
       eventPageText.includes('type === \'firefox.activation.apply\''),
       true,


### PR DESCRIPTION
## Summary

- adds an inert Firefox activation controller for fully prepared synthetic/test sessions
- keeps production `firefox.activation.apply` at `ACTIVATION_NOT_IMPLEMENTED`
- keeps activation ephemeral: no durable `ON`, startup activation, UI, dataset, updater, health, or persistent credential configuration

## Transaction and safety model

The controller validates the exact prepared contract, initializes and verifies the dataset to `READY`, acquires and confirms the exact prevalidated fail-closed floor, clears stale routing/auth state, and only then publishes one immutable active session. The existing top-level listeners dynamically read that session and are never re-registered.

If a failure occurs after floor acquisition, the controller keeps the session `OFF` and attempts exact-match rollback through the existing proxy-control primitive. A failed rollback retains the fail-closed floor and durable cleanup identity. Clear withdraws the session and clears request/auth ephemerals before releasing the exact floor. Restart intentionally returns to durable `OFF`, reconciles any retained exact floor, restores the prior Firefox proxy configuration, and never resumes activation.

Prepared activation requires a verified dataset/store, valid provider key, canonical externally prevalidated random-loopback floor, synchronous routing-input factory, synchronous in-memory credential resolver, and granted private-window access. Credentials are neither persisted nor exposed.

## Verification

- supply-chain: 11/11
- Chromium PAC: 26/26
- Chromium MV3: 428/428
- Firefox deterministic: 135/135 (17 activation-controller cases)
- aggregate: 580/580
- Firefox package: 13 allowlisted files
- Chromium package: 70/70; added 0, missing 0, SHA-256 differences 0
- dependencies/lockfiles: unchanged

Firefox 154.0.1 local-only E2E used the exact tracked controller with a synthetic two-rule dataset and disposable profiles. Provider Direct/MISS/Proxy, explicit Direct/Proxy, closed-A to working-B failover, degraded Proxy+Direct exhaustion, HTTP and HTTPS CONNECT proxy authentication, and private-window routing passed. A protected request paused after floor acquisition and before session publication contacted no origin. Private-access revocation caused genuine event-page recreation; the new context reconciled to `OFF` without resuming the ephemeral session. Protected-origin contacts: 0. Credential leaks: 0.

The existing production-package lifecycle smoke also confirmed genuine idle recreation remains durable `OFF`. The exact proxy-control smoke confirmed previous-manual-proxy restoration by network marker, including Clear after private revocation and OFF startup reconciliation.

The known random-loopback-port collision assumption remains documented. Production activation remains unavailable.
