### PR TITLE
Handle Firefox active proxy control loss

### DIFF
--- a/docs/development/FIREFOX_MV3_SKELETON.md
+++ b/docs/development/FIREFOX_MV3_SKELETON.md
@@ -145,9 +145,29 @@ random port никогда не считается заново prevalidated и 
 принимает только exact сохранённые dataset hash и routing descriptor, строит
 index, очищает ephemeral maps и публикует session последним присваиванием.
 Missing/mismatched floor переводит durable intent в `OFF`, не
-перезаписывая чужие settings. Missing configuration/dataset/credentials или
+перезаписывая чужие settings, но сохраняет точную старую floor identity как
+cleanup identity на случай, если Firefox позже восстановит слой расширения.
+Missing configuration/dataset/credentials или
 revoked private access оставляет session недоступной, а exact floor —
 fail-closed до Clear.
+
+`proxy.settings.onChange` регистрируется синхронно рядом с network listeners.
+Если `READY` session видит что-либо кроме exact persisted floor с
+`controlled_by_this_extension`, handler без ожидания скрывает active session,
+переводит runtime в `BLOCKED_CONTROL_LOSS` и очищает routing/auth ephemeral
+state. Асинхронная часть затем сохраняет `OFF` с retained cleanup identity;
+она никогда не вызывает `set()` и не очищает setting другого расширения или
+policy. Ошибка записи `OFF` оставляет runtime blocked/fail-closed и не
+восстанавливает session.
+
+Если Firefox после освобождения внешнего controller автоматически возвращает
+старый exact extension-owned floor, уже `OFF` controller удаляет только этот
+точно совпавший слой, восстанавливает нижележащую настройку и удаляет cleanup
+identity лишь после подтверждённого release. Resurfacing никогда не означает
+восстановление `ON` или `READY`. Безопасность на границе передачи control
+по-прежнему зависит от своевременной доставки Firefox события
+`proxy.settings.onChange`; до доставки browser может продолжать вызывать
+старые routing listeners.
 
 Prepared activation теперь фиксирует `ON` после floor confirmation, но до
 session publication. Crash до записи `ON` оставляет `OFF` + cleanup identity;

