### PR TITLE
Security alert cleanup

### DIFF
--- a/.github/workflows/mv3.yml
+++ b/.github/workflows/mv3.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Verify documentation integrity
         run: node ./scripts/verify-docs.mjs
 
+      - name: Test documentation parser safety
+        run: node --test ./scripts/verify-docs-parser.test.mjs
+
       - name: Verify supply-chain policy
         env:
           SUPPLY_CHAIN_BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || '' }}

--- a/extensions/chromium/runet-censorship-bypass/package-lock.json
+++ b/extensions/chromium/runet-censorship-bypass/package-lock.json
@@ -9,19 +9,19 @@
       "version": "0.0.19",
       "license": "GPLv3",
       "dependencies": {
-        "gulp": "^5.0.1",
-        "plugin-error": "^1.0.1",
-        "through2": "^4.0.2",
+        "gulp": "5.0.1",
+        "plugin-error": "1.0.1",
+        "through2": "4.0.2",
         "tldts": "7.4.8"
       },
       "devDependencies": {
-        "@eslint/js": "^10.0.1",
-        "chai": "^4.5.0",
-        "eslint": "^10.8.1",
-        "eslint-config-google": "^0.14.0",
-        "globals": "^17.11.0",
-        "mocha": "^11.8.0",
-        "puppeteer-core": "^25.8.0"
+        "@eslint/js": "10.0.1",
+        "chai": "4.5.0",
+        "eslint": "10.8.1",
+        "eslint-config-google": "0.14.0",
+        "globals": "17.11.0",
+        "mocha": "11.8.0",
+        "puppeteer-core": "25.8.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -2993,16 +2993,6 @@
         "node": ">=22.12.0"
       }
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/readable-stream": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
@@ -3160,13 +3150,13 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/shebang-command": {
@@ -5402,7 +5392,7 @@
         "minimatch": "^9.0.5",
         "ms": "^2.1.3",
         "picocolors": "^1.1.1",
-        "serialize-javascript": "^6.0.2",
+        "serialize-javascript": "7.0.5",
         "strip-json-comments": "^3.1.1",
         "supports-color": "^8.1.1",
         "workerpool": "^9.2.0",
@@ -5745,15 +5735,6 @@
         "ws": "^8.21.1"
       }
     },
-    "randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "readable-stream": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
@@ -5858,13 +5839,10 @@
       }
     },
     "serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
-      "dev": true,
-      "requires": {
-        "randombytes": "^2.1.0"
-      }
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
+      "dev": true
     },
     "shebang-command": {
       "version": "2.0.0",

--- a/extensions/chromium/runet-censorship-bypass/package.json
+++ b/extensions/chromium/runet-censorship-bypass/package.json
@@ -43,5 +43,10 @@
     "plugin-error": "1.0.1",
     "through2": "4.0.2",
     "tldts": "7.4.8"
+  },
+  "overrides": {
+    "mocha": {
+      "serialize-javascript": "7.0.5"
+    }
   }
 }

