### PR TITLE
Add authenticated Firefox provider update pipeline

### DIFF
--- a/docs/development/FIREFOX_MV3_SKELETON.md
+++ b/docs/development/FIREFOX_MV3_SKELETON.md
@@ -99,8 +99,9 @@ route-auth, так и attempt state. Отмена исчерпанного auth 
 request вместо перехода к следующему proxy candidate; это известное Firefox
 availability-отличие, а не Direct fallback или утечка.
 
-Реальный provider dataset, updater, активация, production credential
-configuration/UI и health-проверки ещё не реализованы. Ownership/auth
+Реальный provider dataset, production updater configuration, активация,
+production credential configuration/UI и health-проверки ещё не реализованы.
+Ownership/auth
 primitives не делают routing доступным. Команда
 активации всегда отвечает
 `ACTIVATION_NOT_IMPLEMENTED`; наличие широких сетевых разрешений не делает
@@ -205,9 +206,40 @@ active -> previous LKG -> packaged baseline; parsed index хранится то�
 в отдельных object stores Firefox-specific IndexedDB; запись артефакта и
 переключение pointer выполняются одной транзакцией только после проверки точных
 bytes. Remote candidate с unauthenticated trust не может стать active. Пакет не
-содержит реального или синтетического provider
-dataset и в `OFF` не открывает dataset storage. Он не меняет Chromium build
-output. Отдельный
+содержит реального или синтетического provider dataset и в `OFF` не открывает
+dataset storage. Он не меняет Chromium build output.
+
+Пакет содержит инертный authenticated-update pipeline, но production event
+page его не создаёт и не вызывает: отсутствуют production URL, public key,
+alarm/timer, startup fetch и RPC update command. Update manifest schema v1
+содержит только `schemaVersion`, `providerKey`, monotonic `sequence`, `keyId`,
+relative `artifactPath` и строгий dataset `envelope`. Отдельная 64-byte
+Ed25519 signature проверяется native WebCrypto над точными UTF-8 bytes
+manifest до доверия его полям. `keyId` выбирает ключ только из injected pinned
+`Map`; remote JSON не может объявить `trust`. После signature, manifest,
+provider identity, exact byte count, SHA-256 и общей declarative dataset
+verification pipeline внутренне присваивает `REMOTE_AUTHENTICATED`.
+
+Fetch boundary принимает только явный HTTPS URL без credentials/query/fragment,
+использует manual redirects с максимум тремя same-origin HTTPS переходами,
+`credentials: omit`, `referrerPolicy: no-referrer`, общий deadline/AbortSignal и
+streaming size bounds. Manifest ограничен 256 KiB, signature — ровно 64 bytes,
+artifact — существующим пределом 16 MiB. Downloaded bytes никогда не
+исполняются и остаются `HOST_BUCKETS_V1` data.
+
+Provider pointer schema v2 мигрирует v1 с сохранением `active`,
+`previousLkg` и `packagedBaseline`, добавляя отдельный `staged` pointer и
+anti-rollback пару `highestAuthenticatedSequence`/artifact SHA-256. Lower
+sequence отклоняется; одинаковые sequence+SHA idempotent, а одинаковый
+sequence с другим SHA даёт conflict. Только полностью verified candidate
+атомарно записывает immutable artifact, staged pointer и sequence metadata.
+Stage не меняет active/LKG/live session/durable ON identity. Отдельный explicit
+promotion одной IndexedDB transaction переводит staged в active, прежний
+active в LKG и очищает staged; production event page promotion не вызывает.
+Storage/signature/network failure не продвигает sequence и не меняет текущий
+routing dataset.
+
+Отдельный
 локальный smoke с установленным Firefox 154.0.1 и одноразовым профилем можно
 запустить командой:
 

--- a/extensions/chromium/runet-censorship-bypass/gulpfile.js
+++ b/extensions/chromium/runet-censorship-bypass/gulpfile.js
@@ -94,6 +94,7 @@ const firefoxMv3RuntimeSrc = [
   './src/extension-firefox-mv3/background/off-state.js',
   './src/extension-firefox-mv3/background/proxy-control.js',
   './src/extension-firefox-mv3/background/dataset-store.js',
+  './src/extension-firefox-mv3/background/provider-updater.js',
   './src/extension-firefox-mv3/background/provider-lookup.js',
   './src/extension-firefox-mv3/background/dataset-runtime.js',
   './src/extension-firefox-mv3/background/routing-adapter.js',

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/background/dataset-store.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/background/dataset-store.js
@@ -21,7 +21,8 @@
 
       const DATABASE_NAME = 'rucb-firefox-provider-datasets-v1';
       const DATABASE_VERSION = 1;
-      const POINTER_SCHEMA_VERSION = 1;
+      const LEGACY_POINTER_SCHEMA_VERSION = 1;
+      const POINTER_SCHEMA_VERSION = 2;
       const ARTIFACT_STORE = 'artifacts';
       const POINTER_STORE = 'providerPointers';
       const SHA256_PATTERN = /^[a-f0-9]{64}$/;
@@ -31,13 +32,25 @@
         'activeArtifactSha256',
         'packagedBaselineArtifactSha256',
         'previousLkgArtifactSha256',
+        'stagedArtifactSha256',
       ]);