--- a/extensions/chromium/runet-censorship-bypass/gulpfile.js
+++ b/extensions/chromium/runet-censorship-bypass/gulpfile.js
@@ -28,9 +28,14 @@ const templatePlugin = (context) => through.obj(function(file, encoding, cb) {
 
       }, { keys: [], values: [] });
       try {
-        file.contents = Buffer.from(
-          (new Function(...keys, 'return `' + String(file.contents) + '`;'))(...values)
-        );
+        const rendered =
+          (new Function(...keys, 'return `' + String(file.contents) + '`;'))(
+              ...values,
+          );
+        file.contents = Buffer.from(rendered.replace(
+            '__ANTICENSORITY_PAC_URLS__',
+            JSON.stringify(context.anticensorityPacUrls, null, 2),
+        ));
       } catch(e) {
         e.message += '\nIN FILE: ' + originalPath;
         return cb(new PluginError(PluginName, e));

--- a/extensions/chromium/runet-censorship-bypass/src/extension-common/37-sync-pac-script-with-pac-provider-api.tmpl.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-common/37-sync-pac-script-with-pac-provider-api.tmpl.js
@@ -195,19 +195,23 @@
 
       const pacMods = window.apis.pacKitchen.getPacMods();
       if (!pacMods.filteredCustomsString) {
-        addWarning(
-          ifRu
-            ? \`
-              Не найдено СВОИХ прокси. Этот PAC-скрипт
-              работает только со <a href="https://git.io/ac-own-proxy">СВОИМИ прокси</a>
-              (по умолчанию будет использоваться локальный <a href="https://git.io/ac-tor">Tor</a>).
-            \`
-            : \`
-              Couldn't find OWN proxies. This PAC-script
-              works only with <a href="https://git.io/ac-own-proxy">OWN proxies</a>
-              (by default local <a href="https://git.io/ac-tor">Tor</a> will be used).
-            \`,
-        );
+        if (ifRu) {
+          addWarning([
+            '',
+            '              Не найдено СВОИХ прокси. Этот PAC-скрипт',
+            '              работает только со <a href="https://git.io/ac-own-proxy">СВОИМИ прокси</a>',
+            '              (по умолчанию будет использоваться локальный <a href="https://git.io/ac-tor">Tor</a>).',
+            '            ',
+          ].join(String.fromCharCode(10)));
+        } else {
+          addWarning([
+            '',
+            "              Couldn't find OWN proxies. This PAC-script",
+            '              works only with <a href="https://git.io/ac-own-proxy">OWN proxies</a>',
+            '              (by default local <a href="https://git.io/ac-tor">Tor</a> will be used).',
+            '            ',
+          ].join(String.fromCharCode(10)));
+        }
       }
 
     }
@@ -263,16 +267,20 @@
         distinctKey: 'Antizapret',
         label: chrome.i18n.getMessage('Antizapret'),
         desc: ifRu
-                ? \`Основной PAC-скрипт от автора проекта «Антизапрет».
-                    Охватывет меньше сайтов.
-                    Блокировка определяется по доменному имени и при необходимости по IP.
-                    <br/> <a href="https://github.com/anticensority/runet-censorship-bypass/wiki/PAC-скрипты:-различия">Сравнение PAC-скриптов</a>.
-                  \`
-                : \`The main PAC-script from the author of project "Antizapret"\.
-                    Covers fewer sites.
-                    Block is detected based on a domain name and, if necessary, on an IP.
-                    <br/> <a href="https://github.com/anticensority/runet-censorship-bypass/wiki/PAC-скрипты:-различия">Comparison of PAC-scripts (ru)</a>.
-                  \`,
+                ? [
+                  'Основной PAC-скрипт от автора проекта «Антизапрет».',
+                  '                    Охватывет меньше сайтов.',
+                  '                    Блокировка определяется по доменному имени и при необходимости по IP.',
+                  '                    <br/> <a href="https://github.com/anticensority/runet-censorship-bypass/wiki/PAC-скрипты:-различия">Сравнение PAC-скриптов</a>.',
+                  '                  ',
+                ].join(String.fromCharCode(10))
+                : [
+                  'The main PAC-script from the author of project "Antizapret".',
+                  '                    Covers fewer sites.',
+                  '                    Block is detected based on a domain name and, if necessary, on an IP.',
+                  '                    <br/> <a href="https://github.com/anticensority/runet-censorship-bypass/wiki/PAC-скрипты:-различия">Comparison of PAC-scripts (ru)</a>.',
+                  '                  ',
+                ].join(String.fromCharCode(10)),
         order: 0,
         pacUrls: [
           'https://e.cen.rodeo:8443/proxy.pac',
@@ -285,18 +293,22 @@
         distinctKey: 'Anticensority',
         label: chrome.i18n.getMessage('Anticensority'),
         desc: ifRu
-                ? \`Альтернативный PAC-скрипт от автора расширения.
-                    Охватывает больше сайтов.
-                    Блокировка определятся по доменному имени или IP адресу.
-                    Подходит для провайдеров, блокирующих все сайты на одном IP.
-                    <br/> <a href="https://github.com/anticensority/runet-censorship-bypass/wiki/PAC-скрипты:-различия">Сравнение PAC-скриптов</a>.
-                  \`
-                : \`Alternative PAC-script from the author of this extension.
-                    Covers more sites.
-                    Block is detected based on a domain name and on an IP address.
-                    Better fits providers that block all sites on one IP.
-                    <br/> <a href="https://github.com/anticensority/runet-censorship-bypass/wiki/PAC-скрипты:-различия">Comparison of PAC-scripts (ru)</a>.
-                  \`,
+                ? [
+                  'Альтернативный PAC-скрипт от автора расширения.',
+                  '                    Охватывает больше сайтов.',
+                  '                    Блокировка определятся по доменному имени или IP адресу.',
+                  '                    Подходит для провайдеров, блокирующих все сайты на одном IP.',
+                  '                    <br/> <a href="https://github.com/anticensority/runet-censorship-bypass/wiki/PAC-скрипты:-различия">Сравнение PAC-скриптов</a>.',
+                  '                  ',
+                ].join(String.fromCharCode(10))
+                : [
+                  'Alternative PAC-script from the author of this extension.',
+                  '                    Covers more sites.',
+                  '                    Block is detected based on a domain name and on an IP address.',
+                  '                    Better fits providers that block all sites on one IP.',
+                  '                    <br/> <a href="https://github.com/anticensority/runet-censorship-bypass/wiki/PAC-скрипты:-различия">Comparison of PAC-scripts (ru)</a>.',
+                  '                  ',
+                ].join(String.fromCharCode(10)),
         order: 1,
 
         /*
@@ -304,7 +316,7 @@
           Some urls are encoded to counter abuse.
           Version: 0.17
         */
-        pacUrls: ${JSON.stringify(anticensorityPacUrls, null, 2)},
+        pacUrls: __ANTICENSORITY_PAC_URLS__,
       },
       onlyOwnSites: {
         distinctKey: 'onlyOwnSites',
@@ -342,9 +354,10 @@
     setTitle() {
 
       const upDate = new Date(this.lastPacUpdateStamp).toLocaleString('ru-RU')
-        .replace(/:\\d+$/, '').replace(/\\.\\d{4}/, '');
+        .replace(/:[0-9]+$/, '').replace(/[.][0-9]{4}/, '');
       chrome.browserAction.setTitle({
-        title: \`\${chrome.i18n.getMessage('Updated')} \${upDate} | \${chrome.i18n.getMessage('Version')} \${window.apis.version.build}\`,
+        title: chrome.i18n.getMessage('Updated') + ' ' + upDate + ' | ' +
+          chrome.i18n.getMessage('Version') + ' ' + window.apis.version.build,
       });
 
     },
@@ -618,7 +631,7 @@
 
       })
     );
-    console.log('Alarm listener installed. We won\\'t miss any PAC update.');
+    console.log("Alarm listener installed. We won't miss any PAC update.");
 
     window.addEventListener('online', () => {
 

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/background/activation-controller.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/background/activation-controller.js
@@ -37,11 +37,14 @@
       ]);
       const RESULTS = Object.freeze({
         ACTIVE: 'ACTIVE',
+        CONTROL_RETAINED: 'CONTROL_RETAINED',
         OFF: 'OFF',
         RECOVERED: 'RECOVERED',
+        RESURFACED_FLOOR_RECONCILED: 'RESURFACED_FLOOR_RECONCILED',
       });
       const RECOVERY_STATUS = Object.freeze({
         ACTIVE: 'ACTIVE',
+        BLOCKED_CONTROL_LOSS: 'BLOCKED_CONTROL_LOSS',
         BLOCKED_PRIVATE_ACCESS: 'BLOCKED_PRIVATE_ACCESS',
         FAILED: 'FAILED',
         INITIALIZING: 'INITIALIZING',
@@ -54,6 +57,7 @@
         ACTIVATION_INTERRUPTED: 'ACTIVATION_INTERRUPTED',
         ACTIVATION_ROLLBACK_FAILED: 'ACTIVATION_ROLLBACK_FAILED',
         BOOT_NOT_READY: 'BOOT_NOT_READY',
+        CONTROL_LOSS: 'CONTROL_LOSS',
         DATASET_IDENTITY_MISMATCH: 'DATASET_IDENTITY_MISMATCH',
         DATASET_INITIALIZATION_FAILED: 'DATASET_INITIALIZATION_FAILED',
         DATASET_NOT_READY: 'DATASET_NOT_READY',
@@ -232,6 +236,8 @@
         let recoveryStatus = RECOVERY_STATUS.INITIALIZING;
         let failureCode = null;
         let operationQueue = Promise.resolve();
+        let controlLossPersistencePending = false;
+        let resurfacedReconciliationPending = false;
 
         function enqueue(operation) {
 
@@ -499,10 +505,13 @@
 
         }
 
-        async function transitionLostFloorToOff() {
+        async function transitionLostFloorToOff(floorIdentity) {
 
           try {
-            const next = await OffState.writeOffState(storageArea, null);
+            const next = await OffState.writeOffState(
+                storageArea,
+                floorIdentity,
+            );
             clearEphemeralState();
             setOff(next);
             return true;
@@ -522,7 +531,9 @@
           if (!owned || owned.ok !== true) {
             if (owned && owned.error &&
                 owned.error.code === ProxyControl.ERRORS.OWNERSHIP_MISMATCH) {
-              const transitioned = await transitionLostFloorToOff();
+              const transitioned = await transitionLostFloorToOff(
+                  state.floorIdentity,
+              );
               return errorResult(transitioned ?
                 ERRORS.RECOVERY_FLOOR_MISMATCH :
                 ERRORS.DURABLE_OFF_PERSIST_FAILED, {
@@ -703,6 +714,152 @@
 
         }
 
+        async function persistControlLossOff(floorIdentity) {
+
+          try {
+            const next = await OffState.writeOffState(
+                storageArea,
+                floorIdentity,
+            );
+            clearEphemeralState();
+            setOff(next);
+            return errorResult(ERRORS.CONTROL_LOSS, {
+              transitionedToOff: true,
+              floorRetained: true,
+            });
+          } catch (_error) {
+            activeSession = null;
+            runtimeState = DatasetRuntime.STATES.FAILED;
+            recoveryStatus = RECOVERY_STATUS.BLOCKED_CONTROL_LOSS;
+            failureCode = ERRORS.DURABLE_OFF_PERSIST_FAILED;
+            return errorResult(ERRORS.DURABLE_OFF_PERSIST_FAILED, {
+              transitionedToOff: false,
+              floorRetained: true,
+            });
+          } finally {
+            controlLossPersistencePending = false;
+          }
+
+        }
+
+        async function reconcileResurfacedFloorNow(expectedFloorIdentity) {
+
+          if (activeSession || !durableState ||
+              durableState.intent !== OffState.OFF ||
+              !ProxyControl.sameFloorIdentity(
+                  durableState.floorIdentity,
+                  expectedFloorIdentity,
+              )) {
+            return {ok: true, status: RESULTS.OFF};
+          }
+          let reconciled;
+          try {
+            reconciled = await floorControl.clearFloor();
+          } catch (_error) {
+            reconciled = null;
+          }
+          if (!reconciled || reconciled.ok !== true) {
+            const code = reconciled && reconciled.error &&
+              reconciled.error.code ? reconciled.error.code :
+              ProxyControl.ERRORS.PROXY_CLEAR_FAILED;
+            if (reconciled && reconciled.durableState) {
+              durableState = reconciled.durableState;
+            }
+            setOff(
+                durableState,
+                RECOVERY_STATUS.OFF_RECONCILIATION_FAILED,
+                code,
+            );
+            return errorResult(code, {floorRetained: true});
+          }
+          setOff(reconciled.durableState || OffState.canonicalOffState());
+          return {
+            ok: true,
+            status: RESULTS.RESURFACED_FLOOR_RECONCILED,
+          };
+
+        }
+
+        function queueResurfacedFloorReconciliation(floorIdentity) {
+
+          if (resurfacedReconciliationPending) {
+            return operationQueue;
+          }
+          resurfacedReconciliationPending = true;
+          const reconciliation = enqueue(() =>
+            reconcileResurfacedFloorNow(floorIdentity));
+          reconciliation.then(
+              () => {
+
+                resurfacedReconciliationPending = false;
+
+              },
+              () => {
+
+                resurfacedReconciliationPending = false;
+
+              },
+          );
+          return reconciliation;
+
+        }
+
+        function handleProxySettingsChange(change) {
+
+          const state = durableState;
+          const floorIdentity = state && state.floorIdentity;
+          let exactOwnedFloor = false;
+          try {
+            exactOwnedFloor = Boolean(floorIdentity &&
+              ProxyControl.isExactOwnedFloor(change, floorIdentity));
+          } catch (_error) {
+            exactOwnedFloor = false;
+          }
+          if (activeSession &&
+              currentRuntimeState() === DatasetRuntime.STATES.READY) {
+            if (exactOwnedFloor) {
+              return {ok: true, status: RESULTS.CONTROL_RETAINED};
+            }
+
+            // This phase is intentionally synchronous: no storage, proxy API,
+            // Promise or network operation may precede session withdrawal.
+            activeSession = null;
+            runtimeState = DatasetRuntime.STATES.FAILED;
+            recoveryStatus = RECOVERY_STATUS.BLOCKED_CONTROL_LOSS;
+            failureCode = ERRORS.CONTROL_LOSS;
+            clearEphemeralState();
+            if (!floorIdentity || controlLossPersistencePending) {
+              return errorResult(ERRORS.CONTROL_LOSS, {
+                reconciliation: operationQueue,
+              });
+            }
+            controlLossPersistencePending = true;
+            return errorResult(ERRORS.CONTROL_LOSS, {
+              reconciliation: enqueue(() =>
+                persistControlLossOff(floorIdentity)),
+            });
+          }
+
+          const mayReconcileResurfacedFloor = Boolean(
+              floorIdentity &&
+              (state.intent === OffState.OFF ||
+                (recoveryStatus === RECOVERY_STATUS.BLOCKED_CONTROL_LOSS &&
+                  controlLossPersistencePending)) &&
+              exactOwnedFloor,
+          );
+          if (mayReconcileResurfacedFloor) {
+            return {
+              ok: true,
+              status: RECOVERY_STATUS.OFF,
+              reconciliation: queueResurfacedFloorReconciliation(
+                  floorIdentity,
+              ),
+            };
+          }
+          return {ok: true, status: recoveryStatus};
+
+        }
+
         function snapshot() {
 
           return Object.freeze({
@@ -732,6 +889,7 @@
             return enqueue(initializeFromDurableNow);
 
           },
+          handleProxySettingsChange,
           resolveCredentials,
           routingInputForRequest,
           snapshot,

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/background/event-page.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/background/event-page.js
@@ -106,6 +106,11 @@
       routingAdapter.onProxyRequest,
       {urls: ['<all_urls>']},
   );
+  browser.proxy.settings.onChange.addListener((change) => {
+
+    activationController.handleProxySettingsChange(change);
+
+  });
   browser.webRequest.onBeforeRequest.addListener(
       routingAdapter.onBeforeRequest,
       {urls: ['<all_urls>']},

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/durable-activation.test.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/durable-activation.test.js
@@ -132,7 +132,9 @@ function memoryStorage(initialState, events = [], options = {}) {
 
       const next = update[OffState.STORAGE_KEY];
       events.push(`storage-set-${next && next.intent || 'unknown'}`);
-      if (options.failOnIntent === (next && next.intent)) {
+      if (options.failOnIntent === (next && next.intent) ||
+          (typeof options.shouldFailSet === 'function' &&
+            options.shouldFailSet(next))) {
         throw new Error('synthetic storage write failure');
       }
       Object.assign(values, structuredClone(update));
@@ -240,6 +242,11 @@ function createSystem(options = {}) {
     get liveSettings() {
 
       return liveSettings;
+
+    },
+    setLiveSettings(value) {
+
+      liveSettings = structuredClone(value);
 
     },
     proxyAuth,
@@ -502,7 +509,7 @@ describe('Firefox durable activation recovery', function() {
         Assert.strictEqual(system.controller.currentRuntimeState(), 'OFF');
         Assert.deepStrictEqual(
             system.storageArea.values[OffState.STORAGE_KEY],
-            OffState.canonicalOffState(),
+            OffState.canonicalOffState(floor()),
         );
         Assert.strictEqual(system.proxyCalls.set, 0);
         Assert.strictEqual(system.proxyCalls.clear, 0);
@@ -834,5 +841,293 @@ describe('Firefox durable activation recovery', function() {
         Assert.strictEqual(system.routingAdapter.authorizationCount(), 1);
 
       });
+
+  describe('active proxy control loss', function() {
+
+    async function activeSystem(options = {}) {
+
+      const store = await verifiedStore();
+      const system = createSystem(options);
+      await system.controller.initializeFromDurable();
+      const activated = await system.controller.activatePrepared(prepared(
+          store,
+          undefined,
+          options.preparedOverrides,
+      ));
+      Assert.strictEqual(activated.ok, true);
+      return system;
+
+    }
+
+    function ownedFloorChange(identity = floor()) {
+
+      return {
+        levelOfControl: 'controlled_by_this_extension',
+        value: identity,
+      };
+
+    }
+
+    function externalChange() {
+
+      return {
+        levelOfControl: 'controlled_by_other_extensions',
+        value: {
+          proxyType: 'manual',
+          http: '127.0.0.1:58080',
+        },
+      };
+
+    }
+
+    it('keeps READY only for the exact extension-owned floor',
+        async function() {
+
+          const system = await activeSystem();
+
+          const observed = system.controller.handleProxySettingsChange(
+              ownedFloorChange(),
+          );
+
+          Assert.deepStrictEqual(observed, {
+            ok: true,
+            status: Activation.RESULTS.CONTROL_RETAINED,
+          });
+          Assert.strictEqual(system.controller.snapshot().active, true);
+          Assert.strictEqual(system.controller.currentRuntimeState(), 'READY');
+
+        });
+
+    it('withdraws synchronously and clears route/auth state before persistence',
+        async function() {
+
+          const authenticated = candidate({authRef: 'fixture-auth'});
+          const system = await activeSystem({
+            preparedOverrides: {
+              resolveCredentials: () => ({
+                username: 'fixture-user',
+                password: 'fixture-password',
+              }),
+              routingBaseInputForRequest: baseInputForRequest(authenticated),
+            },
+          });
+          const request = {
+            requestId: 'active-control-loss',
+            url: 'http://beta.example/',
+          };
+          system.routingAdapter.onProxyRequest(request);
+          system.routingAdapter.onBeforeRequest({
+            requestId: request.requestId,
+            proxyInfo: {type: 'http', host: '127.0.0.1', port: 18080},
+          });
+          system.proxyAuth.onAuthRequired({
+            requestId: request.requestId,
+            isProxy: true,
+            challenger: {host: '127.0.0.1', port: 18080},
+          });
+          Assert.ok(system.routingAdapter.authorizationCount() > 0);
+          Assert.strictEqual(system.proxyAuth.attemptCount(), 1);
+
+          const loss = system.controller.handleProxySettingsChange(
+              externalChange(),
+          );
+
+          Assert.strictEqual(loss.error.code, Activation.ERRORS.CONTROL_LOSS);
+          Assert.deepStrictEqual(system.controller.snapshot(), {
+            runtimeState: 'FAILED',
+            active: false,
+            durableIntent: 'ON',
+            recoveryStatus: Activation.RECOVERY_STATUS.BLOCKED_CONTROL_LOSS,
+            failureCode: Activation.ERRORS.CONTROL_LOSS,
+          });
+          Assert.strictEqual(system.routingAdapter.authorizationCount(), 0);
+          Assert.strictEqual(system.proxyAuth.attemptCount(), 0);
+          Assert.deepStrictEqual(system.routingAdapter.onBeforeRequest({
+            requestId: 'after-observed-loss',
+          }), {cancel: true});
+          await loss.reconciliation;
+          Assert.deepStrictEqual(
+              system.storageArea.values[OffState.STORAGE_KEY],
+              OffState.canonicalOffState(floor()),
+          );
+          Assert.strictEqual(system.controller.currentRuntimeState(), 'OFF');
+
+        });
+
+    it('never clears or overwrites the external controller setting',
+        async function() {
+
+          const system = await activeSystem();
+          const callsBefore = {
+            clear: system.proxyCalls.clear,
+            get: system.proxyCalls.get,
+            set: system.proxyCalls.set,
+          };
+          system.setLiveSettings(externalChange());
+
+          const loss = system.controller.handleProxySettingsChange(
+              externalChange(),
+          );
+          await loss.reconciliation;
+          system.controller.handleProxySettingsChange(externalChange());
+
+          Assert.strictEqual(system.proxyCalls.set, callsBefore.set);
+          Assert.strictEqual(system.proxyCalls.clear, callsBefore.clear);
+          Assert.deepStrictEqual(system.liveSettings, externalChange());
+
+        });
+
+    it('treats malformed or throwing change details as control loss',
+        async function() {
+
+          for (const change of [
+            null,
+            {levelOfControl: 'controlled_by_this_extension', value: null},
+            new Proxy({}, {
+              get() {
+
+                throw new Error('synthetic malformed change');
+
+              },
+            }),
+          ]) {
+            const system = await activeSystem();
+            const loss = system.controller.handleProxySettingsChange(change);
+
+            Assert.strictEqual(loss.error.code, Activation.ERRORS.CONTROL_LOSS);
+            Assert.strictEqual(system.controller.snapshot().active, false);
+            Assert.strictEqual(system.controller.currentRuntimeState(),
+                'FAILED');
+            await loss.reconciliation;
+          }
+
+        });
+
+    it('remains BLOCKED when durable OFF persistence fails', async function() {
+
+      let failOff = false;
+      const storageArea = memoryStorage(
+          OffState.canonicalOffState(),
+          [],
+          {shouldFailSet: (state) => failOff && state.intent === OffState.OFF},
+      );
+      const system = await activeSystem({storageArea});
+      failOff = true;
+
+      const loss = system.controller.handleProxySettingsChange(
+          externalChange(),
+      );
+      const persisted = await loss.reconciliation;
+
+      Assert.strictEqual(persisted.error.code,
+          Activation.ERRORS.DURABLE_OFF_PERSIST_FAILED);
+      Assert.deepStrictEqual(system.controller.snapshot(), {
+        runtimeState: 'FAILED',
+        active: false,
+        durableIntent: 'ON',
+        recoveryStatus: Activation.RECOVERY_STATUS.BLOCKED_CONTROL_LOSS,
+        failureCode: Activation.ERRORS.DURABLE_OFF_PERSIST_FAILED,
+      });
+
+    });
+
+    it('exact-clears a resurfaced old floor once and never resumes READY',
+        async function() {
+
+          const system = await activeSystem();
+          system.setLiveSettings(externalChange());
+          const loss = system.controller.handleProxySettingsChange(
+              externalChange(),
+          );
+          await loss.reconciliation;
+          const clearsBefore = system.proxyCalls.clear;
+          system.setLiveSettings(ownedFloorChange());
+
+          const first = system.controller.handleProxySettingsChange(
+              ownedFloorChange(),
+          );
+          const repeated = system.controller.handleProxySettingsChange(
+              ownedFloorChange(),
+          );
+          await Promise.all([first.reconciliation, repeated.reconciliation]);
+
+          Assert.strictEqual(system.proxyCalls.clear, clearsBefore + 1);
+          Assert.deepStrictEqual(system.storageArea.values[OffState.STORAGE_KEY],
+              OffState.canonicalOffState());
+          Assert.strictEqual(system.controller.currentRuntimeState(), 'OFF');
+          Assert.strictEqual(system.controller.snapshot().active, false);
+
+        });
+
+    it('leaves unrelated resurfaced settings untouched', async function() {
+
+      const system = createSystem({
+        durableState: OffState.canonicalOffState(floor()),
+        liveSettings: externalChange(),
+      });
+      await system.controller.initializeFromDurable();
+      const clearsBefore = system.proxyCalls.clear;
+
+      system.controller.handleProxySettingsChange(externalChange());
+
+      Assert.strictEqual(system.proxyCalls.clear, clearsBefore);
+      Assert.deepStrictEqual(system.liveSettings, externalChange());
+      Assert.strictEqual(system.controller.currentRuntimeState(), 'OFF');
+
+    });
+
+    it('recreation after loss stays OFF and never reacquires the floor',
+        async function() {
+
+          const original = await activeSystem();
+          original.setLiveSettings(externalChange());
+          const loss = original.controller.handleProxySettingsChange(
+              externalChange(),
+          );
+          await loss.reconciliation;
+          const recreated = createSystem({
+            storageArea: original.storageArea,
+            liveSettings: externalChange(),
+          });
+
+          const initialized = await recreated.controller.initializeFromDurable();
+
+          Assert.strictEqual(initialized.ok, false);
+          Assert.strictEqual(recreated.controller.currentRuntimeState(), 'OFF');
+          Assert.strictEqual(recreated.controller.snapshot().active, false);
+          Assert.deepStrictEqual(
+              recreated.storageArea.values[OffState.STORAGE_KEY],
+              OffState.canonicalOffState(floor()),
+          );
+          Assert.strictEqual(recreated.proxyCalls.set, 0);
+          Assert.strictEqual(recreated.proxyCalls.clear, 0);
+
+        });
+
+    it('retains cleanup identity when ON recovery sees a policy mismatch',
+        async function() {
+
+          const system = createSystem({
+            durableState: onState(),
+            liveSettings: {
+              levelOfControl: 'controlled_by_policy',
+              value: {proxyType: 'none'},
+            },
+          });
+
+          const result = await system.controller.initializeFromDurable();
+
+          Assert.strictEqual(result.error.code,
+              Activation.ERRORS.RECOVERY_FLOOR_MISMATCH);
+          Assert.deepStrictEqual(
+              system.storageArea.values[OffState.STORAGE_KEY],
+              OffState.canonicalOffState(floor()),
+          );
+          Assert.strictEqual(system.proxyCalls.set, 0);
+          Assert.strictEqual(system.proxyCalls.clear, 0);
+
+        });
+
+  });
 
 });

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/skeleton.test.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/skeleton.test.js
@@ -102,6 +102,7 @@ function startEventPage(options = {}) {
   };
   let messageListener;
   const networkListeners = {};
+  let proxySettingsChangeListener;
   const browser = {
     extension: {
       async isAllowedIncognitoAccess() {
@@ -136,6 +137,14 @@ function startEventPage(options = {}) {
         },
       },
       settings: {
+        onChange: {
+          addListener(listener) {
+
+            events.push('proxy-settings-change-listener-registered');
+            proxySettingsChangeListener = listener;
+
+          },
+        },
         async clear() {
 
           proxySettingsCalls.clear += 1;
@@ -251,6 +260,12 @@ function startEventPage(options = {}) {
     events,
     networkListeners,
     proxySettingsCalls,
+    proxySettingsChange(change) {
+
+      Assert.strictEqual(typeof proxySettingsChangeListener, 'function');
+      return proxySettingsChangeListener(change);
+
+    },
     storage,
     async ready() {
 
@@ -436,8 +451,9 @@ describe('Firefox MV3 inert skeleton', function() {
         const eventPage = startEventPage();
         await eventPage.ready();
 
-        Assert.deepStrictEqual(eventPage.events.slice(0, 7), [
+        Assert.deepStrictEqual(eventPage.events.slice(0, 8), [
           'proxy-listener-registered',
+          'proxy-settings-change-listener-registered',
           'guard-listener-registered',
           'auth-listener-registered',
           'completed-listener-registered',


### PR DESCRIPTION
## Summary

- synchronously register `proxy.settings.onChange` with the Firefox network listeners
- withdraw a READY session and clear routing/auth ephemerals before any asynchronous work when the exact owned floor is lost
- persist durable `OFF` while retaining the exact old floor identity for later cleanup
- exact-clear a resurfaced old floor without overwriting another extension or policy, and never silently resume
- retain cleanup identity when durable ON recovery finds a missing or mismatched floor
- keep production `firefox.activation.apply` as `ACTIVATION_NOT_IMPLEMENTED`

## CodeQL preflight

The Default Setup parse warning came from
`src/extension-common/37-sync-pac-script-with-pac-provider-api.tmpl.js`.
That tracked Gulp input had been source text embedded in an outer template literal; escaped nested delimiters/interpolations made the checked-in file invalid to CodeQL as standalone JavaScript. The input is now ordinary valid JavaScript with a non-executable `__ANTICENSORITY_PAC_URLS__` sentinel, and the existing Gulp template step substitutes the JSON PAC URL array. The warning-site conditional was also expressed as ordinary `if/else` statements for extractor compatibility. All tracked JavaScript and generated mini/full/beta outputs pass `node --check`; no active JS/TS path is excluded. The final PR CodeQL run explicitly logs `Extracting` and `Done extracting` for the corrected head file. Its diagnostic summary still echoes the old line-200 parse diagnostic from the cached `e1b7cec` overlay-base database; a fresh default-branch database after merge is required to retire that baseline diagnostic.

## Control-loss behavior

`READY` accepts only `controlled_by_this_extension` plus an exact canonical persisted floor. Every other or malformed change immediately publishes:

- inactive session
- runtime `FAILED`
- recovery status `BLOCKED_CONTROL_LOSS`
- failure code `CONTROL_LOSS`
- empty routing/auth ephemeral maps

Queued persistence writes `OFF` with the old exact floor identity. A failed OFF write remains blocked and never restores the session. External settings are neither set nor cleared. If Firefox later resurfaces the exact old extension-owned layer, serialized OFF reconciliation clears only that layer and deletes cleanup identity only after confirmed release.

## Verification

- supply-chain tests: 11/11
- PAC: 26/26
- Chromium MV3: 428/428
- Firefox deterministic: 167/167
- aggregate: 612/612
- Firefox package: 13 allowlisted files
- Chromium package: 70 vs 70; added 0; missing 0; SHA-256 differences 0
- dependencies/lockfiles: unchanged
- docs, lint, MV2/MV3/Firefox builds, both package-integrity checks, and `git diff --check`: pass

Firefox 154.0.1 build 20260824154132, disposable local-only two-extension smoke:

- 100 takeover-race requests
- 25 requests entered A before `onChange`; 75 after
- A proxy routes after `onChange`: 0
- unexpected protected-origin contacts: 0
- top-level Direct origin contacts after loss: 0
- nine previously routed A requests completed after notification and are reported separately as in-flight
- B Clear resurfaced A's exact floor; A exact-cleared it, restored the previous manual proxy, and stayed OFF
- genuine later event-page recreation had a new boot ID and remained OFF without reacquisition

The enterprise-policy browser fixture remains inconclusive on Firefox Release because the test policy did not become active/locked. Deterministic policy-shaped control states follow the same fail-closed mismatch path. The remaining platform assumption is timely Firefox delivery of `proxy.settings.onChange`.