--- a/scripts/verify-docs-parser.mjs
+++ b/scripts/verify-docs-parser.mjs
@@ -1,0 +1,23 @@
+export const inlineMarkdownLinkPattern =
+  /(!?)\[[^\]\n]*\]\(\s*(?:<([^>\n]+)>|((?:\\.|[^()\\\s]|\([^()\n]*\))+))(?:\s+(?:"[^"]*"|'[^']*'|\([^)]*\)))?\s*\)/gu;
+
+export function stripHtmlTags(value) {
+  let result = '';
+  let insideTag = false;
+
+  for (const character of value) {
+    if (character === '<') {
+      insideTag = true;
+      continue;
+    }
+    if (insideTag) {
+      if (character === '>') {
+        insideTag = false;
+      }
+      continue;
+    }
+    result += character;
+  }
+
+  return result;
+}

--- a/scripts/verify-docs-parser.test.mjs
+++ b/scripts/verify-docs-parser.test.mjs
@@ -1,0 +1,28 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  inlineMarkdownLinkPattern,
+  stripHtmlTags,
+} from './verify-docs-parser.mjs';
+
+test('inline Markdown links retain supported escaping and nested parentheses', () => {
+  const source = String.raw`[one](docs/a\ file.md) [two](docs/(nested).md "title")`;
+  const matches = [...source.matchAll(inlineMarkdownLinkPattern)];
+
+  assert.deepEqual(matches.map((match) => match[2] ?? match[3]), [
+    String.raw`docs/a\ file.md`,
+    'docs/(nested).md',
+  ]);
+});
+
+test('inline Markdown link matching handles a long unmatched escape sequence', () => {
+  const source = `[label](${String.raw`\!`.repeat(20_000)}`;
+
+  assert.deepEqual([...source.matchAll(inlineMarkdownLinkPattern)], []);
+});
+
+test('HTML tag stripping cannot recreate a nested tag sequence', () => {
+  assert.equal(stripHtmlTags('<scr<script>ipt>alert</script>'), 'ipt>alert');
+  assert.equal(stripHtmlTags('before <em>inside</em> after'), 'before inside after');
+});

--- a/scripts/verify-docs.mjs
+++ b/scripts/verify-docs.mjs
@@ -5,6 +5,11 @@ import path from 'node:path';
 import { spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 
+import {
+  inlineMarkdownLinkPattern,
+  stripHtmlTags,
+} from './verify-docs-parser.mjs';
+
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const releaseMetadataPath = 'docs/release-current.json';
 const expectedCoreDocs = [
@@ -26,6 +31,7 @@ const expectedCoreDocs = [
   '.github/workflows/mv3.yml',
   releaseMetadataPath,
   'scripts/verify-docs.mjs',
+  'scripts/verify-docs-parser.mjs',
 ];
 const expectedReadmeNavigation = [
   'docs/README.md',
@@ -106,7 +112,7 @@ function extractLinks(text) {
   const occupied = [];
   const patterns = [
     {
-      regex: /(!?)\[[^\]\n]*\]\(\s*(?:<([^>\n]+)>|((?:\\.|[^()\s]|\([^()\n]*\))+))(?:\s+(?:"[^"]*"|'[^']*'|\([^)]*\)))?\s*\)/gu,
+      regex: inlineMarkdownLinkPattern,
       build: (match) => ({ target: match[2] ?? match[3], image: match[1] === '!' }),
     },
     {
@@ -146,8 +152,7 @@ function extractLinks(text) {
 }
 
 function githubSlug(value) {
-  return value
-    .replace(/<[^>]*>/gu, '')
+  return stripHtmlTags(value)
     .replace(/!\[([^\]]*)\]\([^)]*\)/gu, '$1')
     .replace(/\[([^\]]+)\]\([^)]*\)/gu, '$1')
     .replace(/[`*_~]/gu, '')


### PR DESCRIPTION
## Summary

This focused security cleanup fixes the two open Code Scanning findings and resolves the maintained dependency alerts without changing Chromium or Firefox runtime behavior.

## Code Scanning

- Fixes 2 Code Scanning alerts in `scripts/verify-docs.mjs`:
  - CodeQL `js/redos`: makes the Markdown link-target matcher alternatives disjoint.
  - CodeQL `js/incomplete-multi-character-sanitization`: replaces the one-pass HTML-tag removal regex with a deterministic single-pass scanner.
- Adds focused parser regression coverage.
- No alert is suppressed or dismissed.

## Dependabot and audits

- Dependabot: **39 -> 37** after updating maintained Mocha's transitive `serialize-javascript` resolution to 7.0.5.
- Remaining **37 alerts** are confined to the quarantined legacy Options compiler lockfile; that compiler is not installed by maintained CI and is excluded from current Chromium/Firefox builds and packages.
- Remaining production/runtime Dependabot alerts: **0**.
- Production npm audit: **0 vulnerabilities**.
- Maintained full npm audit: **2 low, dev-only** findings in Mocha/jsdiff. The fixing Mocha major was less than the repository's required 168-hour publication age during this review, so that isolated tooling upgrade is intentionally deferred.

## Verification

- Supply-chain tests: 11/11
- PAC tests: 26/26
- Chromium MV3 tests: 428/428
- Firefox deterministic tests: 191/191
- Aggregate tests: 636/636
- Documentation/parser checks, lint, MV2/MV3 builds, package verification, and browser smoke passed.
- Chromium package: **70/70 files**, added 0, missing 0, **0 SHA-256 differences**.
- Firefox package: **14 files**.
- Dependencies are unchanged except for the reviewed transitive maintained-test resolution and lockfile metadata normalization; production runtime dependencies are unchanged.

## Runtime impact

- Chromium runtime: none.
- Firefox architecture/runtime: none.
- Manifest permissions, provider data/update semantics, activation, UI, and release configuration: unchanged.