### PR TITLE
Add durable Firefox activation recovery

### DIFF
--- a/docs/development/FIREFOX_MV3_SKELETON.md
+++ b/docs/development/FIREFOX_MV3_SKELETON.md
@@ -48,15 +48,16 @@ well-known и другие low ports невалидны. Кандидат high p
 primitive требует внешне prevalidated identity и не вызывается ни startup, ни
 RPC. Остаточный риск local-port collision сохраняется.
 
-Durable OFF state имеет schema v2:
+Durable state имеет schema v3; канонический `OFF` имеет форму:
 
 ```json
-{"schemaVersion":2,"intent":"OFF","floorIdentity":null}
+{"schemaVersion":3,"intent":"OFF","floorIdentity":null}
 ```
 
 `floorIdentity` может содержать только точный canonical floor, нужный для
-cleanup после interruption. Schema v1 OFF мигрирует в v2 OFF; malformed и
-future state нормализуются в OFF без floor identity. Ownership признаётся
+cleanup после interruption. Schema v1/v2 OFF мигрирует в v3 OFF; malformed и
+future state нормализуются в OFF и могут сохранить только отдельно валидную
+floor identity для безопасного cleanup. Ownership признаётся
 только при одновременных exact identity match и
 `levelOfControl === "controlled_by_this_extension"`. Clear сначала сохраняет
 OFF, очищает ephemeral requestId budgets, затем освобождает только точный
@@ -110,25 +111,56 @@ primitives не делают routing доступным. Команда
 но не вызывает: RPC, startup и storage не имеют пути к `activatePrepared`, а
 capability `activationSupported` остаётся `false`. Prepared input имеет строгую
 форму и содержит только exact prevalidated floor identity, подтверждение
-внешней проверки порта, provider key, dataset store, synchronous routing-input
-factory и synchronous in-memory credential resolver. Credentials не
-сохраняются.
+внешней проверки порта, provider key, exact dataset identity, строгий routing
+descriptor, dataset store, synchronous routing-input factory и synchronous
+in-memory credential resolver. Credentials не сохраняются.
 
-Транзакция сначала полностью проверяет dataset и строит lookup index, затем
-требует `READY`, приобретает и подтверждает exact fail-closed floor, очищает
-старое request/auth ephemeral state и только последним синхронным присваиванием
-публикует immutable active session. До floor acquisition controller остаётся
-`OFF`; между acquisition и publication обычный listener не задаёт route, а
-global floor закрывает сетевой путь. Clear сначала скрывает session и очищает
-request/auth state, только затем освобождает exact floor. Ошибка после
+Транзакция сначала полностью проверяет exact dataset и строит lookup index,
+затем требует `READY`, приобретает и подтверждает exact fail-closed floor,
+записывает строгий durable `ON`, очищает старое request/auth ephemeral state и
+только последним синхронным присваиванием публикует immutable active session.
+До floor acquisition controller остаётся `OFF`; между acquisition и publication
+обычный listener не задаёт route, а global floor закрывает сетевой путь. Clear
+сначала записывает `OFF` с cleanup identity, затем скрывает session и очищает
+request/auth state, и только после этого освобождает exact floor. Ошибка после
 acquisition запускает тот же exact-match rollback; если release невозможен,
-session остаётся `OFF`, floor и durable cleanup identity остаются fail-closed
-для следующего startup reconciliation.
+session остаётся недоступной, floor и durable cleanup identity остаются
+fail-closed для следующего startup reconciliation.
 
-Активная prepared session намеренно только ephemeral. После уничтожения event
-page новая production instance всегда начинает с `OFF`, не восстанавливает
-session или credentials и очищает сохранённый exact floor через существующий
-OFF reconciliation. Durable `ON` всё ещё не существует и не принимается.
+Durable state schema v3 различает `OFF` и строгий `ON`. `ON` содержит только
+canonical floor identity, provider key, exact dataset identity
+(`datasetVersion` + SHA-256) и routing descriptor, который ссылается на
+отдельную версионированную конфигурацию по key/version/SHA-256. Functions,
+credentials, request IDs, auth attempts и session state не сохраняются.
+Malformed или future `ON` никогда не активируется; допустимая cleanup floor
+identity сохраняется только для безопасного exact-match освобождения.
+
+Новый event page начинает с `INITIALIZING`, поэтому blocking guard отменяет
+запросы, пока storage intent неизвестен. `OFF` выполняет cleanup reconciliation
+и только затем разрешает обычный browser routing. Для `ON` recovery сначала
+требует private access и уже существующий exact extension-owned floor; старый
+random port никогда не считается заново prevalidated и floor не переустанавливается.
+Затем recovery factory должен восстановить dataset store, routing-input factory,
+тот же exact routing descriptor и in-memory credential resolver. Controller
+принимает только exact сохранённые dataset hash и routing descriptor, строит
+index, очищает ephemeral maps и публикует session последним присваиванием.
+Missing/mismatched floor переводит durable intent в `OFF`, не
+перезаписывая чужие settings. Missing configuration/dataset/credentials или
+revoked private access оставляет session недоступной, а exact floor —
+fail-closed до Clear.
+
+Prepared activation теперь фиксирует `ON` после floor confirmation, но до
+session publication. Crash до записи `ON` оставляет `OFF` + cleanup identity;
+startup очищает floor. Crash после записи `ON` восстанавливает exact session.
+Clear сначала записывает `OFF` с cleanup identity, затем скрывает session,
+очищает request/auth state и освобождает exact floor. Ошибка release сохраняет
+durable `OFF` и floor identity для следующего reconciliation.
+
+Production event page намеренно не передаёт recovery factory и по-прежнему не
+имеет пути создания `ON`: `firefox.activation.apply` возвращает
+`ACTIVATION_NOT_IMPLEMENTED`, а capability `activationSupported` равен `false`.
+Synthetic recovery factory используется только в tests/browser QA; реальная
+конфигурация, provider artifact и persistent credentials в package отсутствуют.
 
 Для каркаса используется development-only Gecko ID
 `firefox-mv3-skeleton@runet-censorship-bypass.invalid`. Production Gecko/AMO ID

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/background/activation-controller.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/background/activation-controller.js
@@ -5,9 +5,11 @@
 
   const datasetRuntime = typeof module === 'object' && module.exports ?
     require('./dataset-runtime') : root.rucbFirefoxDatasetRuntime;
+  const offState = typeof module === 'object' && module.exports ?
+    require('./off-state') : root.rucbFirefoxOffState;
   const proxyControl = typeof module === 'object' && module.exports ?
     require('./proxy-control') : root.rucbFirefoxProxyControl;