-      const POINTER_RECORD_FIELDS = Object.freeze([
+      const LEGACY_POINTER_RECORD_FIELDS = Object.freeze([
         'activeArtifactSha256',
         'packagedBaselineArtifactSha256',
         'previousLkgArtifactSha256',
         'providerKey',
         'schemaVersion',
+      ]);
+      const POINTER_RECORD_FIELDS = Object.freeze([
+        'activeArtifactSha256',
+        'highestAuthenticatedArtifactSha256',
+        'highestAuthenticatedSequence',
+        'packagedBaselineArtifactSha256',
+        'previousLkgArtifactSha256',
+        'providerKey',
+        'schemaVersion',
+        'stagedArtifactSha256',
+        'stagedSequence',
       ]);
       const ARTIFACT_RECORD_FIELDS = Object.freeze([
         'artifactBytes',
@@ -88,6 +101,10 @@
           activeArtifactSha256: null,
           previousLkgArtifactSha256: null,
           packagedBaselineArtifactSha256: null,
+          stagedArtifactSha256: null,
+          stagedSequence: null,
+          highestAuthenticatedSequence: null,
+          highestAuthenticatedArtifactSha256: null,
         };
 
       }
@@ -96,18 +113,34 @@
 
         const normalized = emptyPointers(providerKey);
         const corruptions = {};
-        if (!value || typeof value !== 'object' || Array.isArray(value) ||
-            Object.keys(value).length !== POINTER_RECORD_FIELDS.length ||
-            Object.keys(value).some((key) =>
-              !POINTER_RECORD_FIELDS.includes(key)) ||
-            value.schemaVersion !== POINTER_SCHEMA_VERSION ||
-            value.providerKey !== providerKey) {
+        if (!value || typeof value !== 'object' || Array.isArray(value)) {
           POINTER_FIELDS.forEach((field) => {
             corruptions[field] = value !== null && value !== undefined;
           });
           return {pointers: normalized, corruptions};
         }
+        const keys = Object.keys(value);
+        const isLegacy =
+          value.schemaVersion === LEGACY_POINTER_SCHEMA_VERSION &&
+          value.providerKey === providerKey &&
+          keys.length === LEGACY_POINTER_RECORD_FIELDS.length &&
+          keys.every((key) => LEGACY_POINTER_RECORD_FIELDS.includes(key));
+        const isCurrent =
+          value.schemaVersion === POINTER_SCHEMA_VERSION &&
+          value.providerKey === providerKey &&
+          keys.length === POINTER_RECORD_FIELDS.length &&
+          keys.every((key) => POINTER_RECORD_FIELDS.includes(key));
+        if (!isLegacy && !isCurrent) {
+          POINTER_FIELDS.forEach((field) => {
+            corruptions[field] = true;
+          });
+          corruptions.authenticatedSequenceState = true;
+          return {pointers: normalized, corruptions};
+        }
         for (const field of POINTER_FIELDS) {
+          if (isLegacy && field === 'stagedArtifactSha256') {
+            continue;
+          }
           const pointer = value[field];
           if (pointer === null || pointer === undefined) {
             normalized[field] = null;
@@ -116,6 +149,39 @@
           } else {
             corruptions[field] = true;
           }
+        }
+        if (isLegacy) {
+          return {
+            pointers: normalized,
+            corruptions,
+            migratedFromSchemaVersion: LEGACY_POINTER_SCHEMA_VERSION,
+          };
+        }
+        const validSequencePair = (sequence, artifactSha256) =>
+          (sequence === null && artifactSha256 === null) ||
+          (Number.isSafeInteger(sequence) && sequence >= 1 &&
+           isSha256(artifactSha256));
+        if (!validSequencePair(
+            value.highestAuthenticatedSequence,
+            value.highestAuthenticatedArtifactSha256,
+        ) || !validSequencePair(
+            value.stagedSequence,
+            value.stagedArtifactSha256,
+        ) || (value.stagedSequence !== null &&
+          (value.stagedSequence !== value.highestAuthenticatedSequence ||
+           value.stagedArtifactSha256 !==
+             value.highestAuthenticatedArtifactSha256))) {
+          normalized.stagedArtifactSha256 = null;
+          normalized.stagedSequence = null;
+          normalized.highestAuthenticatedSequence = null;
+          normalized.highestAuthenticatedArtifactSha256 = null;
+          corruptions.authenticatedSequenceState = true;
+        } else {
+          normalized.stagedSequence = value.stagedSequence;
+          normalized.highestAuthenticatedSequence =
+            value.highestAuthenticatedSequence;
+          normalized.highestAuthenticatedArtifactSha256 =
+            value.highestAuthenticatedArtifactSha256;
         }
         return {pointers: normalized, corruptions};
 
@@ -246,9 +312,16 @@
             const artifacts = transaction.objectStore(ARTIFACT_STORE);
             const pointers = transaction.objectStore(POINTER_STORE);
             let failure = null;
-            const existingRequest = artifacts.get(
-                nextArtifact.artifactSha256,
-            );
+            if (!nextArtifact) {
+              pointers.put(nextPointers);
+              transaction.oncomplete = () => resolve();
+              transaction.onerror = () => {};
+              transaction.onabort = () => reject(
+                  transaction.error || storeError('INDEXED_DB_COMMIT_ABORTED'),
+              );
+              return;
+            }
+            const existingRequest = artifacts.get(nextArtifact.artifactSha256);
             existingRequest.onsuccess = () => {
               try {
                 const existing = existingRequest.result;
@@ -307,6 +380,15 @@
         if (typeof sha256 !== 'function') {
           throw storeError('SHA256_IMPLEMENTATION_REQUIRED');
         }
+        let mutationQueue = Promise.resolve();
+
+        function enqueueMutation(operation) {
+
+          const result = mutationQueue.then(operation, operation);
+          mutationQueue = result.catch(() => {});
+          return result;
+
+        }
 
         async function verifyInput(input) {
 
@@ -328,6 +410,7 @@
             POINTER_FIELDS.forEach((field) => {
               normalized.corruptions[field] = true;
             });
+            normalized.corruptions.authenticatedSequenceState = true;
             return normalized;
           }
 
@@ -475,10 +558,147 @@
 
         }
 
+        async function stageAuthenticatedCandidate({
+          envelope,
+          artifactBytes,
+          sequence,
+        } = {}) {
+
+          if (!Number.isSafeInteger(sequence) || sequence < 1) {
+            return rejection('INVALID_AUTHENTICATED_SEQUENCE');
+          }
+          const candidate = await verifyInput({
+            envelope,
+            artifactBytes,
+            trust: Dataset.TRUST.REMOTE_AUTHENTICATED,
+          });
+          if (!candidate.ok) {
+            return candidate;
+          }
+          const providerKey = candidate.dataset.identity.providerKey;
+          const current = await readPointerState(providerKey);
+          if (current.corruptions.authenticatedSequenceState) {
+            return rejection('AUTHENTICATED_SEQUENCE_STATE_CORRUPT');
+          }
+          const pointers = current.pointers;
+          const artifactSha256 = candidate.dataset.identity.artifactSha256;
+          if (pointers.highestAuthenticatedSequence !== null) {
+            if (sequence < pointers.highestAuthenticatedSequence) {
+              return rejection('ROLLBACK_REJECTED');
+            }
+            if (sequence === pointers.highestAuthenticatedSequence) {
+              if (artifactSha256 !==
+                  pointers.highestAuthenticatedArtifactSha256) {
+                return rejection('SEQUENCE_CONFLICT');
+              }
+              return Object.freeze({
+                ok: true,
+                status: 'UNCHANGED',
+                verification: candidate,
+                sequence,
+              });
+            }
+          }
+          pointers.stagedArtifactSha256 = artifactSha256;
+          pointers.stagedSequence = sequence;
+          pointers.highestAuthenticatedSequence = sequence;
+          pointers.highestAuthenticatedArtifactSha256 = artifactSha256;
+          await backend.commit(
+              artifactRecord(candidate, artifactBytes),
+              pointers,
+          );
+          return Object.freeze({
+            ok: true,
+            status: 'STAGED',
+            verification: candidate,
+            sequence,
+          });
+
+        }
+
+        async function loadStaged(providerKey) {
+
+          if (!isProviderKey(providerKey)) {
+            throw storeError('INVALID_PROVIDER_KEY');
+          }
+          const current = await readPointerState(providerKey);
+          if (current.corruptions.authenticatedSequenceState ||
+              current.corruptions.stagedArtifactSha256) {
+            return rejection('STAGED_POINTER_CORRUPT');
+          }
+          if (!current.pointers.stagedArtifactSha256) {
+            return Object.freeze({
+              ok: true,
+              status: 'EMPTY',
+              pointers: current.pointers,
+              verification: null,
+            });
+          }
+          const verification = await verifyStored(
+              providerKey,
+              current.pointers.stagedArtifactSha256,
+              'STAGED_ARTIFACT',
+          );
+          return Object.freeze({
+            ok: Boolean(verification && verification.ok),
+            status: verification && verification.ok ? 'STAGED' : 'REJECTED',
+            code: verification && !verification.ok ? verification.code : null,
+            sequence: current.pointers.stagedSequence,
+            pointers: current.pointers,
+            verification,
+          });
+
+        }
+
+        async function promoteStaged(providerKey) {
+
+          const staged = await loadStaged(providerKey);
+          if (!staged.ok || staged.status !== 'STAGED' ||
+              staged.verification.trust !==
+                Dataset.TRUST.REMOTE_AUTHENTICATED) {
+            return staged.ok ? rejection('NO_STAGED_CANDIDATE') : staged;
+          }
+          const pointers = Object.assign({}, staged.pointers);
+          pointers.previousLkgArtifactSha256 =
+            pointers.activeArtifactSha256 ||
+            pointers.previousLkgArtifactSha256;
+          pointers.activeArtifactSha256 = pointers.stagedArtifactSha256;
+          pointers.stagedArtifactSha256 = null;
+          pointers.stagedSequence = null;
+          await backend.commit(null, pointers);
+          return Object.freeze({
+            ok: true,
+            status: 'PROMOTED',
+            sequence: staged.sequence,
+            verification: staged.verification,
+          });
+
+        }
+
         return Object.freeze({
-          activateCandidate,
-          commitPackagedBaseline,
+          activateCandidate(input) {
+
+            return enqueueMutation(() => activateCandidate(input));
+
+          },
+          commitPackagedBaseline(input) {
+
+            return enqueueMutation(() => commitPackagedBaseline(input));
+
+          },
           loadVerifications,
+          loadStaged,
+          promoteStaged(providerKey) {
+
+            return enqueueMutation(() => promoteStaged(providerKey));
+
+          },
+          stageAuthenticatedCandidate(input) {
+
+            return enqueueMutation(() =>
+              stageAuthenticatedCandidate(input));
+
+          },
         });
 
       }
@@ -486,6 +706,7 @@
       return Object.freeze({
         DATABASE_NAME,
         DATABASE_VERSION,
+        LEGACY_POINTER_SCHEMA_VERSION,
         POINTER_SCHEMA_VERSION,
         createIndexedDbBackend,
         createStore,

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/background/provider-updater.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/background/provider-updater.js
@@ -1,0 +1,505 @@
+'use strict';
+/* global require */
+
+(function publishFirefoxProviderUpdater(root, factory) {
+
+  const dataset = typeof module === 'object' && module.exports ?
+    require('../../extension-mv3-common/provider-dataset') :
+    root.mv3ProviderDataset;
+  const api = factory(dataset, root);
+  if (typeof module === 'object' && module.exports) {
+    module.exports = api;
+    return;
+  }
+  root.rucbFirefoxProviderUpdater = api;
+
+})(typeof globalThis === 'object' ? globalThis : this,
+    function(Dataset, root) {
+
+      const MANIFEST_SCHEMA_VERSION = 1;
+      const MAX_MANIFEST_BYTES = 256 * 1024;
+      const MAX_SIGNATURE_BYTES = 64;
+      const MAX_REDIRECTS = 3;
+      const DEFAULT_DEADLINE_MS = 15000;
+      const IDENTIFIER_PATTERN = /^[a-z0-9](?:[a-z0-9._-]{0,63})$/;
+      const ARTIFACT_PATH_PATTERN =
+        /^[A-Za-z0-9](?:[A-Za-z0-9._/-]{0,511})$/;
+      const MANIFEST_FIELDS = Object.freeze([
+        'artifactPath',
+        'envelope',
+        'keyId',
+        'providerKey',
+        'schemaVersion',
+        'sequence',
+      ]);
+      const REDIRECT_STATUSES = Object.freeze([301, 302, 303, 307, 308]);
+
+      function updaterError(code) {
+
+        const error = new TypeError(code);
+        error.code = code;
+        return error;
+
+      }
+
+      function rejection(error) {
+
+        return Object.freeze({
+          ok: false,
+          status: 'REJECTED',
+          code: error && error.code ? error.code : 'UPDATE_REJECTED',
+        });
+
+      }
+
+      function isPlainObject(value) {
+
+        if (!value || typeof value !== 'object' || Array.isArray(value)) {
+          return false;
+        }
+        const prototype = Object.getPrototypeOf(value);
+        return prototype === Object.prototype || prototype === null;
+
+      }
+
+      function requireExactObject(value, fields, code) {
+
+        if (!isPlainObject(value)) {
+          throw updaterError(code);
+        }
+        const keys = Object.keys(value);
+        if (keys.length !== fields.length ||
+            keys.some((key) => !fields.includes(key))) {
+          throw updaterError(code);
+        }
+
+      }
+
+      function requireIdentifier(value, code) {
+
+        if (typeof value !== 'string' || !IDENTIFIER_PATTERN.test(value)) {
+          throw updaterError(code);
+        }
+        return value;
+
+      }
+
+      function copyBytes(value, code) {
+
+        let source;
+        if (value instanceof Uint8Array) {
+          source = value;
+        } else if (value instanceof ArrayBuffer) {
+          source = new Uint8Array(value);
+        } else {
+          throw updaterError(code);
+        }
+        const copy = new Uint8Array(source.byteLength);
+        copy.set(source);
+        return copy;
+
+      }
+
+      function decodeManifest(bytes) {
+
+        if (typeof TextDecoder !== 'function') {
+          throw updaterError('UTF8_DECODER_UNAVAILABLE');
+        }
+        if (bytes.byteLength >= 3 && bytes[0] === 0xef &&
+            bytes[1] === 0xbb && bytes[2] === 0xbf) {
+          throw updaterError('MANIFEST_UTF8_BOM_REJECTED');
+        }
+        let text;
+        try {
+          text = new TextDecoder('utf-8', {fatal: true}).decode(bytes);
+        } catch (_error) {
+          throw updaterError('INVALID_MANIFEST_UTF8');
+        }
+        try {
+          return JSON.parse(text);
+        } catch (_error) {
+          throw updaterError('MALFORMED_UPDATE_MANIFEST');
+        }
+
+      }
+
+      function validateArtifactPath(value) {
+
+        if (typeof value !== 'string' ||
+            !ARTIFACT_PATH_PATTERN.test(value) ||
+            value.startsWith('/') || value.includes('//') ||
+            value.split('/').some((part) => part === '.' || part === '..')) {
+          throw updaterError('INVALID_ARTIFACT_PATH');
+        }
+        return value;
+
+      }
+
+      function validateManifest(value, expectedProviderKey) {
+
+        requireExactObject(value, MANIFEST_FIELDS, 'INVALID_UPDATE_MANIFEST');
+        if (value.schemaVersion !== MANIFEST_SCHEMA_VERSION) {
+          throw updaterError('UNSUPPORTED_UPDATE_MANIFEST_SCHEMA');
+        }
+        const providerKey = requireIdentifier(
+            value.providerKey,
+            'INVALID_UPDATE_PROVIDER_KEY',
+        );
+        if (providerKey !== expectedProviderKey) {
+          throw updaterError('UPDATE_PROVIDER_KEY_MISMATCH');
+        }
+        const keyId = requireIdentifier(value.keyId, 'INVALID_UPDATE_KEY_ID');
+        if (!Number.isSafeInteger(value.sequence) || value.sequence < 1) {
+          throw updaterError('INVALID_AUTHENTICATED_SEQUENCE');
+        }
+        if (!isPlainObject(value.envelope) ||
+            value.envelope.providerKey !== providerKey) {
+          throw updaterError('UPDATE_ENVELOPE_PROVIDER_MISMATCH');
+        }
+        return Object.freeze({
+          schemaVersion: MANIFEST_SCHEMA_VERSION,
+          providerKey,
+          sequence: value.sequence,
+          keyId,
+          artifactPath: validateArtifactPath(value.artifactPath),
+          envelope: value.envelope,
+        });
+
+      }
+
+      function validateHttpsUrl(value, code) {
+
+        let url;
+        try {
+          url = new URL(value);
+        } catch (_error) {
+          throw updaterError(code);
+        }
+        if (url.protocol !== 'https:' || url.username || url.password ||
+            url.hash || url.search) {
+          throw updaterError(code);
+        }
+        return url;
+
+      }
+
+      function sameOriginUrl(value, origin, code) {
+
+        const url = validateHttpsUrl(value, code);
+        if (url.origin !== origin) {
+          throw updaterError(code);
+        }
+        return url;
+
+      }
+
+      async function readBoundedResponse(response, maximumBytes, sizeCode) {
+
+        const lengthValue = response.headers &&
+          typeof response.headers.get === 'function' ?
+          response.headers.get('content-length') : null;
+        if (lengthValue !== null) {
+          const declared = Number(lengthValue);
+          if (!Number.isSafeInteger(declared) || declared < 0 ||
+              declared > maximumBytes) {
+            throw updaterError(sizeCode);
+          }
+        }
+        if (!response.body || typeof response.body.getReader !== 'function') {
+          throw updaterError('STREAMING_RESPONSE_REQUIRED');
+        }
+        const reader = response.body.getReader();
+        const chunks = [];
+        let total = 0;
+        while (true) {
+          const part = await reader.read();
+          if (part.done) {
+            break;
+          }
+          const chunk = copyBytes(part.value, 'INVALID_RESPONSE_BYTES');
+          total += chunk.byteLength;
+          if (total > maximumBytes) {
+            try {
+              await reader.cancel();
+            } catch (_error) {
+              // The size rejection remains authoritative if cancellation fails.
+            }
+            throw updaterError(sizeCode);
+          }
+          chunks.push(chunk);
+        }
+        const bytes = new Uint8Array(total);
+        let offset = 0;
+        chunks.forEach((chunk) => {
+          bytes.set(chunk, offset);
+          offset += chunk.byteLength;
+        });
+        return bytes;
+
+      }
+
+      function createUpdater(options = {}) {
+
+        const fetchImpl = options.fetchImpl;
+        const cryptoSubtle = options.cryptoSubtle;
+        const trustedPublicKeys = options.trustedPublicKeys;
+        const store = options.store;
+        const sha256 = options.sha256;
+        const AbortControllerImpl = options.AbortController ||
+          root.AbortController;
+        const deadlineMs = options.deadlineMs === undefined ?
+          DEFAULT_DEADLINE_MS : options.deadlineMs;
+        if (typeof fetchImpl !== 'function') {
+          throw updaterError('FETCH_IMPLEMENTATION_REQUIRED');
+        }
+        if (!cryptoSubtle || typeof cryptoSubtle.importKey !== 'function' ||
+            typeof cryptoSubtle.verify !== 'function') {
+          throw updaterError('ED25519_WEBCRYPTO_REQUIRED');
+        }
+        if (!(trustedPublicKeys instanceof Map)) {
+          throw updaterError('TRUSTED_PUBLIC_KEYS_REQUIRED');
+        }
+        if (!store || typeof store.stageAuthenticatedCandidate !== 'function') {
+          throw updaterError('DATASET_STORE_REQUIRED');
+        }
+        if (typeof sha256 !== 'function') {
+          throw updaterError('SHA256_IMPLEMENTATION_REQUIRED');
+        }
+        if (typeof AbortControllerImpl !== 'function' ||
+            !Number.isSafeInteger(deadlineMs) || deadlineMs < 1 ||
+            deadlineMs > 120000) {
+          throw updaterError('INVALID_UPDATE_DEADLINE');
+        }
+
+        async function fetchBounded(initialUrl, origin, maximumBytes,
+            sizeCode, signal) {
+
+          let current = sameOriginUrl(initialUrl, origin, 'UNSAFE_UPDATE_URL');
+          for (let redirects = 0; redirects <= MAX_REDIRECTS; redirects += 1) {
+            let response;
+            try {
+              response = await fetchImpl.call(null, current.href, {
+                cache: 'no-store',
+                credentials: 'omit',
+                method: 'GET',
+                redirect: 'manual',
+                referrerPolicy: 'no-referrer',
+                signal,
+              });
+            } catch (error) {
+              if (signal.aborted) {
+                throw updaterError('UPDATE_TIMEOUT');
+              }
+              throw updaterError('UPDATE_FETCH_FAILED');
+            }
+            if (!response || !Number.isInteger(response.status)) {
+              throw updaterError('INVALID_UPDATE_RESPONSE');
+            }
+            if (REDIRECT_STATUSES.includes(response.status)) {
+              if (redirects === MAX_REDIRECTS) {
+                throw updaterError('TOO_MANY_UPDATE_REDIRECTS');
+              }
+              const location = response.headers &&
+                typeof response.headers.get === 'function' ?
+                response.headers.get('location') : null;
+              if (!location) {
+                throw updaterError('UNREADABLE_UPDATE_REDIRECT');
+              }
+              let redirected;
+              try {
+                redirected = new URL(location, current);
+              } catch (_error) {
+                throw updaterError('UNSAFE_UPDATE_REDIRECT');
+              }
+              current = sameOriginUrl(
+                  redirected.href,
+                  origin,
+                  'UNSAFE_UPDATE_REDIRECT',
+              );
+              continue;
+            }
+            if (response.status !== 200 || response.redirected === true) {
+              throw updaterError('UPDATE_HTTP_STATUS_REJECTED');
+            }
+            if (response.url) {
+              const reported = sameOriginUrl(
+                  response.url,
+                  origin,
+                  'UNSAFE_FINAL_UPDATE_URL',
+              );
+              if (reported.href !== current.href) {
+                throw updaterError('UNEXPECTED_UPDATE_REDIRECT');
+              }
+            }
+            return Object.freeze({
+              bytes: await readBoundedResponse(
+                  response,
+                  maximumBytes,
+                  sizeCode,
+              ),
+              finalUrl: current,
+            });
+          }
+          throw updaterError('TOO_MANY_UPDATE_REDIRECTS');
+
+        }
+
+        async function verifyManifestSignature(manifestBytes, signatureBytes,
+            keyId) {
+
+          const rawKey = trustedPublicKeys.get(keyId);
+          if (!(rawKey instanceof Uint8Array) || rawKey.byteLength !== 32) {
+            throw updaterError('UNKNOWN_UPDATE_KEY_ID');
+          }
+          let publicKey;
+          try {
+            publicKey = await cryptoSubtle.importKey(
+                'raw',
+                copyBytes(rawKey, 'INVALID_UPDATE_PUBLIC_KEY'),
+                {name: 'Ed25519'},
+                false,
+                ['verify'],
+            );
+          } catch (_error) {
+            throw updaterError('ED25519_UNAVAILABLE');
+          }
+          let valid;
+          try {
+            valid = await cryptoSubtle.verify(
+                {name: 'Ed25519'},
+                publicKey,
+                signatureBytes,
+                manifestBytes,
+            );
+          } catch (_error) {
+            throw updaterError('ED25519_VERIFICATION_FAILED');
+          }
+          if (valid !== true) {
+            throw updaterError('INVALID_UPDATE_SIGNATURE');
+          }
+
+        }
+
+        async function runUpdate({manifestUrl, providerKey} = {}, signal) {
+
+          const expectedProviderKey = requireIdentifier(
+              providerKey,
+              'INVALID_UPDATE_PROVIDER_KEY',
+          );
+          const initialManifestUrl = validateHttpsUrl(
+              manifestUrl,
+              'UNSAFE_MANIFEST_URL',
+          );
+          const origin = initialManifestUrl.origin;
+          const manifestResponse = await fetchBounded(
+              initialManifestUrl.href,
+              origin,
+              MAX_MANIFEST_BYTES,
+              'UPDATE_MANIFEST_TOO_LARGE',
+              signal,
+          );
+          const untrustedManifest = decodeManifest(manifestResponse.bytes);
+          const untrustedKeyId = requireIdentifier(
+              untrustedManifest && untrustedManifest.keyId,
+              'INVALID_UPDATE_KEY_ID',
+          );
+          const signatureUrl = new URL(manifestResponse.finalUrl.href);
+          signatureUrl.pathname += '.sig';
+          const signatureResponse = await fetchBounded(
+              signatureUrl.href,
+              origin,
+              MAX_SIGNATURE_BYTES,
+              'INVALID_UPDATE_SIGNATURE_SIZE',
+              signal,
+          );
+          if (signatureResponse.bytes.byteLength !== MAX_SIGNATURE_BYTES) {
+            throw updaterError('INVALID_UPDATE_SIGNATURE_SIZE');
+          }
+          await verifyManifestSignature(
+              manifestResponse.bytes,
+              signatureResponse.bytes,
+              untrustedKeyId,
+          );
+          const manifest = validateManifest(
+              untrustedManifest,
+              expectedProviderKey,
+          );
+          if (manifest.keyId !== untrustedKeyId) {
+            throw updaterError('UPDATE_KEY_ID_MISMATCH');
+          }
+          const artifactUrl = new URL(
+              manifest.artifactPath,
+              manifestResponse.finalUrl,
+          );
+          sameOriginUrl(
+              artifactUrl.href,
+              origin,
+              'UNSAFE_ARTIFACT_URL',
+          );
+          const artifactResponse = await fetchBounded(
+              artifactUrl.href,
+              origin,
+              Dataset.LIMITS.MAX_ARTIFACT_BYTES,
+              'ARTIFACT_TOO_LARGE',
+              signal,
+          );
+          const verification = await Dataset.verifyProviderDataset({
+            envelope: manifest.envelope,
+            artifactBytes: artifactResponse.bytes,
+            sha256,
+            trust: Dataset.TRUST.REMOTE_AUTHENTICATED,
+          });
+          if (!verification.ok || verification.activationEligible !== true ||
+              verification.dataset.identity.providerKey !==
+                expectedProviderKey) {
+            throw updaterError(
+                verification.code || 'REMOTE_DATASET_VERIFICATION_FAILED',
+            );
+          }
+          return store.stageAuthenticatedCandidate({
+            envelope: manifest.envelope,
+            artifactBytes: artifactResponse.bytes,
+            sequence: manifest.sequence,
+          });
+
+        }
+
+        async function fetchAndStage(input) {
+
+          const controller = new AbortControllerImpl();
+          let timer = null;
+          try {
+            return await Promise.race([
+              runUpdate(input, controller.signal),
+              new Promise((_resolve, reject) => {
+                timer = root.setTimeout(() => {
+                  controller.abort();
+                  reject(updaterError('UPDATE_TIMEOUT'));
+                }, deadlineMs);
+              }),
+            ]);
+          } catch (error) {
+            return rejection(error);
+          } finally {
+            if (timer !== null) {
+              root.clearTimeout(timer);
+            }
+          }
+
+        }
+
+        return Object.freeze({fetchAndStage});
+
+      }
+
+      return Object.freeze({
+        DEFAULT_DEADLINE_MS,
+        MANIFEST_SCHEMA_VERSION,
+        MAX_MANIFEST_BYTES,
+        MAX_REDIRECTS,
+        MAX_SIGNATURE_BYTES,
+        createUpdater,
+        validateManifest,
+      });
+
+    });

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/manifest.json
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/manifest.json
@@ -20,6 +20,7 @@
       "background/off-state.js",
       "background/proxy-control.js",
       "background/dataset-store.js",
+      "background/provider-updater.js",
       "background/provider-lookup.js",
       "background/dataset-runtime.js",
       "background/routing-adapter.js",

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/dataset-test-helpers.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/dataset-test-helpers.js
@@ -90,10 +90,12 @@ function memoryBackend() {
     },
     async commit(nextArtifact, nextPointers) {
 
-      artifacts.set(nextArtifact.artifactSha256, copy(nextArtifact));
+      if (nextArtifact) {
+        artifacts.set(nextArtifact.artifactSha256, copy(nextArtifact));
+      }
       pointers.set(nextPointers.providerKey, copy(nextPointers));
       commits.push({
-        artifactSha256: nextArtifact.artifactSha256,
+        artifactSha256: nextArtifact ? nextArtifact.artifactSha256 : null,
         pointers: copy(nextPointers),
       });
 

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/provider-updater.test.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/provider-updater.test.js
@@ -1,0 +1,672 @@
+'use strict';
+
+const Assert = require('node:assert');
+const Crypto = require('node:crypto');
+const Updater = require('../background/provider-updater');
+const Store = require('../background/dataset-store');
+const {
+  Dataset,
+  PROVIDER_KEY,
+  artifact,
+  memoryBackend,
+  payload,
+  sha256,
+} = require('./dataset-test-helpers');
+
+const MANIFEST_URL = 'https://updates.example/releases/manifest.json';
+const SIGNATURE_URL = `${MANIFEST_URL}.sig`;
+const ARTIFACT_URL = 'https://updates.example/releases/v2.json';
+const KEY_ID = 'synthetic-key-1';
+
+function updateArtifact(version, host = 'next.example') {
+
+  return artifact({
+    datasetVersion: version,
+    payload: payload([{
+      width: host.length,
+      routeRef: 'PROVIDER_PROXY',
+      hosts: host,
+    }]),
+    trust: Dataset.TRUST.REMOTE_AUTHENTICATED,
+  });
+
+}
+
+function stream(bytes, chunkSize = bytes.byteLength || 1) {
+
+  let offset = 0;
+  return {
+    getReader() {
+
+      return {
+        async cancel() {},
+        async read() {
+
+          if (offset >= bytes.byteLength) {
+            return {done: true};
+          }
+          const end = Math.min(bytes.byteLength, offset + chunkSize);
+          const value = bytes.slice(offset, end);
+          offset = end;
+          return {done: false, value};
+
+        },
+      };
+
+    },
+  };
+
+}
+
+function response(url, bytes, options = {}) {
+
+  const headers = new Map(Object.entries(options.headers || {}).map(
+      ([key, value]) => [key.toLowerCase(), String(value)],
+  ));
+  return {
+    status: options.status === undefined ? 200 : options.status,
+    redirected: options.redirected === true,
+    url: options.reportedUrl === undefined ? url : options.reportedUrl,
+    headers: {get: (name) => headers.get(name.toLowerCase()) || null},
+    body: stream(bytes || new Uint8Array(), options.chunkSize),
+  };
+
+}
+
+function fakeNetwork(routes) {
+
+  const calls = [];
+  return {
+    calls,
+    async fetch(url, options) {
+
+      calls.push({url, options});
+      const route = routes.get(url);
+      if (typeof route === 'function') {
+        return route(url, options);
+      }
+      if (!route) {
+        throw new Error('unexpected synthetic URL');
+      }
+      return response(url, route.bytes, route);
+
+    },
+  };
+
+}
+
+function pointersSnapshot(backend) {
+
+  return structuredClone(backend.pointers.get(PROVIDER_KEY));
+
+}
+
+describe('Firefox authenticated provider update pipeline', function() {
+
+  let keyPair;
+  let publicKeyBytes;
+
+  before(async function() {
+
+    keyPair = await Crypto.webcrypto.subtle.generateKey(
+        {name: 'Ed25519'},
+        true,
+        ['sign', 'verify'],
+    );
+    publicKeyBytes = new Uint8Array(await Crypto.webcrypto.subtle.exportKey(
+        'raw',
+        keyPair.publicKey,
+    ));
+
+  });
+
+  async function bundle(options = {}) {
+
+    const candidate = options.candidate || updateArtifact(
+        '2026.09.06-test.2',
+    );
+    const manifest = Object.assign({
+      schemaVersion: Updater.MANIFEST_SCHEMA_VERSION,
+      providerKey: PROVIDER_KEY,
+      sequence: options.sequence || 2,
+      keyId: options.keyId || KEY_ID,
+      artifactPath: 'v2.json',
+      envelope: candidate.envelope,
+    }, options.manifestOverrides);
+    const manifestBytes = new TextEncoder().encode(JSON.stringify(manifest));
+    const signatureBytes = new Uint8Array(await Crypto.webcrypto.subtle.sign(
+        {name: 'Ed25519'},
+        options.privateKey || keyPair.privateKey,
+        manifestBytes,
+    ));
+    return {candidate, manifest, manifestBytes, signatureBytes};
+
+  }
+
+  async function setup(options = {}) {
+
+    const backend = options.backend || memoryBackend();
+    const store = Store.createStore({backend, sha256});
+    if (options.seed !== false) {
+      await store.activateCandidate(updateArtifact(
+          '2026.09.06-test.0',
+          'zero.example',
+      ));
+      await store.activateCandidate(updateArtifact(
+          '2026.09.06-test.1',
+          'beta.example',
+      ));
+    }
+    const signed = options.signed || await bundle(options);
+    const routes = options.routes || new Map([
+      [MANIFEST_URL, {bytes: signed.manifestBytes}],
+      [SIGNATURE_URL, {bytes: signed.signatureBytes}],
+      [ARTIFACT_URL, {bytes: signed.candidate.artifactBytes, chunkSize: 7}],
+    ]);
+    const network = fakeNetwork(routes);
+    const updater = Updater.createUpdater({
+      AbortController,
+      cryptoSubtle: Crypto.webcrypto.subtle,
+      deadlineMs: options.deadlineMs || 1000,
+      fetchImpl: network.fetch,
+      sha256,
+      store,
+      trustedPublicKeys: options.trustedPublicKeys ||
+        new Map([[KEY_ID, publicKeyBytes]]),
+    });
+    return {backend, network, signed, store, updater};
+
+  }
+
+  async function fetchAndStage(context, input = {}) {
+
+    return context.updater.fetchAndStage(Object.assign({
+      manifestUrl: MANIFEST_URL,
+      providerKey: PROVIDER_KEY,
+    }, input));
+
+  }
+
+  it('verifies exact signed bytes and stages without changing active or LKG',
+      async function() {
+
+        const context = await setup();
+        const before = pointersSnapshot(context.backend);
+        const result = await fetchAndStage(context);
+        const after = pointersSnapshot(context.backend);
+
+        Assert.strictEqual(result.ok, true);
+        Assert.strictEqual(result.status, 'STAGED');
+        Assert.strictEqual(after.activeArtifactSha256,
+            before.activeArtifactSha256);
+        Assert.strictEqual(after.previousLkgArtifactSha256,
+            before.previousLkgArtifactSha256);
+        Assert.strictEqual(after.stagedArtifactSha256,
+            context.signed.candidate.envelope.artifactSha256);
+        Assert.strictEqual(after.highestAuthenticatedSequence, 2);
+        Assert.strictEqual(
+            context.signed.manifest.trust,
+            undefined,
+        );
+        Assert.deepStrictEqual(context.network.calls.map((call) => call.url), [
+          MANIFEST_URL,
+          SIGNATURE_URL,
+          ARTIFACT_URL,
+        ]);
+        context.network.calls.forEach((call) => {
+          Assert.strictEqual(call.options.redirect, 'manual');
+          Assert.strictEqual(call.options.credentials, 'omit');
+          Assert.strictEqual(call.options.referrerPolicy, 'no-referrer');
+        });
+
+      });
+
+  it('promotes staged data atomically and rotates active into LKG',
+      async function() {
+
+        const context = await setup();
+        const before = pointersSnapshot(context.backend);
+        await fetchAndStage(context);
+        const result = await context.store.promoteStaged(PROVIDER_KEY);
+        const after = pointersSnapshot(context.backend);
+
+        Assert.strictEqual(result.status, 'PROMOTED');
+        Assert.strictEqual(after.activeArtifactSha256,
+            context.signed.candidate.envelope.artifactSha256);
+        Assert.strictEqual(after.previousLkgArtifactSha256,
+            before.activeArtifactSha256);
+        Assert.strictEqual(after.stagedArtifactSha256, null);
+        Assert.strictEqual(after.stagedSequence, null);
+        Assert.strictEqual(after.highestAuthenticatedSequence, 2);
+        Assert.strictEqual(
+            context.backend.commits.at(-1).artifactSha256,
+            null,
+        );
+
+      });
+
+  it('migrates v1 pointers without losing active, LKG, or baseline',
+      function() {
+
+        const legacy = {
+          schemaVersion: 1,
+          providerKey: PROVIDER_KEY,
+          activeArtifactSha256: 'a'.repeat(64),
+          previousLkgArtifactSha256: 'b'.repeat(64),
+          packagedBaselineArtifactSha256: 'c'.repeat(64),
+        };
+        const normalized = Store.normalizePointers(legacy, PROVIDER_KEY);
+
+        Assert.strictEqual(normalized.migratedFromSchemaVersion, 1);
+        Assert.deepStrictEqual(normalized.pointers, {
+          schemaVersion: 2,
+          providerKey: PROVIDER_KEY,
+          activeArtifactSha256: 'a'.repeat(64),
+          previousLkgArtifactSha256: 'b'.repeat(64),
+          packagedBaselineArtifactSha256: 'c'.repeat(64),
+          stagedArtifactSha256: null,
+          stagedSequence: null,
+          highestAuthenticatedSequence: null,
+          highestAuthenticatedArtifactSha256: null,
+        });
+
+      });
+
+  async function rejectedWithoutPointerChanges(mutator, expectedCode) {
+
+    const context = await setup();
+    const before = pointersSnapshot(context.backend);
+    await mutator(context);
+    const result = await fetchAndStage(context);
+
+    Assert.strictEqual(result.ok, false);
+    Assert.strictEqual(result.code, expectedCode);
+    Assert.deepStrictEqual(pointersSnapshot(context.backend), before);
+
+  }
+
+  it('rejects a bad detached signature', async function() {
+
+    await rejectedWithoutPointerChanges((context) => {
+      context.signed.signatureBytes.fill(0);
+    }, 'INVALID_UPDATE_SIGNATURE');
+
+  });
+
+  it('rejects an unknown keyId without trusting manifest content',
+      async function() {
+
+        const signed = await bundle({keyId: 'unknown-key'});
+        const context = await setup({signed});
+        const before = pointersSnapshot(context.backend);
+        const result = await fetchAndStage(context);
+
+        Assert.strictEqual(result.code, 'UNKNOWN_UPDATE_KEY_ID');
+        Assert.deepStrictEqual(pointersSnapshot(context.backend), before);
+
+      });
+
+  it('rejects any manifest-byte modification after signing', async function() {
+
+    const signed = await bundle();
+    signed.manifestBytes = new TextEncoder().encode(
+        `${new TextDecoder().decode(signed.manifestBytes)} `,
+    );
+    const context = await setup({signed});
+    const before = pointersSnapshot(context.backend);
+    const result = await fetchAndStage(context);
+
+    Assert.strictEqual(result.code, 'INVALID_UPDATE_SIGNATURE');
+    Assert.deepStrictEqual(pointersSnapshot(context.backend), before);
+
+  });
+
+  it('rejects a modified artifact', async function() {
+
+    await rejectedWithoutPointerChanges((context) => {
+      context.signed.candidate.artifactBytes[0] ^= 1;
+    }, 'ARTIFACT_SHA256_MISMATCH');
+
+  });
+
+  it('rejects a signed wrong artifact byte count', async function() {
+
+    const base = updateArtifact('wrong-count', 'count.example');
+    const signed = await bundle({candidate: base, manifestOverrides: {
+      envelope: Object.assign({}, base.envelope, {
+        artifactByteCount: base.envelope.artifactByteCount + 1,
+      }),
+    }});
+    const context = await setup({signed});
+    const before = pointersSnapshot(context.backend);
+    const result = await fetchAndStage(context);
+
+    Assert.strictEqual(result.code, 'ARTIFACT_BYTE_COUNT_MISMATCH');
+    Assert.deepStrictEqual(pointersSnapshot(context.backend), before);
+
+  });
+
+  it('rejects provider identity mismatch at the signed manifest boundary',
+      async function() {
+
+        const signed = await bundle({manifestOverrides: {
+          providerKey: 'different-provider',
+        }});
+        const context = await setup({signed});
+        const before = pointersSnapshot(context.backend);
+        const result = await fetchAndStage(context);
+
+        Assert.strictEqual(result.code, 'UPDATE_PROVIDER_KEY_MISMATCH');
+        Assert.deepStrictEqual(pointersSnapshot(context.backend), before);
+
+      });
+
+  it('rejects signed envelope/provider disagreement', async function() {
+
+    const candidate = updateArtifact('wrong-provider', 'wrong.example');
+    const signed = await bundle({candidate, manifestOverrides: {
+      envelope: Object.assign({}, candidate.envelope, {
+        providerKey: 'different-provider',
+      }),
+    }});
+    const context = await setup({signed});
+    const before = pointersSnapshot(context.backend);
+    const result = await fetchAndStage(context);
+
+    Assert.strictEqual(result.code, 'UPDATE_ENVELOPE_PROVIDER_MISMATCH');
+    Assert.deepStrictEqual(pointersSnapshot(context.backend), before);
+
+  });
+
+  it('rejects a signed dataset with an unsupported schema', async function() {
+
+    const candidate = updateArtifact('bad-schema', 'schema.example');
+    const signed = await bundle({candidate, manifestOverrides: {
+      envelope: Object.assign({}, candidate.envelope, {schemaVersion: 2}),
+    }});
+    const context = await setup({signed});
+    const before = pointersSnapshot(context.backend);
+    const result = await fetchAndStage(context);
+
+    Assert.strictEqual(result.code, 'UNSUPPORTED_SCHEMA_VERSION');
+    Assert.deepStrictEqual(pointersSnapshot(context.backend), before);
+
+  });
+
+  it('rejects oversized streamed artifacts before storage', async function() {
+
+    const context = await setup();
+    context.signed.candidate.artifactBytes = new Uint8Array(1);
+    const route = new Map([
+      [MANIFEST_URL, {bytes: context.signed.manifestBytes}],
+      [SIGNATURE_URL, {bytes: context.signed.signatureBytes}],
+      [ARTIFACT_URL, {
+        bytes: new Uint8Array(1),
+        headers: {'content-length': Dataset.LIMITS.MAX_ARTIFACT_BYTES + 1},
+      }],
+    ]);
+    context.network = fakeNetwork(route);
+    context.updater = Updater.createUpdater({
+      AbortController,
+      cryptoSubtle: Crypto.webcrypto.subtle,
+      fetchImpl: context.network.fetch,
+      sha256,
+      store: context.store,
+      trustedPublicKeys: new Map([[KEY_ID, publicKeyBytes]]),
+    });
+    const before = pointersSnapshot(context.backend);
+    const result = await fetchAndStage(context);
+
+    Assert.strictEqual(result.code, 'ARTIFACT_TOO_LARGE');
+    Assert.deepStrictEqual(pointersSnapshot(context.backend), before);
+
+  });
+
+  for (const [name, location] of [
+    ['HTTP', 'http://updates.example/elsewhere'],
+    ['cross-origin', 'https://other.example/elsewhere'],
+  ]) {
+    it(`rejects a ${name} redirect`, async function() {
+
+      const context = await setup();
+      const routes = new Map([
+        [MANIFEST_URL, {
+          status: 302,
+          headers: {location},
+          bytes: new Uint8Array(),
+        }],
+      ]);
+      context.network = fakeNetwork(routes);
+      context.updater = Updater.createUpdater({
+        AbortController,
+        cryptoSubtle: Crypto.webcrypto.subtle,
+        fetchImpl: context.network.fetch,
+        sha256,
+        store: context.store,
+        trustedPublicKeys: new Map([[KEY_ID, publicKeyBytes]]),
+      });
+      const before = pointersSnapshot(context.backend);
+      const result = await fetchAndStage(context);
+
+      Assert.strictEqual(result.code, 'UNSAFE_UPDATE_REDIRECT');
+      Assert.deepStrictEqual(pointersSnapshot(context.backend), before);
+
+    });
+  }
+
+  it('rejects more than three same-origin redirects', async function() {
+
+    const context = await setup();
+    const routes = new Map();
+    let current = MANIFEST_URL;
+    for (let index = 1; index <= 4; index += 1) {
+      const next = `https://updates.example/releases/redirect-${index}.json`;
+      routes.set(current, {
+        status: 302,
+        headers: {location: next},
+        bytes: new Uint8Array(),
+      });
+      current = next;
+    }
+    context.network = fakeNetwork(routes);
+    context.updater = Updater.createUpdater({
+      AbortController,
+      cryptoSubtle: Crypto.webcrypto.subtle,
+      fetchImpl: context.network.fetch,
+      sha256,
+      store: context.store,
+      trustedPublicKeys: new Map([[KEY_ID, publicKeyBytes]]),
+    });
+    const before = pointersSnapshot(context.backend);
+    const result = await fetchAndStage(context);
+
+    Assert.strictEqual(result.code, 'TOO_MANY_UPDATE_REDIRECTS');
+    Assert.strictEqual(context.network.calls.length, 4);
+    Assert.deepStrictEqual(pointersSnapshot(context.backend), before);
+
+  });
+
+  it('rejects manifest URLs containing credentials before fetching',
+      async function() {
+
+        const context = await setup();
+        const before = pointersSnapshot(context.backend);
+        const result = await fetchAndStage(context, {
+          manifestUrl: 'https://user:secret@updates.example/manifest.json',
+        });
+
+        Assert.strictEqual(result.code, 'UNSAFE_MANIFEST_URL');
+        Assert.strictEqual(context.network.calls.length, 0);
+        Assert.deepStrictEqual(pointersSnapshot(context.backend), before);
+
+      });
+
+  it('rejects malformed UTF-8 manifest bytes before any trust assignment',
+      async function() {
+
+        const context = await setup();
+        const routes = new Map([
+          [MANIFEST_URL, {bytes: new Uint8Array([0xc3, 0x28])}],
+        ]);
+        context.network = fakeNetwork(routes);
+        context.updater = Updater.createUpdater({
+          AbortController,
+          cryptoSubtle: Crypto.webcrypto.subtle,
+          fetchImpl: context.network.fetch,
+          sha256,
+          store: context.store,
+          trustedPublicKeys: new Map([[KEY_ID, publicKeyBytes]]),
+        });
+        const before = pointersSnapshot(context.backend);
+        const result = await fetchAndStage(context);
+
+        Assert.strictEqual(result.code, 'INVALID_MANIFEST_UTF8');
+        Assert.deepStrictEqual(pointersSnapshot(context.backend), before);
+
+      });
+
+  it('aborts and rejects a request at the configured deadline',
+      async function() {
+
+        const context = await setup({deadlineMs: 5});
+        context.updater = Updater.createUpdater({
+          AbortController,
+          cryptoSubtle: Crypto.webcrypto.subtle,
+          deadlineMs: 5,
+          fetchImpl: () => new Promise(() => {}),
+          sha256,
+          store: context.store,
+          trustedPublicKeys: new Map([[KEY_ID, publicKeyBytes]]),
+        });
+        const before = pointersSnapshot(context.backend);
+        const result = await fetchAndStage(context);
+
+        Assert.strictEqual(result.code, 'UPDATE_TIMEOUT');
+        Assert.deepStrictEqual(pointersSnapshot(context.backend), before);
+
+      });
+
+  it('rejects lower authenticated sequence without replacing staged data',
+      async function() {
+
+        const context = await setup();
+        const higher = updateArtifact('higher', 'higher.example');
+        await context.store.stageAuthenticatedCandidate({
+          envelope: higher.envelope,
+          artifactBytes: higher.artifactBytes,
+          sequence: 5,
+        });
+        const before = pointersSnapshot(context.backend);
+        const result = await fetchAndStage(context);
+
+        Assert.strictEqual(result.code, 'ROLLBACK_REJECTED');
+        Assert.deepStrictEqual(pointersSnapshot(context.backend), before);
+
+      });
+
+  it('treats the same sequence and artifact as idempotent', async function() {
+
+    const context = await setup();
+    const first = await fetchAndStage(context);
+    const commitCount = context.backend.commits.length;
+    const second = await fetchAndStage(context);
+
+    Assert.strictEqual(first.status, 'STAGED');
+    Assert.strictEqual(second.status, 'UNCHANGED');
+    Assert.strictEqual(context.backend.commits.length, commitCount);
+
+  });
+
+  it('rejects the same sequence with a different artifact', async function() {
+
+    const context = await setup();
+    const other = updateArtifact('other', 'other.example');
+    await context.store.stageAuthenticatedCandidate({
+      envelope: other.envelope,
+      artifactBytes: other.artifactBytes,
+      sequence: 2,
+    });
+    const before = pointersSnapshot(context.backend);
+    const result = await fetchAndStage(context);
+
+    Assert.strictEqual(result.code, 'SEQUENCE_CONFLICT');
+    Assert.deepStrictEqual(pointersSnapshot(context.backend), before);
+
+  });
+
+  it('serializes concurrent pointer mutations against rollback races',
+      async function() {
+
+        const backend = memoryBackend();
+        const originalCommit = backend.commit;
+        backend.commit = async (nextArtifact, nextPointers) => {
+          if (nextPointers.highestAuthenticatedSequence === 2) {
+            await new Promise((resolve) => setTimeout(resolve, 20));
+          }
+          return originalCommit(nextArtifact, nextPointers);
+        };
+        const store = Store.createStore({backend, sha256});
+        const sequenceTwo = updateArtifact('sequence-two', 'two.example');
+        const sequenceThree = updateArtifact(
+            'sequence-three',
+            'three.example',
+        );
+        const [first, second] = await Promise.all([
+          store.stageAuthenticatedCandidate({
+            envelope: sequenceTwo.envelope,
+            artifactBytes: sequenceTwo.artifactBytes,
+            sequence: 2,
+          }),
+          store.stageAuthenticatedCandidate({
+            envelope: sequenceThree.envelope,
+            artifactBytes: sequenceThree.artifactBytes,
+            sequence: 3,
+          }),
+        ]);
+        const pointers = pointersSnapshot(backend);
+
+        Assert.strictEqual(first.status, 'STAGED');
+        Assert.strictEqual(second.status, 'STAGED');
+        Assert.strictEqual(pointers.highestAuthenticatedSequence, 3);
+        Assert.strictEqual(
+            pointers.stagedArtifactSha256,
+            sequenceThree.envelope.artifactSha256,
+        );
+
+      });
+
+  it('does not advance pointers when the atomic store commit fails',
+      async function() {
+
+        const backend = memoryBackend();
+        const context = await setup({backend});
+        const before = pointersSnapshot(backend);
+        const originalCommit = backend.commit;
+        backend.commit = async () => {
+          const error = new Error('synthetic write failure');
+          error.code = 'INDEXED_DB_COMMIT_ABORTED';
+          throw error;
+        };
+        const result = await fetchAndStage(context);
+
+        Assert.strictEqual(result.code, 'INDEXED_DB_COMMIT_ABORTED');
+        Assert.deepStrictEqual(pointersSnapshot(backend), before);
+        backend.commit = originalCommit;
+
+      });
+
+  it('rejects remote trust claims as unknown manifest fields', async function() {
+
+    const signed = await bundle({manifestOverrides: {
+      trust: Dataset.TRUST.REMOTE_AUTHENTICATED,
+    }});
+    const context = await setup({signed});
+    const before = pointersSnapshot(context.backend);
+    const result = await fetchAndStage(context);
+
+    Assert.strictEqual(result.code, 'INVALID_UPDATE_MANIFEST');
+    Assert.deepStrictEqual(pointersSnapshot(context.backend), before);
+
+  });
+
+});

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/skeleton.test.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/skeleton.test.js
@@ -40,6 +40,10 @@ const datasetStoreSource = Fs.readFileSync(
     Path.join(sourceRoot, 'background', 'dataset-store.js'),
     'utf8',
 );
+const providerUpdaterSource = Fs.readFileSync(
+    Path.join(sourceRoot, 'background', 'provider-updater.js'),
+    'utf8',
+);
 const providerLookupSource = Fs.readFileSync(
     Path.join(sourceRoot, 'background', 'provider-lookup.js'),
     'utf8',
@@ -241,6 +245,9 @@ function startEventPage(options = {}) {
   Vm.runInContext(offStateSource, context, {filename: 'off-state.js'});
   Vm.runInContext(proxyControlSource, context, {filename: 'proxy-control.js'});
   Vm.runInContext(datasetStoreSource, context, {filename: 'dataset-store.js'});
+  Vm.runInContext(providerUpdaterSource, context, {
+    filename: 'provider-updater.js',
+  });
   Vm.runInContext(providerLookupSource, context, {
     filename: 'provider-lookup.js',
   });
@@ -296,6 +303,7 @@ describe('Firefox MV3 inert skeleton', function() {
         'background/off-state.js',
         'background/proxy-control.js',
         'background/dataset-store.js',
+        'background/provider-updater.js',
         'background/provider-lookup.js',
         'background/dataset-runtime.js',
         'background/routing-adapter.js',
@@ -661,6 +669,7 @@ describe('Firefox MV3 inert skeleton', function() {
           offStateSource,
           proxyControlSource,
           datasetStoreSource,
+          providerUpdaterSource,
           providerLookupSource,
           datasetRuntimeSource,
           routingAdapterSource,
@@ -682,6 +691,8 @@ describe('Firefox MV3 inert skeleton', function() {
             false,
         );
         Assert.strictEqual(eventPageSource.includes('activatePrepared('), false);
+        Assert.strictEqual(eventPageSource.includes('fetchAndStage'), false);
+        Assert.strictEqual(eventPageSource.includes('promoteStaged'), false);
         Assert.strictEqual(eventPageSource.includes('recoveryFactory:'), false);
         Assert.strictEqual(eventPageSource.includes('proxy.settings.set'), false);
 

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/verify-package.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/verify-package.js
@@ -14,6 +14,7 @@ const EXPECTED_FILES = Object.freeze([
   'background/event-page.js',
   'background/off-state.js',
   'background/provider-lookup.js',
+  'background/provider-updater.js',
   'background/proxy-auth.js',
   'background/proxy-control.js',
   'background/routing-adapter.js',
@@ -92,6 +93,7 @@ function verifyPackage(packageRoot, sourceRoot) {
     'background/off-state.js',
     'background/proxy-control.js',
     'background/dataset-store.js',
+    'background/provider-updater.js',
     'background/provider-lookup.js',
     'background/dataset-runtime.js',
     'background/routing-adapter.js',
@@ -116,6 +118,8 @@ function verifyPackage(packageRoot, sourceRoot) {
   Assert.strictEqual(eventPageText.includes('proxy.settings.set'), false);
   Assert.strictEqual(eventPageText.includes('acquirePrevalidatedFloor('), false);
   Assert.strictEqual(eventPageText.includes('activatePrepared('), false);
+  Assert.strictEqual(eventPageText.includes('fetchAndStage'), false);
+  Assert.strictEqual(eventPageText.includes('promoteStaged'), false);
   Assert.strictEqual(
       eventPageText.includes('type === \'firefox.activation.apply\''),
       true,


### PR DESCRIPTION
## Summary

- add a strict signed provider-update manifest and detached Ed25519 verification over the exact UTF-8 manifest bytes
- enforce HTTPS, credential-free URLs, at most three same-origin HTTPS redirects, bounded streamed bodies, and a 15-second default deadline
- assign `REMOTE_AUTHENTICATED` only after signature, manifest, provider identity, byte count, SHA-256, and declarative dataset verification succeed
- migrate Firefox provider pointers from schema v1 to v2 with staged candidate and per-provider authenticated sequence metadata
- stage verified updates without changing active/LKG/live session/durable ON; provide an explicit atomic promotion primitive
- serialize pointer mutations to prevent concurrent anti-rollback races

## Security and production boundary

This PR contains synthetic test data only. It ships no real Anticensority/provider dataset, production public key, production update URL, timer/alarm, startup fetch, update RPC, or automatic promotion. Remote JSON cannot declare trust. Downloaded bytes remain declarative `HOST_BUCKETS_V1` data and are never executed.

Production `firefox.activation.apply` remains `ACTIVATION_NOT_IMPLEMENTED`; the shipped Firefox package remains durable OFF.

## Validation

- supply-chain: 11/11
- PAC: 26/26
- Chromium MV3: 428/428
- Firefox deterministic: 191/191
- aggregate: 636/636
- Firefox package: 14 allowlisted files
- Chromium package: 70 vs 70 files; added 0; missing 0; SHA-256 differences 0
- dependencies and lockfiles: unchanged

Firefox 154.0.1 build 20260824154132 local-only browser smoke:
- native WebCrypto Ed25519 verification succeeded
- active v1 remained active while signed v2 was staged
- genuine idle event-page recreation produced a new boot ID and recovered active v1 with v2 still staged
- explicit promotion made v2 active and v1 previous LKG
- invalidly signed v3 was rejected without changing active/LKG
- external traffic: 0
- protected-origin contacts: 0

The localhost HTTPS certificate trust and Ed25519 keypair were synthetic and confined to the disposable profile/harness; neither is tracked or packaged.