-  const api = factory(datasetRuntime, proxyControl);
+  const api = factory(datasetRuntime, offState, proxyControl);
   if (typeof module === 'object' && module.exports) {
     module.exports = api;
     return;
@@ -15,27 +17,57 @@
   root.rucbFirefoxActivationController = api;
 
 })(typeof globalThis === 'object' ? globalThis : this,
-    function(DatasetRuntime, ProxyControl) {
+    function(DatasetRuntime, OffState, ProxyControl) {
 
       const PREPARED_KEYS = Object.freeze([
+        'datasetIdentity',
         'datasetStore',
         'floorIdentity',
         'portPrevalidated',
         'providerKey',
         'resolveCredentials',
         'routingBaseInputForRequest',
+        'routingDescriptor',
       ]);
-      const PROVIDER_KEY_PATTERN = /^[a-z0-9](?:[a-z0-9._-]{0,63})$/;
-      const RESULTS = Object.freeze({ACTIVE: 'ACTIVE'});
+      const RECOVERY_KEYS = Object.freeze([
+        'datasetStore',
+        'resolveCredentials',
+        'routingBaseInputForRequest',
+        'routingDescriptor',
+      ]);
+      const RESULTS = Object.freeze({
+        ACTIVE: 'ACTIVE',
+        OFF: 'OFF',
+        RECOVERED: 'RECOVERED',
+      });
+      const RECOVERY_STATUS = Object.freeze({
+        ACTIVE: 'ACTIVE',
+        BLOCKED_PRIVATE_ACCESS: 'BLOCKED_PRIVATE_ACCESS',
+        FAILED: 'FAILED',
+        INITIALIZING: 'INITIALIZING',
+        OFF: 'OFF',
+        OFF_RECONCILIATION_FAILED: 'OFF_RECONCILIATION_FAILED',
+        RECOVERED: 'RECOVERED',
+      });
       const ERRORS = Object.freeze({
         ACTIVATION_ALREADY_ACTIVE: 'ACTIVATION_ALREADY_ACTIVE',
         ACTIVATION_INTERRUPTED: 'ACTIVATION_INTERRUPTED',
         ACTIVATION_ROLLBACK_FAILED: 'ACTIVATION_ROLLBACK_FAILED',
+        BOOT_NOT_READY: 'BOOT_NOT_READY',
+        DATASET_IDENTITY_MISMATCH: 'DATASET_IDENTITY_MISMATCH',
         DATASET_INITIALIZATION_FAILED: 'DATASET_INITIALIZATION_FAILED',
         DATASET_NOT_READY: 'DATASET_NOT_READY',
+        DURABLE_OFF_PERSIST_FAILED: 'DURABLE_OFF_PERSIST_FAILED',
+        DURABLE_ON_PERSIST_FAILED: 'DURABLE_ON_PERSIST_FAILED',
+        DURABLE_STATE_UNAVAILABLE: 'DURABLE_STATE_UNAVAILABLE',
         EPHEMERAL_CLEAR_FAILED: 'EPHEMERAL_CLEAR_FAILED',
         INVALID_CONTROLLER_DEPENDENCIES: 'INVALID_CONTROLLER_DEPENDENCIES',
         INVALID_PREPARED_ACTIVATION: 'INVALID_PREPARED_ACTIVATION',
+        INVALID_RECOVERY_RESULT: 'INVALID_RECOVERY_RESULT',
+        RECOVERY_FACTORY_FAILED: 'RECOVERY_FACTORY_FAILED',
+        RECOVERY_FLOOR_MISMATCH: 'RECOVERY_FLOOR_MISMATCH',
+        RECOVERY_UNAVAILABLE: 'RECOVERY_UNAVAILABLE',
+        ROUTING_DESCRIPTOR_MISMATCH: 'ROUTING_DESCRIPTOR_MISMATCH',
       });
 
       function hasExactKeys(value, expected) {
@@ -63,13 +95,44 @@
 
       }
 
+      function sameDatasetIdentity(leftValue, rightValue) {
+
+        function identityFields(value) {
+
+          return value && typeof value === 'object' ? {
+            providerKey: value.providerKey,
+            datasetVersion: value.datasetVersion,
+            artifactSha256: value.artifactSha256,
+          } : value;
+
+        }
+        const left = OffState.canonicalizeDatasetIdentity(
+            identityFields(leftValue),
+        );
+        const right = OffState.canonicalizeDatasetIdentity(
+            identityFields(rightValue),
+        );
+        return Boolean(left && right &&
+          OffState.DATASET_IDENTITY_KEYS.every((key) =>
+            left[key] === right[key]));
+
+      }
+
+      function sameRoutingDescriptor(leftValue, rightValue) {
+
+        const left = OffState.canonicalizeRoutingDescriptor(leftValue);
+        const right = OffState.canonicalizeRoutingDescriptor(rightValue);
+        return Boolean(left && right &&
+          OffState.ROUTING_DESCRIPTOR_KEYS.every((key) =>
+            left[key] === right[key]));
+
+      }
+
       function validatePreparedActivation(value) {
 
         try {
           if (!hasExactKeys(value, PREPARED_KEYS) ||
               value.portPrevalidated !== true ||
-              typeof value.providerKey !== 'string' ||
-              !PROVIDER_KEY_PATTERN.test(value.providerKey) ||
               !value.datasetStore ||
               typeof value.datasetStore.loadVerifications !== 'function' ||
               !isSynchronousCallable(value.routingBaseInputForRequest) ||
@@ -79,16 +142,52 @@
           const floorIdentity = ProxyControl.canonicalizeFloorIdentity(
               value.floorIdentity,
           );
-          if (!floorIdentity) {
+          const datasetIdentity = OffState.canonicalizeDatasetIdentity(
+              value.datasetIdentity,
+          );
+          const routingDescriptor = OffState.canonicalizeRoutingDescriptor(
+              value.routingDescriptor,
+          );
+          if (!floorIdentity || !datasetIdentity || !routingDescriptor ||
+              value.providerKey !== datasetIdentity.providerKey) {
+            return null;
+          }
+          return Object.freeze({
+            datasetIdentity: Object.freeze(datasetIdentity),
+            datasetStore: value.datasetStore,
+            floorIdentity: Object.freeze(floorIdentity),
+            portPrevalidated: true,
+            providerKey: datasetIdentity.providerKey,
+            resolveCredentials: value.resolveCredentials,
+            routingBaseInputForRequest: value.routingBaseInputForRequest,
+            routingDescriptor: Object.freeze(routingDescriptor),
+          });
+        } catch (_error) {
+          return null;
+        }
+
+      }
+
+      function validateRecoveryResult(value) {
+
+        try {
+          if (!hasExactKeys(value, RECOVERY_KEYS) || !value.datasetStore ||
+              typeof value.datasetStore.loadVerifications !== 'function' ||
+              !isSynchronousCallable(value.routingBaseInputForRequest) ||
+              !isSynchronousCallable(value.resolveCredentials)) {
+            return null;
+          }
+          const routingDescriptor = OffState.canonicalizeRoutingDescriptor(
+              value.routingDescriptor,
+          );
+          if (!routingDescriptor) {
             return null;
           }
           return Object.freeze({
             datasetStore: value.datasetStore,
-            floorIdentity: Object.freeze(floorIdentity),
-            portPrevalidated: true,
-            providerKey: value.providerKey,
             resolveCredentials: value.resolveCredentials,
             routingBaseInputForRequest: value.routingBaseInputForRequest,
+            routingDescriptor: Object.freeze(routingDescriptor),
           });
         } catch (_error) {
           return null;
@@ -101,22 +200,37 @@
         const floorControl = options.proxyControl;
         const routingAdapter = options.routingAdapter;
         const proxyAuth = options.proxyAuth;
+        const storageArea = options.storageArea;
         const createDatasetRuntime = options.createDatasetRuntime ||
           DatasetRuntime.createRuntime;
+        const recoveryFactory = options.recoveryFactory;
         const afterFloorAcquired = options.afterFloorAcquired;
+        const afterDurableOnPersisted = options.afterDurableOnPersisted;
         if (!floorControl ||
             typeof floorControl.acquirePrevalidatedFloor !== 'function' ||
+            typeof floorControl.checkPrivateAccess !== 'function' ||
             typeof floorControl.clearFloor !== 'function' ||
+            typeof floorControl.inspectOwnedFloor !== 'function' ||
             !routingAdapter ||
             typeof routingAdapter.clearAllAuthorizations !== 'function' ||
             !proxyAuth || typeof proxyAuth.clearAllAttempts !== 'function' ||
+            !storageArea || typeof storageArea.get !== 'function' ||
+            typeof storageArea.set !== 'function' ||
             typeof createDatasetRuntime !== 'function' ||
+            (recoveryFactory !== undefined &&
+              typeof recoveryFactory !== 'function') ||
             (afterFloorAcquired !== undefined &&
-              typeof afterFloorAcquired !== 'function')) {
+              typeof afterFloorAcquired !== 'function') ||
+            (afterDurableOnPersisted !== undefined &&
+              typeof afterDurableOnPersisted !== 'function')) {
           throw new TypeError(ERRORS.INVALID_CONTROLLER_DEPENDENCIES);
         }
 
         let activeSession = null;
+        let durableState = null;
+        let runtimeState = DatasetRuntime.STATES.INITIALIZING;
+        let recoveryStatus = RECOVERY_STATUS.INITIALIZING;
+        let failureCode = null;
         let operationQueue = Promise.resolve();
 
         function enqueue(operation) {
@@ -144,11 +258,42 @@
 
         }
 
+        function setUnavailable(code, status = RECOVERY_STATUS.FAILED) {
+
+          activeSession = null;
+          runtimeState = DatasetRuntime.STATES.FAILED;
+          recoveryStatus = status;
+          failureCode = code;
+
+        }
+
+        function setOff(state, status = RECOVERY_STATUS.OFF, code = null) {
+
+          activeSession = null;
+          durableState = state;
+          runtimeState = DatasetRuntime.STATES.OFF;
+          recoveryStatus = status;
+          failureCode = code;
+
+        }
+
+        function publishSession(runtime, resolveCredentials, status) {
+
+          activeSession = Object.freeze({
+            datasetRuntime: runtime,
+            resolveCredentials,
+          });
+          runtimeState = DatasetRuntime.STATES.READY;
+          recoveryStatus = status;
+          failureCode = null;
+
+        }
+
         function currentRuntimeState() {
 
           const session = activeSession;
           if (!session) {
-            return DatasetRuntime.STATES.OFF;
+            return runtimeState;
           }
           try {
             return session.datasetRuntime.getState() ===
@@ -184,45 +329,15 @@
 
         }
 
-        async function rollback(code) {
-
-          activeSession = null;
-          clearEphemeralState();
-          let cleared;
-          try {
-            cleared = await floorControl.clearFloor();
-          } catch (_error) {
-            cleared = null;
-          }
-          if (!cleared || cleared.ok !== true) {
-            return errorResult(ERRORS.ACTIVATION_ROLLBACK_FAILED, {
-              cause: {code},
-              floorRetained: true,
-            });
-          }
-          return errorResult(code, {
-            rollback: {ok: true, status: cleared.status},
-          });
-
-        }
-
-        async function activatePreparedNow(input) {
-
-          if (activeSession) {
-            return errorResult(ERRORS.ACTIVATION_ALREADY_ACTIVE);
-          }
-          const prepared = validatePreparedActivation(input);
-          if (!prepared) {
-            return errorResult(ERRORS.INVALID_PREPARED_ACTIVATION);
-          }
+        async function buildExactRuntime(input) {
 
           let runtime;
           try {
             runtime = createDatasetRuntime({
               protectionIntended: true,
-              providerKey: prepared.providerKey,
-              store: prepared.datasetStore,
-              baseInputForRequest: prepared.routingBaseInputForRequest,
+              providerKey: input.providerKey,
+              store: input.datasetStore,
+              baseInputForRequest: input.routingBaseInputForRequest,
             });
           } catch (_error) {
             return errorResult(ERRORS.DATASET_INITIALIZATION_FAILED);
@@ -232,25 +347,95 @@
               typeof runtime.routingInputForRequest !== 'function') {
             return errorResult(ERRORS.DATASET_INITIALIZATION_FAILED);
           }
-
           let initialized;
           try {
             initialized = await runtime.initialize();
           } catch (_error) {
             return errorResult(ERRORS.DATASET_INITIALIZATION_FAILED);
           }
-          let initializedReady = false;
-          try {
-            initializedReady = Boolean(initialized) &&
-              initialized.state === DatasetRuntime.STATES.READY &&
-              runtime.getState() === DatasetRuntime.STATES.READY;
-          } catch (_error) {
-            initializedReady = false;
+          if (!initialized ||
+              initialized.state !== DatasetRuntime.STATES.READY ||
+              runtime.getState() !== DatasetRuntime.STATES.READY) {
+            return errorResult(
+                initialized && initialized.failureCode ?
+                  initialized.failureCode : ERRORS.DATASET_NOT_READY,
+            );
           }
-          if (!initializedReady) {
-            const code = initialized && initialized.failureCode ?
-              initialized.failureCode : ERRORS.DATASET_NOT_READY;
-            return errorResult(code);
+          if (!sameDatasetIdentity(initialized.selected, input.datasetIdentity)) {
+            return errorResult(ERRORS.DATASET_IDENTITY_MISMATCH);
+          }
+          return {ok: true, runtime, selected: initialized.selected};
+
+        }
+
+        async function rollback(code) {
+
+          activeSession = null;
+          runtimeState = DatasetRuntime.STATES.INITIALIZING;
+          clearEphemeralState();
+          try {
+            durableState = await OffState.writeOffState(
+                storageArea,
+                durableState && durableState.floorIdentity || null,
+            );
+          } catch (_error) {
+            // The exact proxy-control Clear below makes the same durable OFF
+            // transition before releasing the floor and may still recover it.
+          }
+          let cleared;
+          try {
+            cleared = await floorControl.clearFloor();
+          } catch (_error) {
+            cleared = null;
+          }
+          if (!cleared || cleared.ok !== true) {
+            if (cleared && cleared.durableState) {
+              durableState = cleared.durableState;
+            }
+            setUnavailable(ERRORS.ACTIVATION_ROLLBACK_FAILED);
+            return errorResult(ERRORS.ACTIVATION_ROLLBACK_FAILED, {
+              cause: {code},
+              floorRetained: true,
+            });
+          }
+          setOff(cleared.durableState || OffState.canonicalOffState());
+          return errorResult(code, {
+            rollback: {ok: true, status: cleared.status},
+          });
+
+        }
+
+        async function persistOn(prepared) {
+
+          try {
+            return await OffState.writeOnState(storageArea, {
+              floorIdentity: prepared.floorIdentity,
+              providerKey: prepared.providerKey,
+              datasetIdentity: prepared.datasetIdentity,
+              routingDescriptor: prepared.routingDescriptor,
+            });
+          } catch (_error) {
+            return null;
+          }
+
+        }
+
+        async function activatePreparedNow(input) {
+
+          if (activeSession) {
+            return errorResult(ERRORS.ACTIVATION_ALREADY_ACTIVE);
+          }
+          if (!durableState || durableState.intent !== OffState.OFF ||
+              runtimeState !== DatasetRuntime.STATES.OFF) {
+            return errorResult(ERRORS.BOOT_NOT_READY);
+          }
+          const prepared = validatePreparedActivation(input);
+          if (!prepared) {
+            return errorResult(ERRORS.INVALID_PREPARED_ACTIVATION);
+          }
+          const exactRuntime = await buildExactRuntime(prepared);
+          if (!exactRuntime.ok) {
+            return exactRuntime;
           }
 
           let acquired;
@@ -260,32 +445,53 @@
               portPrevalidated: true,
             });
           } catch (_error) {
+            setUnavailable(ProxyControl.ERRORS.PROXY_SET_FAILED);
             return errorResult(ProxyControl.ERRORS.PROXY_SET_FAILED);
           }
           if (!acquired || acquired.ok !== true) {
             const code = acquired && acquired.error && acquired.error.code ?
               acquired.error.code : ProxyControl.ERRORS.PROXY_SET_FAILED;
+            if (acquired && acquired.durableState) {
+              durableState = acquired.durableState;
+              runtimeState = DatasetRuntime.STATES.INITIALIZING;
+              recoveryStatus = RECOVERY_STATUS.INITIALIZING;
+              return rollback(code);
+            }
             return errorResult(code);
           }
+          durableState = acquired.durableState ||
+            OffState.canonicalOffState(prepared.floorIdentity);
+          runtimeState = DatasetRuntime.STATES.INITIALIZING;
+          recoveryStatus = RECOVERY_STATUS.INITIALIZING;
 
           try {
             if (afterFloorAcquired) {
               await afterFloorAcquired();
             }
-            if (runtime.getState() !== DatasetRuntime.STATES.READY) {
+            const persistedOn = await persistOn(prepared);
+            if (!persistedOn) {
+              return rollback(ERRORS.DURABLE_ON_PERSIST_FAILED);
+            }
+            durableState = persistedOn;
+            if (afterDurableOnPersisted) {
+              await afterDurableOnPersisted();
+            }
+            if (exactRuntime.runtime.getState() !==
+                DatasetRuntime.STATES.READY) {
               return rollback(ERRORS.DATASET_NOT_READY);
             }
             if (!clearEphemeralState()) {
               return rollback(ERRORS.EPHEMERAL_CLEAR_FAILED);
             }
-            activeSession = Object.freeze({
-              datasetRuntime: runtime,
-              resolveCredentials: prepared.resolveCredentials,
-            });
+            publishSession(
+                exactRuntime.runtime,
+                prepared.resolveCredentials,
+                RECOVERY_STATUS.ACTIVE,
+            );
             return {
               ok: true,
               status: RESULTS.ACTIVE,
-              dataset: initialized.selected || null,
+              dataset: exactRuntime.selected,
             };
           } catch (_error) {
             return rollback(ERRORS.ACTIVATION_INTERRUPTED);
@@ -293,9 +499,185 @@
 
         }
 
+        async function transitionLostFloorToOff() {
+
+          try {
+            const next = await OffState.writeOffState(storageArea, null);
+            clearEphemeralState();
+            setOff(next);
+            return true;
+          } catch (_error) {
+            setUnavailable(ERRORS.DURABLE_OFF_PERSIST_FAILED);
+            return false;
+          }
+
+        }
+
+        async function recoverOnState(state) {
+
+          const privateAccess = await floorControl.checkPrivateAccess();
+          const owned = await floorControl.inspectOwnedFloor(
+              state.floorIdentity,
+          );
+          if (!owned || owned.ok !== true) {
+            if (owned && owned.error &&
+                owned.error.code === ProxyControl.ERRORS.OWNERSHIP_MISMATCH) {
+              const transitioned = await transitionLostFloorToOff();
+              return errorResult(transitioned ?
+                ERRORS.RECOVERY_FLOOR_MISMATCH :
+                ERRORS.DURABLE_OFF_PERSIST_FAILED, {
+                transitionedToOff: transitioned,
+              });
+            }
+            const code = owned && owned.error && owned.error.code ?
+              owned.error.code : ProxyControl.ERRORS.PROXY_READ_FAILED;
+            setUnavailable(code);
+            return errorResult(code, {floorRetained: true});
+          }
+          if (!privateAccess || privateAccess.ok !== true) {
+            const code = privateAccess && privateAccess.error &&
+              privateAccess.error.code ===
+                ProxyControl.ERRORS.PRIVATE_ACCESS_REQUIRED ?
+              RECOVERY_STATUS.BLOCKED_PRIVATE_ACCESS :
+              ProxyControl.ERRORS.PRIVATE_ACCESS_CHECK_FAILED;
+            setUnavailable(code, code === RECOVERY_STATUS.BLOCKED_PRIVATE_ACCESS ?
+              RECOVERY_STATUS.BLOCKED_PRIVATE_ACCESS :
+              RECOVERY_STATUS.FAILED);
+            return errorResult(code, {floorRetained: true});
+          }
+          if (typeof recoveryFactory !== 'function') {
+            setUnavailable(ERRORS.RECOVERY_UNAVAILABLE);
+            return errorResult(ERRORS.RECOVERY_UNAVAILABLE, {
+              floorRetained: true,
+            });
+          }
+
+          let recovered;
+          try {
+            recovered = validateRecoveryResult(await recoveryFactory(
+                OffState.canonicalOnState(state),
+            ));
+          } catch (_error) {
+            setUnavailable(ERRORS.RECOVERY_FACTORY_FAILED);
+            return errorResult(ERRORS.RECOVERY_FACTORY_FAILED, {
+              floorRetained: true,
+            });
+          }
+          if (!recovered) {
+            setUnavailable(ERRORS.INVALID_RECOVERY_RESULT);
+            return errorResult(ERRORS.INVALID_RECOVERY_RESULT, {
+              floorRetained: true,
+            });
+          }
+          if (!sameRoutingDescriptor(
+              recovered.routingDescriptor,
+              state.routingDescriptor,
+          )) {
+            setUnavailable(ERRORS.ROUTING_DESCRIPTOR_MISMATCH);
+            return errorResult(ERRORS.ROUTING_DESCRIPTOR_MISMATCH, {
+              floorRetained: true,
+            });
+          }
+          const exactRuntime = await buildExactRuntime({
+            datasetIdentity: state.datasetIdentity,
+            datasetStore: recovered.datasetStore,
+            providerKey: state.providerKey,
+            routingBaseInputForRequest: recovered.routingBaseInputForRequest,
+          });
+          if (!exactRuntime.ok) {
+            setUnavailable(exactRuntime.error.code);
+            return errorResult(exactRuntime.error.code, {floorRetained: true});
+          }
+          if (!clearEphemeralState()) {
+            setUnavailable(ERRORS.EPHEMERAL_CLEAR_FAILED);
+            return errorResult(ERRORS.EPHEMERAL_CLEAR_FAILED, {
+              floorRetained: true,
+            });
+          }
+          publishSession(
+              exactRuntime.runtime,
+              recovered.resolveCredentials,
+              RECOVERY_STATUS.RECOVERED,
+          );
+          return {
+            ok: true,
+            status: RESULTS.RECOVERED,
+            dataset: exactRuntime.selected,
+          };
+
+        }
+
+        async function initializeFromDurableNow() {
+
+          if (activeSession &&
+              currentRuntimeState() === DatasetRuntime.STATES.READY) {
+            return {ok: true, status: recoveryStatus};
+          }
+          activeSession = null;
+          runtimeState = DatasetRuntime.STATES.INITIALIZING;
+          recoveryStatus = RECOVERY_STATUS.INITIALIZING;
+          failureCode = null;
+          clearEphemeralState();
+          let state;
+          try {
+            state = await OffState.initialize(storageArea);
+          } catch (_error) {
+            durableState = null;
+            setUnavailable(ERRORS.DURABLE_STATE_UNAVAILABLE);
+            return errorResult(ERRORS.DURABLE_STATE_UNAVAILABLE);
+          }
+          durableState = state;
+          if (state.intent === OffState.ON) {
+            return recoverOnState(state);
+          }
+          let reconciliation;
+          try {
+            reconciliation = await floorControl.reconcileOffOnStartup();
+          } catch (_error) {
+            reconciliation = null;
+          }
+          if (reconciliation && reconciliation.durableState) {
+            durableState = reconciliation.durableState;
+          }
+          if (!reconciliation || reconciliation.ok !== true) {
+            const code = reconciliation && reconciliation.error &&
+              reconciliation.error.code ? reconciliation.error.code :
+              ProxyControl.ERRORS.PROXY_CLEAR_FAILED;
+            setOff(
+                durableState || state,
+                RECOVERY_STATUS.OFF_RECONCILIATION_FAILED,
+                code,
+            );
+            return errorResult(code, {intent: OffState.OFF});
+          }
+          setOff(reconciliation.durableState || state);
+          return {ok: true, status: RESULTS.OFF};
+
+        }
+
         async function clearNow() {
 
+          let state = durableState;
+          if (!state) {
+            try {
+              state = await OffState.initialize(storageArea);
+            } catch (_error) {
+              return errorResult(ERRORS.DURABLE_STATE_UNAVAILABLE);
+            }
+          }
+          let persistedOff;
+          try {
+            persistedOff = await OffState.writeOffState(
+                storageArea,
+                state.floorIdentity || null,
+            );
+          } catch (_error) {
+            return errorResult(ERRORS.DURABLE_OFF_PERSIST_FAILED);
+          }
+          durableState = persistedOff;
           activeSession = null;
+          runtimeState = DatasetRuntime.STATES.INITIALIZING;
+          recoveryStatus = RECOVERY_STATUS.INITIALIZING;
           const ephemeralCleared = clearEphemeralState();
           let cleared;
           try {
@@ -306,8 +688,14 @@
           if (!cleared || cleared.ok !== true) {
             const code = cleared && cleared.error && cleared.error.code ?
               cleared.error.code : ProxyControl.ERRORS.PROXY_CLEAR_FAILED;
+            if (cleared && cleared.durableState) {
+              durableState = cleared.durableState;
+            }
+            setOff(durableState, RECOVERY_STATUS.OFF_RECONCILIATION_FAILED,
+                code);
             return errorResult(code, {floorRetained: true});
           }
+          setOff(cleared.durableState || OffState.canonicalOffState());
           if (!ephemeralCleared) {
             return errorResult(ERRORS.EPHEMERAL_CLEAR_FAILED);
           }
@@ -320,6 +708,9 @@
           return Object.freeze({
             runtimeState: currentRuntimeState(),
             active: activeSession !== null,
+            durableIntent: durableState ? durableState.intent : null,
+            recoveryStatus,
+            failureCode,
           });
 
         }
@@ -336,6 +727,11 @@
 
           },
           currentRuntimeState,
+          initializeFromDurable() {
+
+            return enqueue(initializeFromDurableNow);
+
+          },
           resolveCredentials,
           routingInputForRequest,
           snapshot,
@@ -346,9 +742,14 @@
       return Object.freeze({
         ERRORS,
         PREPARED_KEYS,
+        RECOVERY_KEYS,
+        RECOVERY_STATUS,
         RESULTS,
         createController,
+        sameDatasetIdentity,
+        sameRoutingDescriptor,
         validatePreparedActivation,
+        validateRecoveryResult,
       });
 
     });

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/background/event-page.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/background/event-page.js
@@ -10,7 +10,7 @@
   let activationController = null;
   const routingAdapter = routing.createAdapter({
     runtimeStateForRequest: () => activationController ?
-      activationController.currentRuntimeState() : routing.STATES.OFF,
+      activationController.currentRuntimeState() : routing.STATES.INITIALIZING,
     routingInputForRequest: (details) =>
       activationController.routingInputForRequest(details),
   });
@@ -36,8 +36,8 @@
     proxyControl,
     routingAdapter,
     proxyAuth,
+    storageArea: browser.storage.local,
   });
-  const durableIntent = offState.OFF;
   const bootId = root.crypto && typeof root.crypto.randomUUID === 'function' ?
     root.crypto.randomUUID() :
     `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
@@ -65,15 +65,18 @@
     const type = message && typeof message === 'object' ? message.type : null;
     if (type === 'firefox.capabilities.get') {
       const manifest = browser.runtime.getManifest();
+      const activation = activationController.snapshot();
       return {
         ok: true,
         result: {
-          apiVersion: 1,
+          apiVersion: 2,
           browser: 'FIREFOX',
           manifestVersion: manifest.manifest_version,
           runtimeModel: 'BACKGROUND_EVENT_PAGE',
-          runtimeState: activationController.currentRuntimeState(),
-          durableIntent,
+          runtimeState: activation.runtimeState,
+          durableIntent: activation.durableIntent,
+          recoveryStatus: activation.recoveryStatus,
+          recoveryFailureCode: activation.failureCode,
           privateWindowAccess: await readPrivateWindowAccess(),
           routingImplemented: true,
           activationSupported: false,
@@ -129,10 +132,7 @@
   );
   browser.runtime.onMessage.addListener(handleMessage);
 
-  const initialization = proxyControl.reconcileOffOnStartup()
-      .then((reconciliation) =>
-        reconciliation.durableState || offState.canonicalState())
-      .catch(() => offState.canonicalState());
+  const initialization = activationController.initializeFromDurable();
 
   root.rucbFirefoxSkeletonRuntime = Object.freeze({
     bootId,

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/background/off-state.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/background/off-state.js
@@ -12,14 +12,24 @@
 })(typeof globalThis === 'object' ? globalThis : this, function() {
 
   const STORAGE_KEY = 'firefoxMv3InertState';
-  const SCHEMA_VERSION = 2;
+  const SCHEMA_VERSION = 3;
+  const ROUTING_DESCRIPTOR_SCHEMA_VERSION = 1;
   const OFF = 'OFF';
+  const ON = 'ON';
   const MIN_FLOOR_PORT = 49152;
   const MAX_FLOOR_PORT = 65535;
-  const STATE_KEYS = Object.freeze([
+  const OFF_STATE_KEYS = Object.freeze([
     'schemaVersion',
     'intent',
     'floorIdentity',
+  ]);
+  const ON_STATE_KEYS = Object.freeze([
+    'schemaVersion',
+    'intent',
+    'floorIdentity',
+    'providerKey',
+    'datasetIdentity',
+    'routingDescriptor',
   ]);
   const FLOOR_KEYS = Object.freeze([
     'proxyType',
@@ -32,6 +42,20 @@
     'passthrough',
     'autoConfigUrl',
   ]);
+  const DATASET_IDENTITY_KEYS = Object.freeze([
+    'providerKey',
+    'datasetVersion',
+    'artifactSha256',
+  ]);
+  const ROUTING_DESCRIPTOR_KEYS = Object.freeze([
+    'schemaVersion',
+    'configurationKey',
+    'configurationVersion',
+    'configurationSha256',
+  ]);
+  const IDENTIFIER_PATTERN = /^[a-z0-9](?:[a-z0-9._-]{0,63})$/;
+  const VERSION_PATTERN = /^[A-Za-z0-9](?:[A-Za-z0-9._+-]{0,127})$/;
+  const SHA256_PATTERN = /^[a-f0-9]{64}$/;
 
   function hasExactKeys(value, keys) {
 
@@ -75,7 +99,47 @@
 
   }
 
-  function canonicalState(floorIdentity = null) {
+  function canonicalizeDatasetIdentity(value) {
+
+    if (!hasExactKeys(value, DATASET_IDENTITY_KEYS) ||
+        typeof value.providerKey !== 'string' ||
+        !IDENTIFIER_PATTERN.test(value.providerKey) ||
+        typeof value.datasetVersion !== 'string' ||
+        !VERSION_PATTERN.test(value.datasetVersion) ||
+        typeof value.artifactSha256 !== 'string' ||
+        !SHA256_PATTERN.test(value.artifactSha256)) {
+      return null;
+    }
+    return {
+      providerKey: value.providerKey,
+      datasetVersion: value.datasetVersion,
+      artifactSha256: value.artifactSha256,
+    };
+
+  }
+
+  function canonicalizeRoutingDescriptor(value) {
+
+    if (!hasExactKeys(value, ROUTING_DESCRIPTOR_KEYS) ||
+        value.schemaVersion !== ROUTING_DESCRIPTOR_SCHEMA_VERSION ||
+        typeof value.configurationKey !== 'string' ||
+        !IDENTIFIER_PATTERN.test(value.configurationKey) ||
+        typeof value.configurationVersion !== 'string' ||
+        !VERSION_PATTERN.test(value.configurationVersion) ||
+        typeof value.configurationSha256 !== 'string' ||
+        !SHA256_PATTERN.test(value.configurationSha256)) {
+      return null;
+    }
+    return {
+      schemaVersion: ROUTING_DESCRIPTOR_SCHEMA_VERSION,
+      configurationKey: value.configurationKey,
+      configurationVersion: value.configurationVersion,
+      configurationSha256: value.configurationSha256,
+    };
+
+  }
+
+  function canonicalOffState(floorIdentity = null) {
 
     const floor = floorIdentity === null ? null :
       canonicalizeFloorIdentity(floorIdentity);
@@ -86,24 +150,102 @@
 
   }
 
-  function isCanonicalState(value) {
+  function canonicalOnState(value) {
+
+    const floorIdentity = canonicalizeFloorIdentity(
+        value && value.floorIdentity,
+    );
+    const datasetIdentity = canonicalizeDatasetIdentity(
+        value && value.datasetIdentity,
+    );
+    const routingDescriptor = canonicalizeRoutingDescriptor(
+        value && value.routingDescriptor,
+    );
+    const providerKey = value && value.providerKey;
+    if (!floorIdentity || !datasetIdentity || !routingDescriptor ||
+        typeof providerKey !== 'string' ||
+        !IDENTIFIER_PATTERN.test(providerKey) ||
+        providerKey !== datasetIdentity.providerKey) {
+      throw new TypeError('INVALID_FIREFOX_ON_STATE');
+    }
+    return {
+      schemaVersion: SCHEMA_VERSION,
+      intent: ON,
+      floorIdentity,
+      providerKey,
+      datasetIdentity,
+      routingDescriptor,
+    };
+
+  }
+
+  function canonicalState(floorIdentity = null) {
+
+    return canonicalOffState(floorIdentity);
+
+  }
+
+  function isCanonicalOffState(value) {
 
     return Boolean(
-        hasExactKeys(value, STATE_KEYS) &&
-        value.schemaVersion === SCHEMA_VERSION &&
-        value.intent === OFF &&
+        hasExactKeys(value, OFF_STATE_KEYS) &&
+        value.schemaVersion === SCHEMA_VERSION && value.intent === OFF &&
         (value.floorIdentity === null ||
           canonicalizeFloorIdentity(value.floorIdentity) !== null),
     );
 
   }
 
+  function isCanonicalOnState(value) {
+
+    if (!hasExactKeys(value, ON_STATE_KEYS) ||
+        value.schemaVersion !== SCHEMA_VERSION || value.intent !== ON) {
+      return false;
+    }
+    try {
+      canonicalOnState(value);
+      return true;
+    } catch (_error) {
+      return false;
+    }
+
+  }
+
+  function isCanonicalState(value) {
+
+    return isCanonicalOffState(value) || isCanonicalOnState(value);
+
+  }
+
+  function cleanupFloorFromMalformedState(value) {
+
+    try {
+      return canonicalizeFloorIdentity(value && value.floorIdentity);
+    } catch (_error) {
+      return null;
+    }
+
+  }
+
   function normalizeDurableState(value) {
 
-    if (isCanonicalState(value)) {
-      return canonicalState(value.floorIdentity);
+    if (isCanonicalOffState(value)) {
+      return canonicalOffState(value.floorIdentity);
     }
-    return canonicalState();
+    if (isCanonicalOnState(value)) {
+      return canonicalOnState(value);
+    }
+    if (hasExactKeys(value, OFF_STATE_KEYS) &&
+        value.schemaVersion === 2 && value.intent === OFF) {
+      const oldFloor = value.floorIdentity === null ? null :
+        canonicalizeFloorIdentity(value.floorIdentity);
+      return canonicalOffState(oldFloor);
+    }
+    if (value && typeof value === 'object' && !Array.isArray(value) &&
+        value.schemaVersion === 1 && value.intent === OFF) {
+      return canonicalOffState();
+    }
+    return canonicalOffState(cleanupFloorFromMalformedState(value));
 
   }
 
@@ -132,25 +274,47 @@
   async function writeOffState(storageArea, floorIdentity) {
 
     requireStorage(storageArea);
-    const state = canonicalState(floorIdentity);
+    const state = canonicalOffState(floorIdentity);
+    await storageArea.set({[STORAGE_KEY]: state});
+    return state;
+
+  }
+
+  async function writeOnState(storageArea, value) {
+
+    requireStorage(storageArea);
+    const state = canonicalOnState(value);
     await storageArea.set({[STORAGE_KEY]: state});
     return state;
 
   }
 
   return Object.freeze({
+    DATASET_IDENTITY_KEYS,
     FLOOR_KEYS,
     MAX_FLOOR_PORT,
     MIN_FLOOR_PORT,
     OFF,
+    OFF_STATE_KEYS,
+    ON,
+    ON_STATE_KEYS,
+    ROUTING_DESCRIPTOR_KEYS,
+    ROUTING_DESCRIPTOR_SCHEMA_VERSION,
     SCHEMA_VERSION,
     STORAGE_KEY,
+    canonicalOffState,
+    canonicalOnState,
     canonicalState,
+    canonicalizeDatasetIdentity,
     canonicalizeFloorIdentity,
+    canonicalizeRoutingDescriptor,
     initialize,
+    isCanonicalOffState,
+    isCanonicalOnState,
     isCanonicalState,
     normalizeDurableState,
     writeOffState,
+    writeOnState,
   });
 
 });

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/background/proxy-control.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/background/proxy-control.js
@@ -20,6 +20,7 @@
         ACQUIRED: 'ACQUIRED',
         ALREADY_CLEAR: 'ALREADY_CLEAR',
         CLEARED: 'CLEARED',
+        OWNED: 'OWNED',
       });
       const ERRORS = Object.freeze({
         EPHEMERAL_CLEAR_FAILED: 'EPHEMERAL_CLEAR_FAILED',
@@ -193,6 +194,43 @@
 
         }
 
+        async function checkPrivateAccessNow() {
+
+          if (typeof isPrivateAccessAllowed !== 'function') {
+            return errorResult(ERRORS.PRIVATE_ACCESS_CHECK_FAILED);
+          }
+          try {
+            if (await isPrivateAccessAllowed() !== true) {
+              return errorResult(ERRORS.PRIVATE_ACCESS_REQUIRED);
+            }
+          } catch (_error) {
+            return errorResult(ERRORS.PRIVATE_ACCESS_CHECK_FAILED);
+          }
+          return {ok: true};
+
+        }
+
+        async function inspectOwnedFloorNow(value) {
+
+          const floorIdentity = canonicalizeFloorIdentity(value);
+          if (!floorIdentity) {
+            return errorResult(ERRORS.INVALID_FLOOR_IDENTITY);
+          }
+          const liveResult = await readLiveSettings();
+          if (!liveResult.ok) {
+            return liveResult;
+          }
+          if (!isExactOwnedFloor(liveResult.live, floorIdentity)) {
+            return errorResult(ERRORS.OWNERSHIP_MISMATCH);
+          }
+          return {
+            ok: true,
+            status: RESULTS.OWNED,
+            floorIdentity,
+          };
+
+        }
+
         async function acquirePrevalidatedFloorNow(request) {
 
           const floorIdentity = canonicalizeFloorIdentity(
@@ -204,17 +242,9 @@
           if (!request || request.portPrevalidated !== true) {
             return errorResult(ERRORS.PORT_PREVALIDATION_REQUIRED);
           }
-          if (typeof isPrivateAccessAllowed !== 'function') {
-            return errorResult(ERRORS.PRIVATE_ACCESS_CHECK_FAILED);
-          }
-          let privateAccess;
-          try {
-            privateAccess = await isPrivateAccessAllowed();
-          } catch (_error) {
-            return errorResult(ERRORS.PRIVATE_ACCESS_CHECK_FAILED);
-          }
-          if (privateAccess !== true) {
-            return errorResult(ERRORS.PRIVATE_ACCESS_REQUIRED);
+          const privateAccess = await checkPrivateAccessNow();
+          if (!privateAccess.ok) {
+            return privateAccess;
           }
           const durableState = await persistFloorIdentity(floorIdentity);
           if (!durableState) {
@@ -296,6 +326,16 @@
           clearFloor() {
 
             return enqueue(clearFloorNow);
+
+          },
+          checkPrivateAccess() {
+
+            return enqueue(checkPrivateAccessNow);
+
+          },
+          inspectOwnedFloor(floorIdentity) {
+
+            return enqueue(() => inspectOwnedFloorNow(floorIdentity));
 
           },
           reconcileOffOnStartup() {

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/activation-controller.test.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/activation-controller.test.js
@@ -4,6 +4,7 @@ const Assert = require('node:assert');
 const Activation = require('../background/activation-controller');
 const DatasetRuntime = require('../background/dataset-runtime');
 const DatasetStore = require('../background/dataset-store');
+const OffState = require('../background/off-state');
 const ProxyAuth = require('../background/proxy-auth');
 const ProxyControl = require('../background/proxy-control');
 const Routing = require('../../extension-mv3-common/routing-contract');
@@ -72,13 +73,25 @@ function baseInputForRequest(proxyCandidate = candidate()) {
 
 function prepared(datasetStore, overrides = {}) {
 
+  const envelope = Helpers.artifact().envelope;
   return Object.assign({
+    datasetIdentity: {
+      providerKey: envelope.providerKey,
+      datasetVersion: envelope.datasetVersion,
+      artifactSha256: envelope.artifactSha256,
+    },
     datasetStore,
     floorIdentity: floor(),
     portPrevalidated: true,
     providerKey: Helpers.PROVIDER_KEY,
     resolveCredentials: () => null,
     routingBaseInputForRequest: baseInputForRequest(),
+    routingDescriptor: {
+      schemaVersion: 1,
+      configurationKey: 'synthetic-routing',
+      configurationVersion: '1',
+      configurationSha256: 'a'.repeat(64),
+    },
   }, overrides);
 
 }
@@ -86,26 +99,68 @@ function prepared(datasetStore, overrides = {}) {
 function createHarness(options = {}) {
 
   const events = [];
-  const floorControl = options.proxyControl || {
+  const values = {
+    [OffState.STORAGE_KEY]: options.durableState ||
+      OffState.canonicalOffState(),
+  };
+  const storageArea = options.storageArea || {
+    async get(key) {
+
+      return {[key]: values[key]};
+
+    },
+    async set(update) {
+
+      Object.assign(values, JSON.parse(JSON.stringify(update)));
+
+    },
+  };
+  const floorControl = Object.assign({
     async acquirePrevalidatedFloor(request) {
 
       events.push(['floor-acquire', request]);
+      const durableState = await OffState.writeOffState(
+          storageArea,
+          request.floorIdentity,
+      );
       return options.acquireResult || {
         ok: true,
         status: ProxyControl.RESULTS.ACQUIRED,
+        durableState,
       };
 
     },
     async clearFloor() {
 
       events.push(['floor-clear']);
+      const durableState = await OffState.writeOffState(storageArea, null);
       return options.clearResult || {
         ok: true,
         status: ProxyControl.RESULTS.CLEARED,
+        durableState,
       };
 
     },
-  };
+    async checkPrivateAccess() {
+
+      return {ok: true};
+
+    },
+    async inspectOwnedFloor() {
+
+      return {ok: true, status: ProxyControl.RESULTS.OWNED};
+
+    },
+    async reconcileOffOnStartup() {
+
+      return {
+        ok: true,
+        status: ProxyControl.RESULTS.ALREADY_CLEAR,
+        durableState: await OffState.writeOffState(storageArea, null),
+      };
+
+    },
+  }, options.proxyControl || {});
   let controller = null;
   const routingAdapter = RoutingAdapter.createAdapter({
     runtimeStateForRequest: () => controller ?
@@ -122,10 +177,24 @@ function createHarness(options = {}) {
     proxyControl: floorControl,
     routingAdapter,
     proxyAuth,
+    storageArea,
     createDatasetRuntime: options.createDatasetRuntime,
     afterFloorAcquired: options.afterFloorAcquired,
+    afterDurableOnPersisted: options.afterDurableOnPersisted,
+    recoveryFactory: options.recoveryFactory,
   });
-  return {controller, events, floorControl, proxyAuth, routingAdapter};
+  const ready = options.autoInitialize === false ? null :
+    controller.initializeFromDurable();
+  return {
+    controller,
+    events,
+    floorControl,
+    proxyAuth,
+    ready,
+    routingAdapter,
+    storageArea,
+    values,
+  };
 
 }
 
@@ -174,6 +243,9 @@ describe('Firefox inert activation transaction', function() {
     Assert.deepStrictEqual(harness.controller.snapshot(), {
       runtimeState: DatasetRuntime.STATES.OFF,
       active: false,
+      durableIntent: OffState.OFF,
+      recoveryStatus: Activation.RECOVERY_STATUS.OFF,
+      failureCode: null,
     });
 
   });
@@ -215,6 +287,7 @@ describe('Firefox inert activation transaction', function() {
           },
         });
 
+        await harness.ready;
         Assert.strictEqual(harness.controller.currentRuntimeState(), 'OFF');
         const result = await harness.controller.activatePrepared(
             prepared(wrappedStore),
@@ -231,6 +304,9 @@ describe('Firefox inert activation transaction', function() {
         Assert.deepStrictEqual(harness.controller.snapshot(), {
           runtimeState: DatasetRuntime.STATES.READY,
           active: true,
+          durableIntent: OffState.ON,
+          recoveryStatus: Activation.RECOVERY_STATUS.ACTIVE,
+          failureCode: null,
         });
 
       });
@@ -308,7 +384,7 @@ describe('Firefox inert activation transaction', function() {
 
       });
 
-  it('keeps listeners OFF while paused after the floor is acquired', async function() {
+  it('fails closed while paused after the floor is acquired', async function() {
 
     const store = await verifiedStore();
     let releasePause;
@@ -329,14 +405,14 @@ describe('Firefox inert activation transaction', function() {
     const activation = harness.controller.activatePrepared(prepared(store));
     await floorReached;
 
-    Assert.strictEqual(harness.controller.currentRuntimeState(), 'OFF');
-    Assert.strictEqual(
+    Assert.strictEqual(harness.controller.currentRuntimeState(), 'INITIALIZING');
+    Assert.deepStrictEqual(
         harness.routingAdapter.onProxyRequest({requestId: 'paused'}),
-        undefined,
+        {type: 'direct'},
     );
     Assert.deepStrictEqual(
         harness.routingAdapter.onBeforeRequest({requestId: 'paused'}),
-        {cancel: false},
+        {cancel: true},
     );
 
     releasePause();
@@ -395,7 +471,7 @@ describe('Firefox inert activation transaction', function() {
           cause: {code: Activation.ERRORS.ACTIVATION_INTERRUPTED},
           floorRetained: true,
         });
-        Assert.strictEqual(harness.controller.currentRuntimeState(), 'OFF');
+        Assert.strictEqual(harness.controller.currentRuntimeState(), 'FAILED');
 
       });
 
@@ -437,7 +513,7 @@ describe('Firefox inert activation transaction', function() {
           ok: true,
           status: ProxyControl.RESULTS.CLEARED,
         });
-        Assert.deepStrictEqual(observations, ['OFF', 0, 0]);
+        Assert.deepStrictEqual(observations, ['INITIALIZING', 0, 0]);
         Assert.strictEqual(harness.routingAdapter.authorizationCount(), 0);
         Assert.strictEqual(harness.controller.currentRuntimeState(), 'OFF');
 
@@ -484,6 +560,25 @@ describe('Firefox inert activation transaction', function() {
               return {ok: true, status: ProxyControl.RESULTS.ALREADY_CLEAR};
 
             },
+            async checkPrivateAccess() {
+
+              return {ok: true};
+
+            },
+            async inspectOwnedFloor() {
+
+              return {ok: true};
+
+            },
+            async reconcileOffOnStartup() {
+
+              return {
+                ok: true,
+                status: ProxyControl.RESULTS.ALREADY_CLEAR,
+                durableState: OffState.canonicalOffState(),
+              };
+
+            },
           },
           routingAdapter: {
             clearAllAuthorizations() {
@@ -499,13 +594,22 @@ describe('Firefox inert activation transaction', function() {
 
             },
           },
+          storageArea: {
+            async get(key) {
+
+              return {[key]: OffState.canonicalOffState()};
+
+            },
+            async set() {},
+          },
         });
 
+        await controller.initializeFromDurable();
         Assert.deepStrictEqual(await controller.clear(), {
           ok: false,
           error: {code: Activation.ERRORS.EPHEMERAL_CLEAR_FAILED},
         });
-        Assert.strictEqual(authClears, 1);
+        Assert.strictEqual(authClears, 2);
         Assert.strictEqual(floorClears, 1);
         Assert.strictEqual(controller.currentRuntimeState(), 'OFF');
 
@@ -628,6 +732,7 @@ describe('Firefox inert activation transaction', function() {
         });
         const recreated = createHarness();
 
+        await recreated.ready;
         Assert.strictEqual(recreated.controller.currentRuntimeState(), 'OFF');
         Assert.strictEqual(recreated.routingAdapter.authorizationCount(), 0);
         Assert.strictEqual(recreated.routingAdapter.authContextCount(), 0);

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/durable-activation.test.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/durable-activation.test.js
@@ -1,0 +1,838 @@
+'use strict';
+
+const Assert = require('node:assert');
+const Activation = require('../background/activation-controller');
+const DatasetStore = require('../background/dataset-store');
+const OffState = require('../background/off-state');
+const ProxyAuth = require('../background/proxy-auth');
+const ProxyControl = require('../background/proxy-control');
+const Routing = require('../../extension-mv3-common/routing-contract');
+const RoutingAdapter = require('../background/routing-adapter');
+const Helpers = require('./dataset-test-helpers');
+
+function floor(port = 55031) {
+
+  return {
+    proxyType: 'manual',
+    http: '',
+    httpProxyAll: false,
+    ssl: '',
+    socks: `127.0.0.1:${port}`,
+    socksVersion: 5,
+    proxyDNS: true,
+    passthrough: '',
+    autoConfigUrl: '',
+  };
+
+}
+
+function datasetIdentity(artifact = Helpers.artifact()) {
+
+  return {
+    providerKey: artifact.envelope.providerKey,
+    datasetVersion: artifact.envelope.datasetVersion,
+    artifactSha256: artifact.envelope.artifactSha256,
+  };
+
+}
+
+function routingDescriptor() {
+
+  return {
+    schemaVersion: OffState.ROUTING_DESCRIPTOR_SCHEMA_VERSION,
+    configurationKey: 'synthetic-routing',
+    configurationVersion: '1',
+    configurationSha256: 'b'.repeat(64),
+  };
+
+}
+
+function onState(identity = floor(), artifact = Helpers.artifact()) {
+
+  return OffState.canonicalOnState({
+    floorIdentity: identity,
+    providerKey: artifact.envelope.providerKey,
+    datasetIdentity: datasetIdentity(artifact),
+    routingDescriptor: routingDescriptor(),
+  });
+
+}
+
+function candidate(overrides = {}) {
+
+  return Object.assign({
+    id: 'synthetic-proxy',
+    type: 'HTTP',
+    host: '127.0.0.1',
+    port: 18080,
+    proxyDNS: false,
+    authRef: null,
+    failoverTimeoutSeconds: null,
+  }, overrides);
+
+}
+
+function baseInputForRequest(proxyCandidate = candidate()) {
+
+  return (details) => ({
+    hostname: new URL(details.url).hostname,
+    rules: {},
+    candidateGroups: {},
+    flags: {},
+    providerCandidates: [proxyCandidate],
+    providerFallback: Routing.FALLBACKS.DIRECT,
+  });
+
+}
+
+async function verifiedStore(artifact = Helpers.artifact()) {
+
+  const store = DatasetStore.createStore({
+    backend: Helpers.memoryBackend(),
+    sha256: async (bytes) => Helpers.sha256(Buffer.from(bytes)),
+  });
+  Assert.strictEqual((await store.commitPackagedBaseline(artifact)).ok, true);
+  return store;
+
+}
+
+function prepared(store, artifact = Helpers.artifact(), overrides = {}) {
+
+  return Object.assign({
+    datasetIdentity: datasetIdentity(artifact),
+    datasetStore: store,
+    floorIdentity: floor(),
+    portPrevalidated: true,
+    providerKey: artifact.envelope.providerKey,
+    resolveCredentials: () => null,
+    routingBaseInputForRequest: baseInputForRequest(),
+    routingDescriptor: routingDescriptor(),
+  }, overrides);
+
+}
+
+function memoryStorage(initialState, events = [], options = {}) {
+
+  const values = initialState === undefined ? {} : {
+    [OffState.STORAGE_KEY]: structuredClone(initialState),
+  };
+  return {
+    values,
+    async get(key) {
+
+      events.push('storage-get');
+      if (options.getError) {
+        throw options.getError;
+      }
+      return Object.prototype.hasOwnProperty.call(values, key) ?
+        {[key]: structuredClone(values[key])} : {};
+
+    },
+    async set(update) {
+
+      const next = update[OffState.STORAGE_KEY];
+      events.push(`storage-set-${next && next.intent || 'unknown'}`);
+      if (options.failOnIntent === (next && next.intent)) {
+        throw new Error('synthetic storage write failure');
+      }
+      Object.assign(values, structuredClone(update));
+      if (typeof options.afterSet === 'function') {
+        options.afterSet(next);
+      }
+
+    },
+  };
+
+}
+
+function createSystem(options = {}) {
+
+  const events = options.events || [];
+  const access = options.access || {allowed: true};
+  const storageArea = options.storageArea || memoryStorage(
+      options.durableState === undefined ?
+        OffState.canonicalOffState() : options.durableState,
+      events,
+  );
+  const previousSettings = options.previousSettings || {
+    levelOfControl: 'controllable_by_this_extension',
+    value: {proxyType: 'none'},
+  };
+  let liveSettings = options.liveSettings || previousSettings;
+  const proxyCalls = {clear: 0, get: 0, set: 0};
+  const proxySettings = {
+    async clear() {
+
+      events.push('proxy-clear');
+      proxyCalls.clear += 1;
+      if (options.clearError) {
+        throw options.clearError;
+      }
+      liveSettings = previousSettings;
+
+    },
+    async get() {
+
+      events.push('proxy-get');
+      proxyCalls.get += 1;
+      if (options.getError) {
+        throw options.getError;
+      }
+      return structuredClone(liveSettings);
+
+    },
+    async set(update) {
+
+      events.push('proxy-set');
+      proxyCalls.set += 1;
+      if (options.setError) {
+        throw options.setError;
+      }
+      liveSettings = options.afterSet || {
+        levelOfControl: 'controlled_by_this_extension',
+        value: structuredClone(update.value),
+      };
+
+    },
+  };
+  let controller = null;
+  const routingAdapter = RoutingAdapter.createAdapter({
+    runtimeStateForRequest: () => controller ?
+      controller.currentRuntimeState() : RoutingAdapter.STATES.INITIALIZING,
+    routingInputForRequest: (details) =>
+      controller.routingInputForRequest(details),
+  });
+  const proxyAuth = ProxyAuth.createHandler({
+    routingAdapter,
+    resolveCredentials: (authRef) => controller ?
+      controller.resolveCredentials(authRef) : null,
+  });
+  const proxyControl = ProxyControl.createController({
+    proxySettings,
+    storageArea,
+    async isPrivateAccessAllowed() {
+
+      events.push('private-access');
+      return access.allowed;
+
+    },
+    clearEphemeralState() {
+
+      events.push('control-ephemeral-clear');
+      routingAdapter.clearAllAuthorizations();
+      proxyAuth.clearAllAttempts();
+
+    },
+  });
+  controller = Activation.createController({
+    proxyControl,
+    routingAdapter,
+    proxyAuth,
+    storageArea,
+    recoveryFactory: options.recoveryFactory,
+    afterFloorAcquired: options.afterFloorAcquired,
+    afterDurableOnPersisted: options.afterDurableOnPersisted,
+  });
+  return {
+    access,
+    controller,
+    events,
+    get liveSettings() {
+
+      return liveSettings;
+
+    },
+    proxyAuth,
+    proxyCalls,
+    proxyControl,
+    routingAdapter,
+    storageArea,
+  };
+
+}
+
+function recovery(store, overrides = {}) {
+
+  return Object.assign({
+    datasetStore: store,
+    resolveCredentials: () => null,
+    routingBaseInputForRequest: baseInputForRequest(),
+    routingDescriptor: routingDescriptor(),
+  }, overrides);
+
+}
+
+describe('Firefox durable activation recovery', function() {
+
+  it('accepts only strict serializable schema v3 ON state', function() {
+
+    const state = onState();
+    Assert.strictEqual(OffState.isCanonicalOnState(state), true);
+    Assert.deepStrictEqual(Object.keys(state).sort(), [
+      'datasetIdentity',
+      'floorIdentity',
+      'intent',
+      'providerKey',
+      'routingDescriptor',
+      'schemaVersion',
+    ]);
+    const serialized = JSON.stringify(state);
+    for (const forbidden of [
+      'password',
+      'username',
+      'requestId',
+      'authRef',
+      'function',
+    ]) {
+      Assert.strictEqual(serialized.includes(forbidden), false, forbidden);
+    }
+
+  });
+
+  it('normalizes malformed and future ON safely to OFF cleanup state', function() {
+
+    for (const invalid of [
+      Object.assign({}, onState(), {schemaVersion: 4}),
+      Object.assign({}, onState(), {extra: true}),
+      Object.assign({}, onState(), {providerKey: 'other-provider'}),
+      Object.assign({}, onState(), {
+        datasetIdentity: Object.assign({}, datasetIdentity(), {
+          artifactSha256: 'invalid',
+        }),
+      }),
+      Object.assign({}, onState(), {
+        routingDescriptor: Object.assign({}, routingDescriptor(), {
+          credentials: true,
+        }),
+      }),
+    ]) {
+      Assert.deepStrictEqual(OffState.normalizeDurableState(invalid),
+          OffState.canonicalOffState(floor()));
+    }
+
+  });
+
+  it('persists ON only after exact dataset READY and exact floor ownership',
+      async function() {
+
+        const events = [];
+        const store = await verifiedStore();
+        const wrapped = {
+          async loadVerifications(...args) {
+
+            events.push('dataset-load');
+            return store.loadVerifications(...args);
+
+          },
+        };
+        const system = createSystem({events});
+        await system.controller.initializeFromDurable();
+        events.length = 0;
+
+        const result = await system.controller.activatePrepared(
+            prepared(wrapped),
+        );
+
+        Assert.strictEqual(result.status, Activation.RESULTS.ACTIVE);
+        Assert.ok(events.indexOf('dataset-load') < events.indexOf('proxy-set'));
+        Assert.ok(events.indexOf('proxy-get') <
+          events.indexOf('storage-set-ON'));
+        Assert.strictEqual(
+            system.storageArea.values[OffState.STORAGE_KEY].intent,
+            OffState.ON,
+        );
+        Assert.strictEqual(system.controller.currentRuntimeState(), 'READY');
+
+      });
+
+  it('rolls back the floor when durable ON persistence fails', async function() {
+
+    const events = [];
+    const storageArea = memoryStorage(OffState.canonicalOffState(), events, {
+      failOnIntent: OffState.ON,
+    });
+    const store = await verifiedStore();
+    const system = createSystem({events, storageArea});
+    await system.controller.initializeFromDurable();
+
+    const result = await system.controller.activatePrepared(prepared(store));
+
+    Assert.strictEqual(result.error.code,
+        Activation.ERRORS.DURABLE_ON_PERSIST_FAILED);
+    Assert.strictEqual(result.rollback.ok, true);
+    Assert.strictEqual(system.proxyCalls.set, 1);
+    Assert.strictEqual(system.proxyCalls.clear, 1);
+    Assert.deepStrictEqual(storageArea.values[OffState.STORAGE_KEY],
+        OffState.canonicalOffState());
+
+  });
+
+  it('retains fail-closed cleanup after floor set or confirmation failure',
+      async function() {
+
+        const store = await verifiedStore();
+        for (const scenario of [
+          {
+            options: {setError: new Error('synthetic set failure')},
+            cause: ProxyControl.ERRORS.PROXY_SET_FAILED,
+          },
+          {
+            options: {
+              afterSet: {
+                levelOfControl: 'controlled_by_this_extension',
+                value: {proxyType: 'none'},
+              },
+            },
+            cause: ProxyControl.ERRORS.OWNERSHIP_MISMATCH,
+          },
+        ]) {
+          const system = createSystem(scenario.options);
+          await system.controller.initializeFromDurable();
+
+          const result = await system.controller.activatePrepared(
+              prepared(store),
+          );
+
+          Assert.strictEqual(result.error.code,
+              Activation.ERRORS.ACTIVATION_ROLLBACK_FAILED);
+          Assert.strictEqual(result.cause.code, scenario.cause);
+          Assert.strictEqual(result.floorRetained, true);
+          Assert.strictEqual(system.controller.currentRuntimeState(), 'FAILED');
+          Assert.strictEqual(system.controller.snapshot().active, false);
+          Assert.deepStrictEqual(
+              system.storageArea.values[OffState.STORAGE_KEY],
+              OffState.canonicalOffState(floor()),
+          );
+          Assert.strictEqual(system.proxyCalls.set, 1);
+          Assert.strictEqual(system.proxyCalls.clear, 0);
+        }
+
+      });
+
+  it('keeps listener behavior fail closed until durable OFF is known',
+      async function() {
+
+        let releaseRead;
+        let reportRead;
+        const readStarted = new Promise((resolve) => {
+          reportRead = resolve;
+        });
+        let readCount = 0;
+        const storageArea = {
+          get() {
+
+            readCount += 1;
+            if (readCount > 1) {
+              return Promise.resolve({
+                [OffState.STORAGE_KEY]: OffState.canonicalOffState(),
+              });
+            }
+            return new Promise((resolve) => {
+              releaseRead = () => resolve({
+                [OffState.STORAGE_KEY]: OffState.canonicalOffState(),
+              });
+              reportRead();
+            });
+
+          },
+          async set() {},
+        };
+        const system = createSystem({storageArea});
+        const boot = system.controller.initializeFromDurable();
+        await readStarted;
+
+        Assert.strictEqual(system.controller.currentRuntimeState(),
+            'INITIALIZING');
+        Assert.deepStrictEqual(system.routingAdapter.onBeforeRequest({
+          requestId: 'cold-request',
+        }), {cancel: true});
+        releaseRead();
+        await boot;
+        Assert.strictEqual(system.controller.currentRuntimeState(), 'OFF');
+
+      });
+
+  it('recovers exact ON state without re-setting its floor', async function() {
+
+    const artifact = Helpers.artifact();
+    const store = await verifiedStore(artifact);
+    const state = onState(floor(), artifact);
+    const system = createSystem({
+      durableState: state,
+      liveSettings: {
+        levelOfControl: 'controlled_by_this_extension',
+        value: floor(),
+      },
+      recoveryFactory: async (descriptor) => {
+
+        Assert.deepStrictEqual(descriptor, state);
+        return recovery(store);
+
+      },
+    });
+
+    const result = await system.controller.initializeFromDurable();
+
+    Assert.strictEqual(result.status, Activation.RESULTS.RECOVERED);
+    Assert.strictEqual(system.proxyCalls.set, 0);
+    Assert.strictEqual(system.controller.currentRuntimeState(), 'READY');
+    Assert.strictEqual(system.controller.snapshot().recoveryStatus,
+        Activation.RECOVERY_STATUS.RECOVERED);
+
+  });
+
+  it('transitions lost or mismatched floor ownership to durable OFF',
+      async function() {
+
+        const store = await verifiedStore();
+        const system = createSystem({
+          durableState: onState(),
+          liveSettings: {
+            levelOfControl: 'controlled_by_this_extension',
+            value: floor(55032),
+          },
+          recoveryFactory: () => recovery(store),
+        });
+
+        const result = await system.controller.initializeFromDurable();
+
+        Assert.strictEqual(result.error.code,
+            Activation.ERRORS.RECOVERY_FLOOR_MISMATCH);
+        Assert.strictEqual(result.transitionedToOff, true);
+        Assert.strictEqual(system.controller.currentRuntimeState(), 'OFF');
+        Assert.deepStrictEqual(
+            system.storageArea.values[OffState.STORAGE_KEY],
+            OffState.canonicalOffState(),
+        );
+        Assert.strictEqual(system.proxyCalls.set, 0);
+        Assert.strictEqual(system.proxyCalls.clear, 0);
+
+      });
+
+  it('keeps exact floor and ON blocked when private access is denied',
+      async function() {
+
+        const store = await verifiedStore();
+        const system = createSystem({
+          access: {allowed: false},
+          durableState: onState(),
+          liveSettings: {
+            levelOfControl: 'controlled_by_this_extension',
+            value: floor(),
+          },
+          recoveryFactory: () => recovery(store),
+        });
+
+        const result = await system.controller.initializeFromDurable();
+
+        Assert.strictEqual(result.error.code,
+            Activation.RECOVERY_STATUS.BLOCKED_PRIVATE_ACCESS);
+        Assert.strictEqual(system.controller.currentRuntimeState(), 'FAILED');
+        Assert.strictEqual(system.controller.snapshot().durableIntent, 'ON');
+        Assert.strictEqual(system.proxyCalls.set, 0);
+        Assert.strictEqual(system.proxyCalls.clear, 0);
+
+      });
+
+  it('keeps ON fail closed when recovery factory is missing or fails',
+      async function() {
+
+        for (const recoveryFactory of [
+          undefined,
+          () => {
+
+            throw new Error('synthetic recovery failure');
+
+          },
+          () => ({}),
+        ]) {
+          const system = createSystem({
+            durableState: onState(),
+            liveSettings: {
+              levelOfControl: 'controlled_by_this_extension',
+              value: floor(),
+            },
+            recoveryFactory,
+          });
+          const result = await system.controller.initializeFromDurable();
+
+          Assert.strictEqual(result.ok, false);
+          Assert.strictEqual(system.controller.currentRuntimeState(), 'FAILED');
+          Assert.strictEqual(system.controller.snapshot().durableIntent, 'ON');
+          Assert.strictEqual(system.proxyCalls.set, 0);
+          Assert.strictEqual(system.proxyCalls.clear, 0);
+        }
+
+      });
+
+  it('rejects missing or silently different recovery datasets', async function() {
+
+    const missing = DatasetStore.createStore({
+      backend: Helpers.memoryBackend(),
+      sha256: async (bytes) => Helpers.sha256(Buffer.from(bytes)),
+    });
+    const differentArtifact = Helpers.artifact({datasetVersion: 'different.1'});
+    const different = await verifiedStore(differentArtifact);
+    for (const store of [missing, different]) {
+      const system = createSystem({
+        durableState: onState(),
+        liveSettings: {
+          levelOfControl: 'controlled_by_this_extension',
+          value: floor(),
+        },
+        recoveryFactory: () => recovery(store),
+      });
+      const result = await system.controller.initializeFromDurable();
+
+      Assert.strictEqual(result.ok, false);
+      Assert.strictEqual(system.controller.currentRuntimeState(), 'FAILED');
+      Assert.strictEqual(system.controller.snapshot().durableIntent, 'ON');
+      Assert.strictEqual(system.proxyCalls.clear, 0);
+    }
+
+  });
+
+  it('rejects a recovery factory for a different routing descriptor',
+      async function() {
+
+        const store = await verifiedStore();
+        const system = createSystem({
+          durableState: onState(),
+          liveSettings: {
+            levelOfControl: 'controlled_by_this_extension',
+            value: floor(),
+          },
+          recoveryFactory: () => recovery(store, {
+            routingDescriptor: Object.assign({}, routingDescriptor(), {
+              configurationSha256: 'c'.repeat(64),
+            }),
+          }),
+        });
+
+        const result = await system.controller.initializeFromDurable();
+
+        Assert.strictEqual(result.error.code,
+            Activation.ERRORS.ROUTING_DESCRIPTOR_MISMATCH);
+        Assert.strictEqual(system.controller.currentRuntimeState(), 'FAILED');
+        Assert.strictEqual(system.controller.snapshot().durableIntent, 'ON');
+        Assert.strictEqual(system.proxyCalls.set, 0);
+        Assert.strictEqual(system.proxyCalls.clear, 0);
+
+      });
+
+  it('reconciles a crash after floor acquisition but before ON persistence',
+      async function() {
+
+        const storageArea = memoryStorage(OffState.canonicalOffState());
+        const acquiring = createSystem({storageArea});
+        const acquired = await acquiring.proxyControl.acquirePrevalidatedFloor({
+          floorIdentity: floor(),
+          portPrevalidated: true,
+        });
+        Assert.strictEqual(acquired.ok, true);
+        const recreated = createSystem({
+          storageArea,
+          liveSettings: acquiring.liveSettings,
+        });
+
+        const result = await recreated.controller.initializeFromDurable();
+
+        Assert.strictEqual(result.status, Activation.RESULTS.OFF);
+        Assert.strictEqual(recreated.proxyCalls.set, 0);
+        Assert.strictEqual(recreated.proxyCalls.clear, 1);
+        Assert.deepStrictEqual(storageArea.values[OffState.STORAGE_KEY],
+            OffState.canonicalOffState());
+
+      });
+
+  it('recovers a crash after ON persistence but before session publication',
+      async function() {
+
+        const artifact = Helpers.artifact();
+        const store = await verifiedStore(artifact);
+        const storageArea = memoryStorage(OffState.canonicalOffState());
+        let reportPersisted;
+        const persisted = new Promise((resolve) => {
+          reportPersisted = resolve;
+        });
+        const first = createSystem({
+          storageArea,
+          afterDurableOnPersisted() {
+
+            reportPersisted();
+            return new Promise(() => {});
+
+          },
+        });
+        await first.controller.initializeFromDurable();
+        first.controller.activatePrepared(prepared(store));
+        await persisted;
+        Assert.strictEqual(
+            storageArea.values[OffState.STORAGE_KEY].intent,
+            OffState.ON,
+        );
+        const recreated = createSystem({
+          storageArea,
+          liveSettings: first.liveSettings,
+          recoveryFactory: () => recovery(store),
+        });
+
+        const result = await recreated.controller.initializeFromDurable();
+
+        Assert.strictEqual(result.status, Activation.RESULTS.RECOVERED);
+        Assert.strictEqual(recreated.proxyCalls.set, 0);
+        Assert.strictEqual(recreated.controller.currentRuntimeState(), 'READY');
+
+      });
+
+  it('persists OFF before hiding the session and releasing the floor',
+      async function() {
+
+        const store = await verifiedStore();
+        const holder = {};
+        const observations = [];
+        const storageArea = memoryStorage(OffState.canonicalOffState(), [], {
+          afterSet(next) {
+
+            if (next.intent === OffState.OFF && holder.system &&
+                holder.system.controller.currentRuntimeState() === 'READY') {
+              observations.push('off-persisted-while-ready');
+            }
+
+          },
+        });
+        const system = createSystem({storageArea});
+        holder.system = system;
+        await system.controller.initializeFromDurable();
+        await system.controller.activatePrepared(prepared(store));
+
+        const result = await system.controller.clear();
+
+        Assert.strictEqual(result.ok, true);
+        Assert.deepStrictEqual(observations, ['off-persisted-while-ready']);
+        Assert.strictEqual(system.controller.currentRuntimeState(), 'OFF');
+        Assert.strictEqual(system.routingAdapter.authorizationCount(), 0);
+        Assert.deepStrictEqual(storageArea.values[OffState.STORAGE_KEY],
+            OffState.canonicalOffState());
+
+      });
+
+  it('retains durable OFF cleanup identity when Clear cannot release floor',
+      async function() {
+
+        const store = await verifiedStore();
+        const system = createSystem({
+          clearError: new Error('synthetic clear failure'),
+        });
+        await system.controller.initializeFromDurable();
+        await system.controller.activatePrepared(prepared(store));
+
+        const result = await system.controller.clear();
+
+        Assert.strictEqual(result.error.code,
+            ProxyControl.ERRORS.PROXY_CLEAR_FAILED);
+        Assert.strictEqual(system.controller.currentRuntimeState(), 'OFF');
+        Assert.strictEqual(system.controller.snapshot().durableIntent, 'OFF');
+        Assert.deepStrictEqual(
+            system.storageArea.values[OffState.STORAGE_KEY].floorIdentity,
+            floor(),
+        );
+        Assert.strictEqual(system.routingAdapter.authorizationCount(), 0);
+
+      });
+
+  it('retries blocked recovery after regrant without a second floor',
+      async function() {
+
+        const store = await verifiedStore();
+        const access = {allowed: false};
+        const system = createSystem({
+          access,
+          durableState: onState(),
+          liveSettings: {
+            levelOfControl: 'controlled_by_this_extension',
+            value: floor(),
+          },
+          recoveryFactory: () => recovery(store),
+        });
+        await system.controller.initializeFromDurable();
+        access.allowed = true;
+
+        const recovered = await system.controller.initializeFromDurable();
+        const repeated = await system.controller.initializeFromDurable();
+
+        Assert.strictEqual(recovered.status, Activation.RESULTS.RECOVERED);
+        Assert.strictEqual(repeated.status, Activation.RECOVERY_STATUS.RECOVERED);
+        Assert.strictEqual(system.proxyCalls.set, 0);
+        Assert.strictEqual(system.proxyCalls.clear, 0);
+
+      });
+
+  it('keeps unreadable durable state fail closed instead of assuming OFF',
+      async function() {
+
+        const system = createSystem({
+          storageArea: memoryStorage(undefined, [], {
+            getError: new Error('synthetic read failure'),
+          }),
+        });
+
+        const result = await system.controller.initializeFromDurable();
+
+        Assert.strictEqual(result.error.code,
+            Activation.ERRORS.DURABLE_STATE_UNAVAILABLE);
+        Assert.strictEqual(system.controller.currentRuntimeState(), 'FAILED');
+        Assert.deepStrictEqual(system.routingAdapter.onBeforeRequest({
+          requestId: 'unknown-durable-intent',
+        }), {cancel: true});
+
+      });
+
+  it('restored session preserves routing, auth, and request isolation',
+      async function() {
+
+        const store = await verifiedStore();
+        const authenticated = candidate({authRef: 'synthetic-auth'});
+        const system = createSystem({
+          durableState: onState(),
+          liveSettings: {
+            levelOfControl: 'controlled_by_this_extension',
+            value: floor(),
+          },
+          recoveryFactory: () => recovery(store, {
+            routingBaseInputForRequest: baseInputForRequest(authenticated),
+            resolveCredentials: (authRef) => authRef === 'synthetic-auth' ? {
+              username: 'fixture-user',
+              password: 'fixture-password',
+            } : null,
+          }),
+        });
+        await system.controller.initializeFromDurable();
+        const first = {requestId: 'first', url: 'http://beta.example/'};
+        const second = {requestId: 'second', url: 'http://beta.example/'};
+
+        system.routingAdapter.onProxyRequest(first);
+        system.routingAdapter.onProxyRequest(second);
+        system.routingAdapter.onBeforeRequest({
+          requestId: first.requestId,
+          proxyInfo: {type: 'http', host: '127.0.0.1', port: 18080},
+        });
+        const response = system.proxyAuth.onAuthRequired({
+          requestId: first.requestId,
+          isProxy: true,
+          challenger: {host: '127.0.0.1', port: 18080},
+        });
+
+        Assert.deepStrictEqual(response, {
+          authCredentials: {
+            username: 'fixture-user',
+            password: 'fixture-password',
+          },
+        });
+        Assert.strictEqual(system.routingAdapter.authorizationCount(), 2);
+        system.routingAdapter.onRequestTerminal(first);
+        Assert.strictEqual(system.routingAdapter.authorizationCount(), 1);
+
+      });
+
+});

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/firefox-lifecycle-smoke.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/firefox-lifecycle-smoke.js
@@ -119,12 +119,18 @@ function makeInstrumentedExtension(collectorPort) {
     'browser.alarms.onAlarm.addListener(() => {});',
     'browser.alarms.create(\'lifecycle-wake\', {delayInMinutes: 1});',
     '(async () => {',
-    '  const state = await globalThis.rucbFirefoxSkeletonRuntime.whenReady();',
+    '  const initialization = await',
+    '    globalThis.rucbFirefoxSkeletonRuntime.whenReady();',
+    '  const stored = await browser.storage.local.get(',
+    '    globalThis.rucbFirefoxOffState.STORAGE_KEY,',
+    '  );',
+    '  const state = stored[globalThis.rucbFirefoxOffState.STORAGE_KEY];',
     `  await fetch(${JSON.stringify(collectorUrl)}, {`,
     '    method: \'POST\',',
     '    headers: {\'content-type\': \'application/json\'},',
     '    body: JSON.stringify({',
     '      bootId: globalThis.rucbFirefoxSkeletonRuntime.bootId,',
+    '      initialization,',
     '      state,',
     '    }),',
     '  });',
@@ -493,6 +499,7 @@ async function main() {
       path: packageRoot,
       temporary: true,
     });
+    await delay(500);
     await navigate(
         client,
         'http://manual-proxy-check.invalid/after-production-install',
@@ -508,7 +515,7 @@ async function main() {
     });
     const first = await waitForBoot(bootEvents, () => true, 15000);
     Assert.deepStrictEqual(first.state, {
-      schemaVersion: 2,
+      schemaVersion: 3,
       intent: 'OFF',
       floorIdentity: null,
     });
@@ -527,7 +534,7 @@ async function main() {
         105000,
     );
     Assert.deepStrictEqual(second.state, {
-      schemaVersion: 2,
+      schemaVersion: 3,
       intent: 'OFF',
       floorIdentity: null,
     });

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/firefox-proxy-control-smoke.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/firefox-proxy-control-smoke.js
@@ -128,9 +128,7 @@ function makeInstrumentedExtension() {
     '      portPrevalidated: true,',
     '    });',
     '  } else if (action === \'clear-rpc\') {',
-    '    result = await browser.runtime.sendMessage({',
-    '      type: \'firefox.activation.clear\',',
-    '    });',
+    '    result = await controller.clearFloor();',
     '  } else if (action === \'set-unrelated\') {',
     '    await proxySettings.set({value: {',
     '      proxyType: \'manual\',',
@@ -337,7 +335,11 @@ async function expectManualProxy(client, handle, targetUrl, proxyRequests,
 
   const beforeOrigin = originRequests.length;
   await client.command('WebDriver:SwitchToWindow', {handle});
-  await Smoke.navigate(client, `${targetUrl}/${phase}?nonce=${Date.now()}`);
+  try {
+    await Smoke.navigate(client, `${targetUrl}/${phase}?nonce=${Date.now()}`);
+  } catch (error) {
+    throw new Error(`${phase}: ${error && error.message ? error.message : error}`);
+  }
   Assert.strictEqual(await Smoke.bodyText(client), MANUAL_PROXY_MARKER);
   Assert.ok(
       proxyRequests.some((url) => url.includes(`/${phase}?`)),
@@ -454,6 +456,7 @@ async function main() {
       path: packageRoot,
       temporary: true,
     });
+    await Smoke.delay(500);
     await expectManualProxy(
         client, handle, targetUrl, proxyRequests, originRequests,
         'production-off',
@@ -473,11 +476,11 @@ async function main() {
     await setAddonEnabled(client, handle, true);
     let status = await control(client, handle, extension, 'status');
     Assert.deepStrictEqual(status.result.durable, {
-      schemaVersion: 2,
+      schemaVersion: 3,
       intent: 'OFF',
       floorIdentity: null,
     });
-    checked('schema v1 OFF migrates to schema v2 OFF');
+    checked('schema v1 OFF migrates to schema v3 OFF');
 
     const denied = await control(client, handle, extension, 'acquire', {port});
     Assert.strictEqual(denied.result.error.code, 'PRIVATE_ACCESS_REQUIRED');
@@ -528,7 +531,7 @@ async function main() {
     const restoredClear = await control(
         client, handle, extension, 'clear-rpc', {port},
     );
-    Assert.strictEqual(restoredClear.result.result.status, 'CLEARED');
+    Assert.strictEqual(restoredClear.result.status, 'CLEARED');
     await expectManualProxy(
         client, handle, targetUrl, proxyRequests, originRequests,
         'exact-clear',
@@ -544,9 +547,7 @@ async function main() {
         client, handle, extension, 'clear-rpc', {port},
     );
     Assert.ok(
-        ['CLEARED', 'ALREADY_CLEAR'].includes(
-            revokedClear.result.result.status,
-        ),
+        ['CLEARED', 'ALREADY_CLEAR'].includes(revokedClear.result.status),
         JSON.stringify(revokedClear),
     );
     await expectManualProxy(
@@ -570,7 +571,7 @@ async function main() {
     await setAddonEnabled(client, handle, true);
     status = await control(client, handle, extension, 'status');
     Assert.deepStrictEqual(status.result.durable, {
-      schemaVersion: 2,
+      schemaVersion: 3,
       intent: 'OFF',
       floorIdentity: null,
     });

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/proxy-control.test.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/proxy-control.test.js
@@ -22,7 +22,7 @@ function floor(port = 55001) {
 
 function durable(floorIdentity = null) {
 
-  return {schemaVersion: 2, intent: 'OFF', floorIdentity};
+  return {schemaVersion: OffState.SCHEMA_VERSION, intent: 'OFF', floorIdentity};
 
 }
 
@@ -215,6 +215,48 @@ describe('Firefox fail-closed proxy control', function() {
           levelOfControl: 'controlled_by_this_extension',
           value: Object.assign({autoLogin: true}, identity),
         }, identity), false);
+
+      });
+
+  it('checks private access and live exact ownership without proxy writes',
+      async function() {
+
+        const identity = floor();
+        const proxy = makeProxySettings({
+          levelOfControl: 'controlled_by_this_extension',
+          value: identity,
+        });
+        const fixture = makeController({proxy});
+
+        Assert.deepStrictEqual(
+            await fixture.controller.checkPrivateAccess(),
+            {ok: true},
+        );
+        Assert.deepStrictEqual(
+            await fixture.controller.inspectOwnedFloor(identity),
+            {ok: true, status: 'OWNED', floorIdentity: identity},
+        );
+        Assert.strictEqual(proxy.calls.get, 1);
+        Assert.strictEqual(proxy.calls.set, 0);
+        Assert.strictEqual(proxy.calls.clear, 0);
+
+      });
+
+  it('reports denied private access and mismatched recovery ownership',
+      async function() {
+
+        const fixture = makeController({privateAccess: false});
+
+        Assert.deepStrictEqual(await fixture.controller.checkPrivateAccess(), {
+          ok: false,
+          error: {code: 'PRIVATE_ACCESS_REQUIRED'},
+        });
+        Assert.deepStrictEqual(
+            await fixture.controller.inspectOwnedFloor(floor()),
+            {ok: false, error: {code: 'OWNERSHIP_MISMATCH'}},
+        );
+        Assert.strictEqual(fixture.proxy.calls.set, 0);
+        Assert.strictEqual(fixture.proxy.calls.clear, 0);
 
       });
 

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/skeleton.test.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/skeleton.test.js
@@ -329,7 +329,7 @@ describe('Firefox MV3 inert skeleton', function() {
       {schemaVersion: 1, intent: 'OFF', extra: true},
     ]) {
       Assert.deepStrictEqual(OffState.normalizeDurableState(value), {
-        schemaVersion: 2,
+        schemaVersion: 3,
         intent: 'OFF',
         floorIdentity: null,
       });
@@ -343,13 +343,13 @@ describe('Firefox MV3 inert skeleton', function() {
     const state = await OffState.initialize(storage.area);
 
     Assert.deepStrictEqual(state, {
-      schemaVersion: 2,
+      schemaVersion: 3,
       intent: 'OFF',
       floorIdentity: null,
     });
     Assert.deepStrictEqual(storage.writes, [{
       [OffState.STORAGE_KEY]: {
-        schemaVersion: 2,
+        schemaVersion: 3,
         intent: 'OFF',
         floorIdentity: null,
       },
@@ -364,21 +364,21 @@ describe('Firefox MV3 inert skeleton', function() {
 
     Assert.deepStrictEqual(
         JSON.parse(JSON.stringify(storage.values[OffState.STORAGE_KEY])), {
-          schemaVersion: 2,
+          schemaVersion: 3,
           intent: 'OFF',
           floorIdentity: null,
         });
 
   });
 
-  it('migrates schema v1 OFF to schema v2 OFF', async function() {
+  it('migrates schema v1 OFF to schema v3 OFF', async function() {
 
     const storage = makeStorage({schemaVersion: 1, intent: 'OFF'});
     await OffState.initialize(storage.area);
 
     Assert.deepStrictEqual(storage.writes, [{
       [OffState.STORAGE_KEY]: {
-        schemaVersion: 2,
+        schemaVersion: 3,
         intent: 'OFF',
         floorIdentity: null,
       },
@@ -386,10 +386,41 @@ describe('Firefox MV3 inert skeleton', function() {
 
   });
 
-  it('does not rewrite canonical schema v2 durable OFF', async function() {
+  it('migrates schema v2 OFF and preserves its exact cleanup floor',
+      async function() {
+
+        const cleanupFloor = {
+          proxyType: 'manual',
+          http: '',
+          httpProxyAll: false,
+          ssl: '',
+          socks: '127.0.0.1:55001',
+          socksVersion: 5,
+          proxyDNS: true,
+          passthrough: '',
+          autoConfigUrl: '',
+        };
+        const storage = makeStorage({
+          schemaVersion: 2,
+          intent: 'OFF',
+          floorIdentity: cleanupFloor,
+        });
+        await OffState.initialize(storage.area);
+
+        Assert.deepStrictEqual(storage.writes, [{
+          [OffState.STORAGE_KEY]: {
+            schemaVersion: 3,
+            intent: 'OFF',
+            floorIdentity: cleanupFloor,
+          },
+        }]);
+
+      });
+
+  it('does not rewrite canonical schema v3 durable OFF', async function() {
 
     const storage = makeStorage({
-      schemaVersion: 2,
+      schemaVersion: 3,
       intent: 'OFF',
       floorIdentity: null,
     });
@@ -429,30 +460,41 @@ describe('Firefox MV3 inert skeleton', function() {
 
       });
 
-  it('keeps the registered production adapter inert while OFF', function() {
+  it('keeps startup fail closed, then leaves traffic inert while OFF',
+      async function() {
 
-    const eventPage = startEventPage();
+        const eventPage = startEventPage();
 
-    Assert.strictEqual(
-        eventPage.networkListeners.proxy.listener({requestId: 'off'}),
-        undefined,
-    );
-    Assert.deepStrictEqual(
-        JSON.parse(JSON.stringify(
-            eventPage.networkListeners.before.listener({requestId: 'off'}),
-        )),
-        {cancel: false},
-    );
-    Assert.strictEqual(
-        eventPage.networkListeners.auth.listener({
-          requestId: 'off',
-          isProxy: true,
-          challenger: {host: 'proxy.test', port: 8080},
-        }),
-        undefined,
-    );
+        Assert.deepStrictEqual(
+            JSON.parse(JSON.stringify(
+                eventPage.networkListeners.before.listener({
+                  requestId: 'initializing',
+                }),
+            )),
+            {cancel: true},
+        );
+        await eventPage.ready();
 
-  });
+        Assert.strictEqual(
+            eventPage.networkListeners.proxy.listener({requestId: 'off'}),
+            undefined,
+        );
+        Assert.deepStrictEqual(
+            JSON.parse(JSON.stringify(
+                eventPage.networkListeners.before.listener({requestId: 'off'}),
+            )),
+            {cancel: false},
+        );
+        Assert.strictEqual(
+            eventPage.networkListeners.auth.listener({
+              requestId: 'off',
+              isProxy: true,
+              challenger: {host: 'proxy.test', port: 8080},
+            }),
+            undefined,
+        );
+
+      });
 
   it('reports stable OFF-only capabilities', async function() {
 
@@ -462,12 +504,14 @@ describe('Firefox MV3 inert skeleton', function() {
     Assert.deepStrictEqual(response, {
       ok: true,
       result: {
-        apiVersion: 1,
+        apiVersion: 2,
         browser: 'FIREFOX',
         manifestVersion: 3,
         runtimeModel: 'BACKGROUND_EVENT_PAGE',
         runtimeState: 'OFF',
         durableIntent: 'OFF',
+        recoveryStatus: 'OFF',
+        recoveryFailureCode: null,
         privateWindowAccess: 'GRANTED',
         routingImplemented: true,
         activationSupported: false,
@@ -489,6 +533,60 @@ describe('Firefox MV3 inert skeleton', function() {
     Assert.strictEqual(response.result.durableIntent, 'OFF');
 
   });
+
+  it('does not recover durable ON without a production recovery factory',
+      async function() {
+
+        const floorIdentity = {
+          proxyType: 'manual',
+          http: '',
+          httpProxyAll: false,
+          ssl: '',
+          socks: '127.0.0.1:55001',
+          socksVersion: 5,
+          proxyDNS: true,
+          passthrough: '',
+          autoConfigUrl: '',
+        };
+        const durableOn = OffState.canonicalOnState({
+          floorIdentity,
+          providerKey: 'synthetic-provider',
+          datasetIdentity: {
+            providerKey: 'synthetic-provider',
+            datasetVersion: 'synthetic.1',
+            artifactSha256: 'a'.repeat(64),
+          },
+          routingDescriptor: {
+            schemaVersion: 1,
+            configurationKey: 'synthetic-routing',
+            configurationVersion: '1',
+            configurationSha256: 'b'.repeat(64),
+          },
+        });
+        const eventPage = startEventPage({
+          storage: makeStorage(durableOn),
+          privateWindowAccess: true,
+          liveProxySettings: {
+            levelOfControl: 'controlled_by_this_extension',
+            value: floorIdentity,
+          },
+        });
+        await eventPage.ready();
+        const response = await eventPage.send({
+          type: 'firefox.capabilities.get',
+        });
+
+        Assert.strictEqual(response.result.durableIntent, 'ON');
+        Assert.strictEqual(response.result.runtimeState, 'FAILED');
+        Assert.strictEqual(response.result.recoveryStatus, 'FAILED');
+        Assert.strictEqual(
+            response.result.recoveryFailureCode,
+            'RECOVERY_UNAVAILABLE',
+        );
+        Assert.strictEqual(eventPage.proxySettingsCalls.set, 0);
+        Assert.strictEqual(eventPage.proxySettingsCalls.clear, 0);
+
+      });
 
   it('rejects activation without changing OFF state', async function() {
 
@@ -533,7 +631,7 @@ describe('Firefox MV3 inert skeleton', function() {
     Assert.strictEqual(capabilities.result.runtimeState, 'OFF');
     Assert.deepStrictEqual(
         JSON.parse(JSON.stringify(storage.values[OffState.STORAGE_KEY])), {
-          schemaVersion: 2,
+          schemaVersion: 3,
           intent: 'OFF',
           floorIdentity: null,
         });
@@ -568,6 +666,7 @@ describe('Firefox MV3 inert skeleton', function() {
             false,
         );
         Assert.strictEqual(eventPageSource.includes('activatePrepared('), false);
+        Assert.strictEqual(eventPageSource.includes('recoveryFactory:'), false);
         Assert.strictEqual(eventPageSource.includes('proxy.settings.set'), false);
 
       });


### PR DESCRIPTION
## Summary

- add strict schema-v3 durable `OFF` / `ON` recovery metadata without persisting functions, credentials, request IDs, auth attempts, or session state
- keep network listeners registered synchronously and treat unknown startup intent as `INITIALIZING` / fail-closed
- persist activation in the order exact dataset READY -> exact floor owned -> durable ON -> clear ephemerals -> immutable session publication
- recover only the exact persisted floor, dataset provider/version/SHA-256, and routing descriptor key/version/SHA-256
- retain the fail-closed floor for blocked private access or unavailable reconstruction, while keeping exact Clear available
- preserve production `firefox.activation.apply -> ACTIVATION_NOT_IMPLEMENTED`; the production event page has no recovery factory or path that creates ON

## Recovery and rollback

- a crash before ON persistence leaves OFF plus cleanup identity and is reconciled by exact Clear
- a crash after ON persistence but before publication reconstructs the exact session without re-setting the old random floor port
- missing/mismatched floor never overwrites another proxy setting and transitions out of claimed ON
- private-access denial retains ON plus the exact floor as `BLOCKED_PRIVATE_ACCESS`; Clear works without regrant
- dataset/config reconstruction failures publish no session and retain the floor fail-closed
- Clear persists OFF before withdrawing the session, clears all routing/auth ephemerals, and only then releases the exact owned floor
- acquisition/set/ownership and Clear failures retain cleanup identity and never publish a partial session

## Verification

- supply-chain: 11/11
- PAC: 26/26
- Chromium MV3: 428/428
- Firefox deterministic: 158/158
- aggregate: 603/603
- Firefox package: 13 allowlisted files
- Chromium runtime comparison: 70 vs 70 files; added 0; missing 0; SHA-256 differences 0
- dependencies and lockfiles: unchanged

Firefox 154.0.1 local-only browser QA with synthetic data completed 10 genuine automatic idle destruction/recovery cycles. All 10 immediate recovery-window protected requests were blocked; restored provider/explicit Direct and Proxy routes, failover, degraded fail-closed exhaustion, authenticated HTTP/HTTPS CONNECT, concurrent request isolation, and private routing passed. Real private-access revocation recreated the context as `BLOCKED_PRIVATE_ACCESS`; Clear succeeded without regrant; a later automatic boot remained OFF. Unexpected protected-origin contacts: 0. Credential leaks: 0.

The dedicated ownership smoke passed 10 checks with nine previous-manual-proxy marker requests and zero protected-origin contacts. The separate production-package lifecycle smoke proved a genuine OFF event-page recreation and four unchanged manual-proxy checks.

No real provider data, updater, health, UI, release work, or persistent credential configuration is included.