### PR TITLE
Add Firefox production recovery configuration

### DIFF
--- a/docs/development/FIREFOX_MV3_SKELETON.md
+++ b/docs/development/FIREFOX_MV3_SKELETON.md
@@ -177,11 +177,38 @@ Clear сначала записывает `OFF` с cleanup identity, затем 
 очищает request/auth state и освобождает exact floor. Ошибка release сохраняет
 durable `OFF` и floor identity для следующего reconciliation.
 
-Production event page намеренно не передаёт recovery factory и по-прежнему не
-имеет пути создания `ON`: `firefox.activation.apply` возвращает
+Production event page теперь передаёт controller реальный recovery factory, но
+по-прежнему не имеет пути создания `ON`: `firefox.activation.apply` возвращает
 `ACTIVATION_NOT_IMPLEMENTED`, а capability `activationSupported` равен `false`.
-Synthetic recovery factory используется только в tests/browser QA; реальная
-конфигурация, provider artifact и persistent credentials в package отсутствуют.
+Factory используется только при уже существующем строгом durable `ON`; чистая
+установка `OFF` не открывает IndexedDB и не читает Firefox product config.
+
+Non-secret product config хранится отдельно под
+`firefoxMv3ProductRoutingConfig` в schema v1. Он содержит exact provider и
+dataset identity, тот же routing descriptor и каноническую структуру всех
+browser-neutral inputs: rules, candidate groups, flags, provider candidates и
+provider fallback. `configurationSha256` — SHA-256 от детерминированных UTF-8
+bytes этой строгой структуры. Поэтому recovery требует одновременного exact
+совпадения provider key, dataset hash/version, descriptor key/version/hash и
+уже принадлежащего расширению floor; новая active/staged/LKG версия dataset не
+подменяет durable identity.
+
+Proxy credentials находятся в отдельной schema v1 записи
+`firefoxMv3ProxyCredentials`, привязанной к тому же routing descriptor.
+Configuration содержит только `authRef`; credential record содержит только
+строгий список `authRef`/username/password. Во время boot credentials читаются
+до publication, проверяется наличие всех и только требуемых `authRef`, после
+чего READY session получает синхронный in-memory resolver. Passwords не входят
+в durable `ON`, routing descriptor, dataset metadata, RPC/status/errors/logs
+или diagnostics. Missing/malformed/future config, descriptor/provider/dataset
+mismatch, missing credential, hash failure или недоступный dataset store
+оставляют session недоступной, а exact floor — fail-closed до Clear.
+
+Recovery не выполняет network request: production dataset store открывается
+локально через IndexedDB только для durable `ON`, exact stored artifact ещё раз
+проверяется существующим dataset runtime, и session публикуется только после
+полного успеха. Реальный provider artifact, updater URL/key и persistent
+production configuration по-прежнему отсутствуют в package.
 
 Для каркаса используется development-only Gecko ID
 `firefox-mv3-skeleton@runet-censorship-bypass.invalid`. Production Gecko/AMO ID

--- a/extensions/chromium/runet-censorship-bypass/gulpfile.js
+++ b/extensions/chromium/runet-censorship-bypass/gulpfile.js
@@ -69,6 +69,7 @@ const firefoxMv3RuntimeSrc = [
   './src/extension-firefox-mv3/background/dataset-runtime.js',
   './src/extension-firefox-mv3/background/routing-adapter.js',
   './src/extension-firefox-mv3/background/proxy-auth.js',
+  './src/extension-firefox-mv3/background/product-config.js',
   './src/extension-firefox-mv3/background/activation-controller.js',
   './src/extension-firefox-mv3/background/event-page.js',
 ];

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/background/activation-controller.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/background/activation-controller.js
@@ -73,6 +73,22 @@
         RECOVERY_UNAVAILABLE: 'RECOVERY_UNAVAILABLE',
         ROUTING_DESCRIPTOR_MISMATCH: 'ROUTING_DESCRIPTOR_MISMATCH',
       });
+      const RECOVERY_FACTORY_ERROR_CODES = Object.freeze([
+        'CREDENTIAL_CONFIG_DESCRIPTOR_MISMATCH',
+        'CREDENTIAL_CONFIG_MALFORMED',
+        'CREDENTIAL_CONFIG_VERSION_UNSUPPORTED',
+        'DATASET_STORE_UNAVAILABLE',
+        'PRODUCT_CONFIG_DATASET_MISMATCH',
+        'PRODUCT_CONFIG_DESCRIPTOR_MISMATCH',
+        'PRODUCT_CONFIG_HASH_MISMATCH',
+        'PRODUCT_CONFIG_MALFORMED',
+        'PRODUCT_CONFIG_MISSING',
+        'PRODUCT_CONFIG_PROVIDER_MISMATCH',
+        'PRODUCT_CONFIG_STORAGE_UNAVAILABLE',
+        'PRODUCT_CONFIG_VERSION_UNSUPPORTED',
+        'REQUIRED_CREDENTIAL_MISSING',
+        'ROUTING_CONFIG_TOO_LARGE',
+      ]);
 
       function hasExactKeys(value, expected) {
 
@@ -96,6 +112,13 @@
 
         return typeof value === 'function' &&
           Object.prototype.toString.call(value) !== '[object AsyncFunction]';
+
+      }
+
+      function recoveryFactoryErrorCode(error) {
+
+        return error && RECOVERY_FACTORY_ERROR_CODES.includes(error.code) ?
+          error.code : ERRORS.RECOVERY_FACTORY_FAILED;
 
       }
 
@@ -568,9 +591,10 @@
             recovered = validateRecoveryResult(await recoveryFactory(
                 OffState.canonicalOnState(state),
             ));
-          } catch (_error) {
-            setUnavailable(ERRORS.RECOVERY_FACTORY_FAILED);
-            return errorResult(ERRORS.RECOVERY_FACTORY_FAILED, {
+          } catch (error) {
+            const code = recoveryFactoryErrorCode(error);
+            setUnavailable(code);
+            return errorResult(code, {
               floorRetained: true,
             });
           }
@@ -899,6 +923,7 @@
 
       return Object.freeze({
         ERRORS,
+        RECOVERY_FACTORY_ERROR_CODES,
         PREPARED_KEYS,
         RECOVERY_KEYS,
         RECOVERY_STATUS,

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/background/event-page.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/background/event-page.js
@@ -7,7 +7,34 @@
   const proxyAuthApi = root.rucbFirefoxProxyAuth;
   const routing = root.rucbFirefoxRoutingAdapter;
   const activationApi = root.rucbFirefoxActivationController;
+  const datasetStoreApi = root.rucbFirefoxDatasetStore;
+  const productConfigApi = root.rucbFirefoxProductConfig;
   let activationController = null;
+  let productionDatasetStore = null;
+
+  async function sha256(bytes) {
+
+    const digest = await root.crypto.subtle.digest('SHA-256', bytes);
+    return Array.from(new Uint8Array(digest), (value) =>
+      value.toString(16).padStart(2, '0')).join('');
+
+  }
+
+  function createProductionDatasetStore() {
+
+    if (!productionDatasetStore) {
+      const backend = datasetStoreApi.createIndexedDbBackend(root.indexedDB);
+      productionDatasetStore = datasetStoreApi.createStore({backend, sha256});
+    }
+    return productionDatasetStore;
+
+  }
+
+  const recoveryFactory = productConfigApi.createRecoveryFactory({
+    storageArea: browser.storage.local,
+    createDatasetStore: createProductionDatasetStore,
+    sha256,
+  });
   const routingAdapter = routing.createAdapter({
     runtimeStateForRequest: () => activationController ?
       activationController.currentRuntimeState() : routing.STATES.INITIALIZING,
@@ -34,6 +61,7 @@
   });
   activationController = activationApi.createController({
     proxyControl,
+    recoveryFactory,
     routingAdapter,
     proxyAuth,
     storageArea: browser.storage.local,

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/background/product-config.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/background/product-config.js
@@ -1,0 +1,625 @@
+'use strict';
+/* global require */
+
+(function publishFirefoxProductConfig(root, factory) {
+
+  const routing = typeof module === 'object' && module.exports ?
+    require('../../extension-mv3-common/routing-contract') :
+    root.mv3RoutingContract;
+  const offState = typeof module === 'object' && module.exports ?
+    require('./off-state') : root.rucbFirefoxOffState;
+  const api = factory(routing, offState);
+  if (typeof module === 'object' && module.exports) {
+    module.exports = api;
+    return;
+  }
+  root.rucbFirefoxProductConfig = api;
+
+})(typeof globalThis === 'object' ? globalThis : this,
+    function(Routing, OffState) {
+
+      const CONFIG_STORAGE_KEY = 'firefoxMv3ProductRoutingConfig';
+      const CREDENTIALS_STORAGE_KEY = 'firefoxMv3ProxyCredentials';
+      const SCHEMA_VERSION = 1;
+      const MAX_RULES = 4096;
+      const MAX_CANDIDATES = 256;
+      const MAX_CREDENTIALS = 256;
+      const MAX_PATTERN_LENGTH = 512;
+      const MAX_CREDENTIAL_FIELD_LENGTH = 4096;
+      const GROUP_NAMES = Object.freeze([
+        'own',
+        'localTor',
+        'torBrowser',
+        'warp',
+      ]);
+      const ROUTING_CONFIG_KEYS = Object.freeze([
+        'candidateGroups',
+        'flags',
+        'providerCandidates',
+        'providerFallback',
+        'rules',
+      ]);
+      const RULE_KEYS = Object.freeze(['direct', 'proxy', 'whitelist']);
+      const CANDIDATE_GROUP_KEYS = Object.freeze([
+        'configured',
+        'directReplacement',
+        'onion',
+      ]);
+      const FLAG_KEYS = Object.freeze([
+        'noDirect',
+        'ownProxiesOnlyForOwnSites',
+        'replaceDirectWithProxy',
+        'useProviderProxies',
+      ]);
+      const CANDIDATE_KEYS = Object.freeze([
+        'authRef',
+        'failoverTimeoutSeconds',
+        'host',
+        'id',
+        'port',
+        'proxyDNS',
+        'type',
+      ]);
+      const CONFIG_KEYS = Object.freeze([
+        'datasetIdentity',
+        'providerKey',
+        'routingConfig',
+        'routingDescriptor',
+        'schemaVersion',
+      ]);
+      const CREDENTIALS_KEYS = Object.freeze([
+        'entries',
+        'routingDescriptor',
+        'schemaVersion',
+      ]);
+      const CREDENTIAL_ENTRY_KEYS = Object.freeze([
+        'authRef',
+        'password',
+        'username',
+      ]);
+      const AUTH_REF_PATTERN = /^[A-Za-z0-9._:-]{1,128}$/;
+      const CANDIDATE_ID_PATTERN = /^[A-Za-z0-9._:-]{1,128}$/;
+      const SHA256_PATTERN = /^[a-f0-9]{64}$/;
+      const ERRORS = Object.freeze({
+        CREDENTIAL_CONFIG_DESCRIPTOR_MISMATCH:
+          'CREDENTIAL_CONFIG_DESCRIPTOR_MISMATCH',
+        CREDENTIAL_CONFIG_MALFORMED: 'CREDENTIAL_CONFIG_MALFORMED',
+        CREDENTIAL_CONFIG_VERSION_UNSUPPORTED:
+          'CREDENTIAL_CONFIG_VERSION_UNSUPPORTED',
+        DATASET_STORE_UNAVAILABLE: 'DATASET_STORE_UNAVAILABLE',
+        INVALID_PRODUCT_CONFIG_DEPENDENCIES:
+          'INVALID_PRODUCT_CONFIG_DEPENDENCIES',
+        PRODUCT_CONFIG_DATASET_MISMATCH: 'PRODUCT_CONFIG_DATASET_MISMATCH',
+        PRODUCT_CONFIG_DESCRIPTOR_MISMATCH:
+          'PRODUCT_CONFIG_DESCRIPTOR_MISMATCH',
+        PRODUCT_CONFIG_HASH_MISMATCH: 'PRODUCT_CONFIG_HASH_MISMATCH',
+        PRODUCT_CONFIG_MALFORMED: 'PRODUCT_CONFIG_MALFORMED',
+        PRODUCT_CONFIG_MISSING: 'PRODUCT_CONFIG_MISSING',
+        PRODUCT_CONFIG_PROVIDER_MISMATCH: 'PRODUCT_CONFIG_PROVIDER_MISMATCH',
+        PRODUCT_CONFIG_STORAGE_UNAVAILABLE:
+          'PRODUCT_CONFIG_STORAGE_UNAVAILABLE',
+        PRODUCT_CONFIG_VERSION_UNSUPPORTED:
+          'PRODUCT_CONFIG_VERSION_UNSUPPORTED',
+        REQUIRED_CREDENTIAL_MISSING: 'REQUIRED_CREDENTIAL_MISSING',
+        ROUTING_CONFIG_TOO_LARGE: 'ROUTING_CONFIG_TOO_LARGE',
+      });
+
+      function configError(code) {
+
+        const error = new TypeError(code);
+        error.code = code;
+        return error;
+
+      }
+
+      function hasExactKeys(value, expected) {
+
+        if (!value || typeof value !== 'object' || Array.isArray(value)) {
+          return false;
+        }
+        const actual = Object.keys(value).sort();
+        const required = [...expected].sort();
+        return actual.length === required.length &&
+          actual.every((key, index) => key === required[index]);
+
+      }
+
+      function sameDescriptor(leftValue, rightValue) {
+
+        const left = OffState.canonicalizeRoutingDescriptor(leftValue);
+        const right = OffState.canonicalizeRoutingDescriptor(rightValue);
+        return Boolean(left && right &&
+          OffState.ROUTING_DESCRIPTOR_KEYS.every((key) =>
+            left[key] === right[key]));
+
+      }
+
+      function sameDatasetIdentity(leftValue, rightValue) {
+
+        const left = OffState.canonicalizeDatasetIdentity(leftValue);
+        const right = OffState.canonicalizeDatasetIdentity(rightValue);
+        return Boolean(left && right &&
+          OffState.DATASET_IDENTITY_KEYS.every((key) =>
+            left[key] === right[key]));
+
+      }
+
+      function canonicalPattern(value) {
+
+        if (typeof value !== 'string' || value.length < 1 ||
+            value.length > MAX_PATTERN_LENGTH || value !== value.trim() ||
+            value !== value.toLowerCase() || hasUnsafeHostCharacter(value) ||
+            value.slice(1).includes('*')) {
+          throw configError(ERRORS.PRODUCT_CONFIG_MALFORMED);
+        }
+        return value;
+
+      }
+
+      function hasUnsafeHostCharacter(value) {
+
+        return Array.from(value).some((character) =>
+          character.charCodeAt(0) <= 32 || '/\\?#@'.includes(character));
+
+      }
+
+      function canonicalRules(value) {
+
+        if (!hasExactKeys(value, RULE_KEYS)) {
+          throw configError(ERRORS.PRODUCT_CONFIG_MALFORMED);
+        }
+        let count = 0;
+        const result = {};
+        for (const key of RULE_KEYS) {
+          if (!Array.isArray(value[key])) {
+            throw configError(ERRORS.PRODUCT_CONFIG_MALFORMED);
+          }
+          const seen = new Set();
+          result[key] = value[key].map((pattern) => {
+            const canonical = canonicalPattern(pattern);
+            if (seen.has(canonical)) {
+              throw configError(ERRORS.PRODUCT_CONFIG_MALFORMED);
+            }
+            seen.add(canonical);
+            count += 1;
+            if (count > MAX_RULES) {
+              throw configError(ERRORS.ROUTING_CONFIG_TOO_LARGE);
+            }
+            return canonical;
+          });
+        }
+        return result;
+
+      }
+
+      function validCandidateHost(value) {
+
+        return typeof value === 'string' && value.length > 0 &&
+          value.length <= 253 && value === value.trim() &&
+          value === value.toLowerCase() &&
+          !hasUnsafeHostCharacter(value);
+
+      }
+
+      function canonicalCandidate(value) {
+
+        if (!hasExactKeys(value, CANDIDATE_KEYS) ||
+            typeof value.id !== 'string' ||
+            !CANDIDATE_ID_PATTERN.test(value.id) ||
+            !Routing.CANDIDATE_TYPES.includes(value.type) ||
+            !validCandidateHost(value.host) ||
+            !Number.isSafeInteger(value.port) || value.port < 1 ||
+            value.port > 65535 || typeof value.proxyDNS !== 'boolean' ||
+            (value.authRef !== null &&
+              (typeof value.authRef !== 'string' ||
+               !AUTH_REF_PATTERN.test(value.authRef))) ||
+            (value.failoverTimeoutSeconds !== null &&
+              (!Number.isSafeInteger(value.failoverTimeoutSeconds) ||
+               value.failoverTimeoutSeconds < 1))) {
+          throw configError(ERRORS.PRODUCT_CONFIG_MALFORMED);
+        }
+        return {
+          id: value.id,
+          type: value.type,
+          host: value.host,
+          port: value.port,
+          proxyDNS: value.proxyDNS,
+          authRef: value.authRef,
+          failoverTimeoutSeconds: value.failoverTimeoutSeconds,
+        };
+
+      }
+
+      function canonicalCandidateList(value, accounting) {
+
+        if (!Array.isArray(value)) {
+          throw configError(ERRORS.PRODUCT_CONFIG_MALFORMED);
+        }
+        return value.map((candidate) => {
+          accounting.count += 1;
+          if (accounting.count > MAX_CANDIDATES) {
+            throw configError(ERRORS.ROUTING_CONFIG_TOO_LARGE);
+          }
+          const canonical = canonicalCandidate(candidate);
+          const endpoint = `${canonical.host}:${canonical.port}`;
+          if (accounting.authRefsByEndpoint.has(endpoint) &&
+              accounting.authRefsByEndpoint.get(endpoint) !==
+                canonical.authRef) {
+            throw configError(ERRORS.PRODUCT_CONFIG_MALFORMED);
+          }
+          accounting.authRefsByEndpoint.set(endpoint, canonical.authRef);
+          if (canonical.authRef !== null) {
+            accounting.requiredAuthRefs.add(canonical.authRef);
+          }
+          return canonical;
+        });
+
+      }
+
+      function canonicalCandidateGroups(value, accounting) {
+
+        if (!hasExactKeys(value, CANDIDATE_GROUP_KEYS)) {
+          throw configError(ERRORS.PRODUCT_CONFIG_MALFORMED);
+        }
+        const result = {};
+        for (const groupKey of CANDIDATE_GROUP_KEYS) {
+          const source = value[groupKey];
+          if (!hasExactKeys(source, GROUP_NAMES)) {
+            throw configError(ERRORS.PRODUCT_CONFIG_MALFORMED);
+          }
+          const group = {};
+          for (const name of GROUP_NAMES) {
+            group[name] = canonicalCandidateList(source[name], accounting);
+          }
+          result[groupKey] = group;
+        }
+        return result;
+
+      }
+
+      function canonicalFlags(value) {
+
+        if (!hasExactKeys(value, FLAG_KEYS) ||
+            FLAG_KEYS.some((key) => typeof value[key] !== 'boolean')) {
+          throw configError(ERRORS.PRODUCT_CONFIG_MALFORMED);
+        }
+        return {
+          noDirect: value.noDirect,
+          ownProxiesOnlyForOwnSites: value.ownProxiesOnlyForOwnSites,
+          replaceDirectWithProxy: value.replaceDirectWithProxy,
+          useProviderProxies: value.useProviderProxies,
+        };
+
+      }
+
+      function canonicalRoutingConfig(value) {
+
+        if (!hasExactKeys(value, ROUTING_CONFIG_KEYS)) {
+          throw configError(ERRORS.PRODUCT_CONFIG_MALFORMED);
+        }
+        const accounting = {
+          authRefsByEndpoint: new Map(),
+          count: 0,
+          requiredAuthRefs: new Set(),
+        };
+        const candidateGroups = canonicalCandidateGroups(
+            value.candidateGroups,
+            accounting,
+        );
+        const providerCandidates = canonicalCandidateList(
+            value.providerCandidates,
+            accounting,
+        );
+        if (!Object.values(Routing.FALLBACKS).includes(
+            value.providerFallback,
+        )) {
+          throw configError(ERRORS.PRODUCT_CONFIG_MALFORMED);
+        }
+        return Object.freeze({
+          value: {
+            rules: canonicalRules(value.rules),
+            candidateGroups,
+            flags: canonicalFlags(value.flags),
+            providerCandidates,
+            providerFallback: value.providerFallback,
+          },
+          requiredAuthRefs: Object.freeze(
+              [...accounting.requiredAuthRefs].sort(),
+          ),
+        });
+
+      }
+
+      function deepFreeze(value) {
+
+        if (!value || typeof value !== 'object' || Object.isFrozen(value)) {
+          return value;
+        }
+        Object.values(value).forEach(deepFreeze);
+        return Object.freeze(value);
+
+      }
+
+      function routingConfigBytes(value) {
+
+        const canonical = canonicalRoutingConfig(value).value;
+        return new TextEncoder().encode(JSON.stringify(canonical));
+
+      }
+
+      function canonicalProductConfig(value) {
+
+        if (!value || typeof value !== 'object' || Array.isArray(value)) {
+          throw configError(ERRORS.PRODUCT_CONFIG_MALFORMED);
+        }
+        if (value.schemaVersion !== SCHEMA_VERSION) {
+          throw configError(Number.isSafeInteger(value.schemaVersion) ?
+            ERRORS.PRODUCT_CONFIG_VERSION_UNSUPPORTED :
+            ERRORS.PRODUCT_CONFIG_MALFORMED);
+        }
+        if (!hasExactKeys(value, CONFIG_KEYS)) {
+          throw configError(ERRORS.PRODUCT_CONFIG_MALFORMED);
+        }
+        const datasetIdentity = OffState.canonicalizeDatasetIdentity(
+            value.datasetIdentity,
+        );
+        const routingDescriptor = OffState.canonicalizeRoutingDescriptor(
+            value.routingDescriptor,
+        );
+        const routingConfig = canonicalRoutingConfig(value.routingConfig);
+        if (!datasetIdentity || !routingDescriptor ||
+            value.providerKey !== datasetIdentity.providerKey) {
+          throw configError(ERRORS.PRODUCT_CONFIG_MALFORMED);
+        }
+        return Object.freeze({
+          config: deepFreeze({
+            schemaVersion: SCHEMA_VERSION,
+            providerKey: value.providerKey,
+            datasetIdentity,
+            routingDescriptor,
+            routingConfig: routingConfig.value,
+          }),
+          requiredAuthRefs: routingConfig.requiredAuthRefs,
+        });
+
+      }
+
+      async function verifyProductConfig(value, sha256) {
+
+        if (typeof sha256 !== 'function') {
+          throw configError(ERRORS.INVALID_PRODUCT_CONFIG_DEPENDENCIES);
+        }
+        const canonical = canonicalProductConfig(value);
+        let digest;
+        try {
+          digest = await sha256(routingConfigBytes(
+              canonical.config.routingConfig,
+          ));
+        } catch (_error) {
+          throw configError(ERRORS.PRODUCT_CONFIG_HASH_MISMATCH);
+        }
+        if (typeof digest !== 'string' || !SHA256_PATTERN.test(digest) ||
+            digest !== canonical.config.routingDescriptor.configurationSha256) {
+          throw configError(ERRORS.PRODUCT_CONFIG_HASH_MISMATCH);
+        }
+        return canonical;
+
+      }
+
+      function canonicalCredentialConfig(value) {
+
+        if (!value || typeof value !== 'object' || Array.isArray(value)) {
+          throw configError(ERRORS.CREDENTIAL_CONFIG_MALFORMED);
+        }
+        if (value.schemaVersion !== SCHEMA_VERSION) {
+          throw configError(Number.isSafeInteger(value.schemaVersion) ?
+            ERRORS.CREDENTIAL_CONFIG_VERSION_UNSUPPORTED :
+            ERRORS.CREDENTIAL_CONFIG_MALFORMED);
+        }
+        if (!hasExactKeys(value, CREDENTIALS_KEYS) ||
+            !Array.isArray(value.entries) ||
+            value.entries.length > MAX_CREDENTIALS) {
+          throw configError(ERRORS.CREDENTIAL_CONFIG_MALFORMED);
+        }
+        const routingDescriptor = OffState.canonicalizeRoutingDescriptor(
+            value.routingDescriptor,
+        );
+        if (!routingDescriptor) {
+          throw configError(ERRORS.CREDENTIAL_CONFIG_MALFORMED);
+        }
+        const seen = new Set();
+        const entries = value.entries.map((entry) => {
+          if (!hasExactKeys(entry, CREDENTIAL_ENTRY_KEYS) ||
+              typeof entry.authRef !== 'string' ||
+              !AUTH_REF_PATTERN.test(entry.authRef) ||
+              typeof entry.username !== 'string' ||
+              entry.username.length > MAX_CREDENTIAL_FIELD_LENGTH ||
+              typeof entry.password !== 'string' ||
+              entry.password.length > MAX_CREDENTIAL_FIELD_LENGTH ||
+              seen.has(entry.authRef)) {
+            throw configError(ERRORS.CREDENTIAL_CONFIG_MALFORMED);
+          }
+          seen.add(entry.authRef);
+          return Object.freeze({
+            authRef: entry.authRef,
+            username: entry.username,
+            password: entry.password,
+          });
+        });
+        return Object.freeze({
+          schemaVersion: SCHEMA_VERSION,
+          routingDescriptor: Object.freeze(routingDescriptor),
+          entries: Object.freeze(entries),
+        });
+
+      }
+
+      function createRoutingBaseInput(routingConfig) {
+
+        const frozen = deepFreeze(routingConfig);
+        return function routingBaseInputForRequest() {
+
+          return frozen;
+
+        };
+
+      }
+
+      function createCredentialResolver(entries) {
+
+        const credentials = new Map(entries.map((entry) => [
+          entry.authRef,
+          Object.freeze({username: entry.username, password: entry.password}),
+        ]));
+        return function resolveCredentials(authRef) {
+
+          return credentials.get(authRef) || null;
+
+        };
+
+      }
+
+      function createRecoveryFactory(options = {}) {
+
+        const storageArea = options.storageArea;
+        const createDatasetStore = options.createDatasetStore;
+        const sha256 = options.sha256;
+        if (!storageArea || typeof storageArea.get !== 'function' ||
+            typeof createDatasetStore !== 'function' ||
+            typeof sha256 !== 'function') {
+          throw configError(ERRORS.INVALID_PRODUCT_CONFIG_DEPENDENCIES);
+        }
+        return async function recoverProductConfiguration(durableState) {
+
+          let stored;
+          try {
+            stored = await storageArea.get([
+              CONFIG_STORAGE_KEY,
+              CREDENTIALS_STORAGE_KEY,
+            ]);
+          } catch (_error) {
+            throw configError(ERRORS.PRODUCT_CONFIG_STORAGE_UNAVAILABLE);
+          }
+          if (!stored || typeof stored !== 'object' || Array.isArray(stored)) {
+            throw configError(ERRORS.PRODUCT_CONFIG_STORAGE_UNAVAILABLE);
+          }
+          if (!Object.prototype.hasOwnProperty.call(stored, CONFIG_STORAGE_KEY)) {
+            throw configError(ERRORS.PRODUCT_CONFIG_MISSING);
+          }
+          const verified = await verifyProductConfig(
+              stored[CONFIG_STORAGE_KEY],
+              sha256,
+          );
+          const config = verified.config;
+          if (config.providerKey !== durableState.providerKey) {
+            throw configError(ERRORS.PRODUCT_CONFIG_PROVIDER_MISMATCH);
+          }
+          if (!sameDatasetIdentity(
+              config.datasetIdentity,
+              durableState.datasetIdentity,
+          )) {
+            throw configError(ERRORS.PRODUCT_CONFIG_DATASET_MISMATCH);
+          }
+          if (!sameDescriptor(
+              config.routingDescriptor,
+              durableState.routingDescriptor,
+          )) {
+            throw configError(ERRORS.PRODUCT_CONFIG_DESCRIPTOR_MISMATCH);
+          }
+
+          const hasCredentialConfig = Object.prototype.hasOwnProperty.call(
+              stored,
+              CREDENTIALS_STORAGE_KEY,
+          );
+          let credentialConfig = null;
+          if (hasCredentialConfig) {
+            credentialConfig = canonicalCredentialConfig(
+                stored[CREDENTIALS_STORAGE_KEY],
+            );
+            if (!sameDescriptor(
+                credentialConfig.routingDescriptor,
+                config.routingDescriptor,
+            )) {
+              throw configError(
+                  ERRORS.CREDENTIAL_CONFIG_DESCRIPTOR_MISMATCH,
+              );
+            }
+          }
+          const entries = credentialConfig ? credentialConfig.entries : [];
+          const entriesByAuthRef = new Map(entries.map((entry) => [
+            entry.authRef,
+            entry,
+          ]));
+          if (verified.requiredAuthRefs.some((authRef) =>
+            !entriesByAuthRef.has(authRef)) || entries.some((entry) =>
+            !verified.requiredAuthRefs.includes(entry.authRef))) {
+            throw configError(ERRORS.REQUIRED_CREDENTIAL_MISSING);
+          }
+
+          let datasetStore;
+          try {
+            datasetStore = createDatasetStore();
+          } catch (_error) {
+            throw configError(ERRORS.DATASET_STORE_UNAVAILABLE);
+          }
+          if (!datasetStore ||
+              typeof datasetStore.loadVerifications !== 'function') {
+            throw configError(ERRORS.DATASET_STORE_UNAVAILABLE);
+          }
+          return Object.freeze({
+            datasetStore,
+            resolveCredentials: createCredentialResolver(entries),
+            routingBaseInputForRequest: createRoutingBaseInput(
+                config.routingConfig,
+            ),
+            routingDescriptor: config.routingDescriptor,
+          });
+
+        };
+
+      }
+
+      async function createProductConfig(options = {}) {
+
+        const routingConfig = canonicalRoutingConfig(options.routingConfig);
+        if (typeof options.sha256 !== 'function') {
+          throw configError(ERRORS.INVALID_PRODUCT_CONFIG_DEPENDENCIES);
+        }
+        const configurationSha256 = await options.sha256(
+            routingConfigBytes(routingConfig.value),
+        );
+        const value = {
+          schemaVersion: SCHEMA_VERSION,
+          providerKey: options.providerKey,
+          datasetIdentity: options.datasetIdentity,
+          routingDescriptor: {
+            schemaVersion: OffState.ROUTING_DESCRIPTOR_SCHEMA_VERSION,
+            configurationKey: options.configurationKey,
+            configurationVersion: options.configurationVersion,
+            configurationSha256,
+          },
+          routingConfig: routingConfig.value,
+        };
+        return (await verifyProductConfig(value, options.sha256)).config;
+
+      }
+
+      return Object.freeze({
+        CONFIG_STORAGE_KEY,
+        CREDENTIALS_STORAGE_KEY,
+        ERRORS,
+        MAX_CANDIDATES,
+        MAX_CREDENTIALS,
+        MAX_RULES,
+        SCHEMA_VERSION,
+        canonicalCredentialConfig,
+        canonicalProductConfig,
+        canonicalRoutingConfig,
+        createCredentialResolver,
+        createProductConfig,
+        createRecoveryFactory,
+        routingConfigBytes,
+        verifyProductConfig,
+      });
+
+    });

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/manifest.json
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/manifest.json
@@ -25,6 +25,7 @@
       "background/dataset-runtime.js",
       "background/routing-adapter.js",
       "background/proxy-auth.js",
+      "background/product-config.js",
       "background/activation-controller.js",
       "background/event-page.js"
     ],

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/durable-activation.test.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/durable-activation.test.js
@@ -572,6 +572,39 @@ describe('Firefox durable activation recovery', function() {
 
       });
 
+  it('preserves only stable production recovery failure codes',
+      async function() {
+
+        for (const [factoryCode, expectedCode] of [
+          ['PRODUCT_CONFIG_MISSING', 'PRODUCT_CONFIG_MISSING'],
+          ['REQUIRED_CREDENTIAL_MISSING', 'REQUIRED_CREDENTIAL_MISSING'],
+          ['secret-value-must-not-escape', 'RECOVERY_FACTORY_FAILED'],
+        ]) {
+          const system = createSystem({
+            durableState: onState(),
+            liveSettings: {
+              levelOfControl: 'controlled_by_this_extension',
+              value: floor(),
+            },
+            recoveryFactory() {
+
+              const error = new Error('sanitized recovery failure');
+              error.code = factoryCode;
+              throw error;
+
+            },
+          });
+          const result = await system.controller.initializeFromDurable();
+
+          Assert.strictEqual(result.ok, false);
+          Assert.strictEqual(result.error.code, expectedCode);
+          Assert.strictEqual(system.controller.snapshot().failureCode,
+              expectedCode);
+          Assert.strictEqual(system.controller.currentRuntimeState(), 'FAILED');
+        }
+
+      });
+
   it('rejects missing or silently different recovery datasets', async function() {
 
     const missing = DatasetStore.createStore({

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/product-config.test.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/product-config.test.js
@@ -1,0 +1,524 @@
+'use strict';
+
+const Assert = require('node:assert');
+const Config = require('../background/product-config');
+const OffState = require('../background/off-state');
+const Routing = require('../../extension-mv3-common/routing-contract');
+const Helpers = require('./dataset-test-helpers');
+
+function sha256(bytes) {
+
+  return Promise.resolve(Helpers.sha256(Buffer.from(bytes)));
+
+}
+
+function candidate(overrides = {}) {
+
+  return Object.assign({
+    authRef: null,
+    failoverTimeoutSeconds: null,
+    host: 'proxy.test',
+    id: 'fixture-proxy',
+    port: 8080,
+    proxyDNS: false,
+    type: 'HTTP',
+  }, overrides);
+
+}
+
+function emptyGroups() {
+
+  const group = () => ({own: [], localTor: [], torBrowser: [], warp: []});
+  return {
+    configured: group(),
+    directReplacement: group(),
+    onion: group(),
+  };
+
+}
+
+function routingConfig(overrides = {}) {
+
+  return Object.assign({
+    candidateGroups: emptyGroups(),
+    flags: {
+      noDirect: false,
+      ownProxiesOnlyForOwnSites: true,
+      replaceDirectWithProxy: false,
+      useProviderProxies: true,
+    },
+    providerCandidates: [candidate()],
+    providerFallback: Routing.FALLBACKS.DIRECT,
+    rules: {direct: [], proxy: [], whitelist: []},
+  }, overrides);
+
+}
+
+function datasetIdentity() {
+
+  const fixture = Helpers.artifact();
+  return {
+    providerKey: fixture.envelope.providerKey,
+    datasetVersion: fixture.envelope.datasetVersion,
+    artifactSha256: fixture.envelope.artifactSha256,
+  };
+
+}
+
+async function productConfig(options = {}) {
+
+  return Config.createProductConfig({
+    configurationKey: options.configurationKey || 'synthetic-routing',
+    configurationVersion: options.configurationVersion || '1',
+    datasetIdentity: options.datasetIdentity || datasetIdentity(),
+    providerKey: options.providerKey || Helpers.PROVIDER_KEY,
+    routingConfig: options.routingConfig || routingConfig(),
+    sha256,
+  });
+
+}
+
+function credentialConfig(descriptor, entries = []) {
+
+  return {
+    schemaVersion: Config.SCHEMA_VERSION,
+    routingDescriptor: descriptor,
+    entries,
+  };
+
+}
+
+function durableOn(config) {
+
+  return OffState.canonicalOnState({
+    floorIdentity: {
+      proxyType: 'manual',
+      http: '',
+      httpProxyAll: false,
+      ssl: '',
+      socks: '127.0.0.1:55101',
+      socksVersion: 5,
+      proxyDNS: true,
+      passthrough: '',
+      autoConfigUrl: '',
+    },
+    providerKey: config.providerKey,
+    datasetIdentity: config.datasetIdentity,
+    routingDescriptor: config.routingDescriptor,
+  });
+
+}
+
+function storage(values = {}, error = null) {
+
+  return {
+    async get(keys) {
+
+      if (error) {
+        throw error;
+      }
+      const result = {};
+      for (const key of keys) {
+        if (Object.prototype.hasOwnProperty.call(values, key)) {
+          result[key] = structuredClone(values[key]);
+        }
+      }
+      return result;
+
+    },
+  };
+
+}
+
+function recoveryFactory(values, options = {}) {
+
+  return Config.createRecoveryFactory({
+    storageArea: storage(values, options.storageError),
+    createDatasetStore: options.createDatasetStore || (() => ({
+      loadVerifications() {},
+    })),
+    sha256,
+  });
+
+}
+
+async function rejectsCode(operation, code) {
+
+  await Assert.rejects(operation, (error) => error && error.code === code);
+
+}
+
+describe('Firefox production recovery configuration', function() {
+
+  it('builds a deterministic descriptor over canonical routing bytes',
+      async function() {
+
+        const first = await productConfig();
+        const second = await productConfig({
+          routingConfig: {
+            rules: {whitelist: [], proxy: [], direct: []},
+            providerFallback: Routing.FALLBACKS.DIRECT,
+            providerCandidates: [candidate()],
+            flags: {
+              useProviderProxies: true,
+              replaceDirectWithProxy: false,
+              ownProxiesOnlyForOwnSites: true,
+              noDirect: false,
+            },
+            candidateGroups: emptyGroups(),
+          },
+        });
+
+        Assert.strictEqual(
+            first.routingDescriptor.configurationSha256,
+            second.routingDescriptor.configurationSha256,
+        );
+        Assert.strictEqual(
+            first.routingDescriptor.configurationSha256,
+            Helpers.sha256(Config.routingConfigBytes(first.routingConfig)),
+        );
+
+      });
+
+  it('preserves every browser-neutral routing input field', async function() {
+
+    const config = routingConfig({
+      rules: {
+        direct: ['direct.example'],
+        proxy: ['*.proxy.example'],
+        whitelist: ['allowed.example'],
+      },
+      flags: {
+        noDirect: true,
+        ownProxiesOnlyForOwnSites: false,
+        replaceDirectWithProxy: true,
+        useProviderProxies: false,
+      },
+    });
+    config.candidateGroups.configured.own.push(candidate());
+    config.candidateGroups.onion.localTor.push(candidate({
+      id: 'tor',
+      host: '127.0.0.1',
+      port: 9050,
+      proxyDNS: true,
+      type: 'SOCKS5',
+    }));
+    config.candidateGroups.directReplacement.warp.push(candidate({
+      id: 'warp',
+      host: 'warp.test',
+      port: 8443,
+      type: 'HTTPS',
+    }));
+    const persisted = await productConfig({routingConfig: config});
+
+    Assert.deepStrictEqual(persisted.routingConfig, config);
+    Assert.strictEqual(Object.isFrozen(persisted.routingConfig), true);
+
+  });
+
+  it('rejects malformed, future, and unknown product schemas', async function() {
+
+    const valid = await productConfig();
+    for (const value of [
+      null,
+      Object.assign({}, valid, {schemaVersion: 2}),
+      Object.assign({}, valid, {extra: true}),
+      Object.assign({}, valid, {routingConfig: {}}),
+    ]) {
+      Assert.throws(
+          () => Config.canonicalProductConfig(value),
+          (error) => error && [
+            Config.ERRORS.PRODUCT_CONFIG_MALFORMED,
+            Config.ERRORS.PRODUCT_CONFIG_VERSION_UNSUPPORTED,
+          ].includes(error.code),
+      );
+    }
+
+  });
+
+  it('rejects duplicate, unsafe, or excessive routing fields', function() {
+
+    for (const value of [
+      routingConfig({rules: {
+        direct: ['same.example', 'same.example'], proxy: [], whitelist: [],
+      }}),
+      routingConfig({rules: {
+        direct: ['https://unsafe.example'], proxy: [], whitelist: [],
+      }}),
+      routingConfig({providerCandidates: [candidate({host: 'UPPER.test'})]}),
+      routingConfig({providerCandidates: [candidate({password: 'forbidden'})]}),
+    ]) {
+      Assert.throws(() => Config.canonicalRoutingConfig(value));
+    }
+
+    Assert.throws(() => Config.canonicalRoutingConfig(routingConfig({
+      providerCandidates: Array.from(
+          {length: Config.MAX_CANDIDATES + 1},
+          (_, index) => candidate({id: `candidate-${index}`})),
+    })), (error) => error.code === Config.ERRORS.ROUTING_CONFIG_TOO_LARGE);
+
+  });
+
+  it('rejects conflicting authRefs for one proxy endpoint', function() {
+
+    Assert.throws(() => Config.canonicalRoutingConfig(routingConfig({
+      providerCandidates: [
+        candidate({id: 'first', authRef: 'first-auth'}),
+        candidate({id: 'second', authRef: 'second-auth'}),
+      ],
+    })), (error) => error.code === Config.ERRORS.PRODUCT_CONFIG_MALFORMED);
+
+  });
+
+  it('verifies the persisted routing hash before recovery', async function() {
+
+    const config = await productConfig();
+    const modified = structuredClone(config);
+    modified.routingConfig.flags.noDirect = true;
+
+    await rejectsCode(
+        () => Config.verifyProductConfig(modified, sha256),
+        Config.ERRORS.PRODUCT_CONFIG_HASH_MISMATCH,
+    );
+
+  });
+
+  it('keeps credentials in a separate descriptor-bound schema',
+      async function() {
+
+        const config = await productConfig({
+          routingConfig: routingConfig({providerCandidates: [candidate({
+            authRef: 'fixture-auth',
+          })]}),
+        });
+        const credentials = Config.canonicalCredentialConfig(
+            credentialConfig(config.routingDescriptor, [{
+              authRef: 'fixture-auth',
+              username: 'synthetic-user',
+              password: 'synthetic-password',
+            }]),
+        );
+
+        Assert.strictEqual(JSON.stringify(config).includes('password'), false);
+        Assert.strictEqual(
+            JSON.stringify(durableOn(config)).includes('password'),
+            false,
+        );
+        Assert.strictEqual(credentials.entries[0].authRef, 'fixture-auth');
+
+      });
+
+  it('rejects malformed, future, duplicate, and oversized credentials',
+      async function() {
+
+        const descriptor = (await productConfig()).routingDescriptor;
+        for (const value of [
+          null,
+          Object.assign(credentialConfig(descriptor), {schemaVersion: 2}),
+          Object.assign(credentialConfig(descriptor), {extra: true}),
+          credentialConfig(descriptor, [
+            {authRef: 'same', username: 'one', password: 'one'},
+            {authRef: 'same', username: 'two', password: 'two'},
+          ]),
+          credentialConfig(descriptor, [{
+            authRef: 'long',
+            username: 'x'.repeat(4097),
+            password: '',
+          }]),
+        ]) {
+          Assert.throws(
+              () => Config.canonicalCredentialConfig(value),
+              (error) => error && [
+                Config.ERRORS.CREDENTIAL_CONFIG_MALFORMED,
+                Config.ERRORS.CREDENTIAL_CONFIG_VERSION_UNSUPPORTED,
+              ].includes(error.code),
+          );
+        }
+
+      });
+
+  it('recovers exact routing config and synchronous in-memory credentials',
+      async function() {
+
+        const config = await productConfig({
+          routingConfig: routingConfig({providerCandidates: [candidate({
+            authRef: 'fixture-auth',
+          })]}),
+        });
+        const values = {
+          [Config.CONFIG_STORAGE_KEY]: config,
+          [Config.CREDENTIALS_STORAGE_KEY]: credentialConfig(
+              config.routingDescriptor,
+              [{
+                authRef: 'fixture-auth',
+                username: 'synthetic-user',
+                password: 'synthetic-password',
+              }],
+          ),
+        };
+        const recovered = await recoveryFactory(values)(durableOn(config));
+
+        Assert.deepStrictEqual(
+            recovered.routingBaseInputForRequest({url: 'http://ignored.test'}),
+            config.routingConfig,
+        );
+        Assert.deepStrictEqual(recovered.resolveCredentials('fixture-auth'), {
+          username: 'synthetic-user',
+          password: 'synthetic-password',
+        });
+        Assert.strictEqual(recovered.resolveCredentials('unknown'), null);
+        Assert.strictEqual(
+            Object.prototype.toString.call(recovered.resolveCredentials),
+            '[object Function]',
+        );
+
+      });
+
+  it('recovers without credential storage when no candidate needs auth',
+      async function() {
+
+        const config = await productConfig();
+        const recovered = await recoveryFactory({
+          [Config.CONFIG_STORAGE_KEY]: config,
+        })(durableOn(config));
+
+        Assert.strictEqual(recovered.resolveCredentials('anything'), null);
+
+      });
+
+  it('rejects every exact durable binding mismatch', async function() {
+
+    const config = await productConfig();
+    const values = {[Config.CONFIG_STORAGE_KEY]: config};
+    const state = durableOn(config);
+    const cases = [
+      [
+        Object.assign({}, state, {providerKey: 'different-provider'}),
+        Config.ERRORS.PRODUCT_CONFIG_PROVIDER_MISMATCH,
+      ],
+      [
+        Object.assign({}, state, {datasetIdentity: Object.assign(
+            {},
+            state.datasetIdentity,
+            {artifactSha256: 'f'.repeat(64)},
+        )}),
+        Config.ERRORS.PRODUCT_CONFIG_DATASET_MISMATCH,
+      ],
+      [
+        Object.assign({}, state, {routingDescriptor: Object.assign(
+            {},
+            state.routingDescriptor,
+            {configurationSha256: 'e'.repeat(64)},
+        )}),
+        Config.ERRORS.PRODUCT_CONFIG_DESCRIPTOR_MISMATCH,
+      ],
+    ];
+    for (const [changed, code] of cases) {
+      await rejectsCode(() => recoveryFactory(values)(changed), code);
+    }
+
+  });
+
+  it('rejects missing or unreadable product storage', async function() {
+
+    const state = durableOn(await productConfig());
+    await rejectsCode(
+        () => recoveryFactory({})(state),
+        Config.ERRORS.PRODUCT_CONFIG_MISSING,
+    );
+    await rejectsCode(
+        () => recoveryFactory({}, {
+          storageError: new Error('synthetic storage failure'),
+        })(state),
+        Config.ERRORS.PRODUCT_CONFIG_STORAGE_UNAVAILABLE,
+    );
+
+  });
+
+  it('requires all and only configured authRef credentials', async function() {
+
+    const config = await productConfig({
+      routingConfig: routingConfig({providerCandidates: [candidate({
+        authRef: 'required-auth',
+      })]}),
+    });
+    const state = durableOn(config);
+    for (const entries of [
+      [],
+      [{authRef: 'extra-auth', username: 'unused', password: 'unused'}],
+    ]) {
+      await rejectsCode(() => recoveryFactory({
+        [Config.CONFIG_STORAGE_KEY]: config,
+        [Config.CREDENTIALS_STORAGE_KEY]: credentialConfig(
+            config.routingDescriptor,
+            entries,
+        ),
+      })(state), Config.ERRORS.REQUIRED_CREDENTIAL_MISSING);
+    }
+
+  });
+
+  it('rejects credential descriptors from another routing configuration',
+      async function() {
+
+        const config = await productConfig({
+          routingConfig: routingConfig({providerCandidates: [candidate({
+            authRef: 'required-auth',
+          })]}),
+        });
+        const descriptor = Object.assign({}, config.routingDescriptor, {
+          configurationSha256: 'c'.repeat(64),
+        });
+        await rejectsCode(() => recoveryFactory({
+          [Config.CONFIG_STORAGE_KEY]: config,
+          [Config.CREDENTIALS_STORAGE_KEY]: credentialConfig(descriptor, [{
+            authRef: 'required-auth',
+            username: 'synthetic',
+            password: 'synthetic',
+          }]),
+        })(durableOn(config)),
+        Config.ERRORS.CREDENTIAL_CONFIG_DESCRIPTOR_MISMATCH);
+
+      });
+
+  it('rejects unavailable or malformed dataset-store construction',
+      async function() {
+
+        const config = await productConfig();
+        for (const createDatasetStore of [
+          () => null,
+          () => ({}),
+          () => {
+            throw new Error('synthetic dataset store failure');
+          },
+        ]) {
+          await rejectsCode(() => recoveryFactory({
+            [Config.CONFIG_STORAGE_KEY]: config,
+          }, {createDatasetStore})(durableOn(config)),
+          Config.ERRORS.DATASET_STORE_UNAVAILABLE);
+        }
+
+      });
+
+  it('contains no browser, network, executable-data, or logging dependency',
+      function() {
+
+        const source = require('node:fs').readFileSync(
+            require.resolve('../background/product-config'),
+            'utf8',
+        );
+        for (const forbidden of [
+          'browser.',
+          'chrome.',
+          'fetch(',
+          'XMLHttpRequest',
+          'eval(',
+          'Function(',
+          'console.',
+        ]) {
+          Assert.strictEqual(source.includes(forbidden), false, forbidden);
+        }
+
+      });
+
+});

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/skeleton.test.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/skeleton.test.js
@@ -60,6 +60,10 @@ const proxyAuthSource = Fs.readFileSync(
     Path.join(sourceRoot, 'background', 'proxy-auth.js'),
     'utf8',
 );
+const productConfigSource = Fs.readFileSync(
+    Path.join(sourceRoot, 'background', 'product-config.js'),
+    'utf8',
+);
 const activationControllerSource = Fs.readFileSync(
     Path.join(sourceRoot, 'background', 'activation-controller.js'),
     'utf8',
@@ -81,7 +85,13 @@ function makeStorage(initialValue) {
     area: {
       async get(key) {
 
-        return key in values ? {[key]: values[key]} : {};
+        const keys = Array.isArray(key) ? key : [key];
+        return keys.reduce((result, item) => {
+          if (item in values) {
+            result[item] = values[item];
+          }
+          return result;
+        }, {});
 
       },
       async set(update) {
@@ -182,7 +192,8 @@ function startEventPage(options = {}) {
       local: {
         async get(key) {
 
-          events.push('storage-get');
+          events.push(Array.isArray(key) ?
+            'product-config-storage-get' : 'storage-get');
           return storage.area.get(key);
 
         },
@@ -258,6 +269,7 @@ function startEventPage(options = {}) {
     filename: 'routing-adapter.js',
   });
   Vm.runInContext(proxyAuthSource, context, {filename: 'proxy-auth.js'});
+  Vm.runInContext(productConfigSource, context, {filename: 'product-config.js'});
   Vm.runInContext(activationControllerSource, context, {
     filename: 'activation-controller.js',
   });
@@ -308,6 +320,7 @@ describe('Firefox MV3 inert skeleton', function() {
         'background/dataset-runtime.js',
         'background/routing-adapter.js',
         'background/proxy-auth.js',
+        'background/product-config.js',
         'background/activation-controller.js',
         'background/event-page.js',
       ],
@@ -558,7 +571,7 @@ describe('Firefox MV3 inert skeleton', function() {
 
   });
 
-  it('does not recover durable ON without a production recovery factory',
+  it('uses production recovery and fails closed without product config',
       async function() {
 
         const floorIdentity = {
@@ -605,10 +618,15 @@ describe('Firefox MV3 inert skeleton', function() {
         Assert.strictEqual(response.result.recoveryStatus, 'FAILED');
         Assert.strictEqual(
             response.result.recoveryFailureCode,
-            'RECOVERY_UNAVAILABLE',
+            'PRODUCT_CONFIG_MISSING',
         );
         Assert.strictEqual(eventPage.proxySettingsCalls.set, 0);
         Assert.strictEqual(eventPage.proxySettingsCalls.clear, 0);
+        Assert.strictEqual(
+            eventPage.events.filter((event) =>
+              event === 'product-config-storage-get').length,
+            1,
+        );
 
       });
 
@@ -624,6 +642,10 @@ describe('Firefox MV3 inert skeleton', function() {
     });
     Assert.strictEqual(capabilities.result.runtimeState, 'OFF');
     Assert.strictEqual(capabilities.result.durableIntent, 'OFF');
+    Assert.strictEqual(
+        eventPage.events.includes('product-config-storage-get'),
+        false,
+    );
 
   });
 
@@ -674,6 +696,7 @@ describe('Firefox MV3 inert skeleton', function() {
           datasetRuntimeSource,
           routingAdapterSource,
           proxyAuthSource,
+          productConfigSource,
           activationControllerSource,
           eventPageSource,
         ].join('\n');
@@ -693,7 +716,7 @@ describe('Firefox MV3 inert skeleton', function() {
         Assert.strictEqual(eventPageSource.includes('activatePrepared('), false);
         Assert.strictEqual(eventPageSource.includes('fetchAndStage'), false);
         Assert.strictEqual(eventPageSource.includes('promoteStaged'), false);
-        Assert.strictEqual(eventPageSource.includes('recoveryFactory:'), false);
+        Assert.strictEqual(eventPageSource.includes('recoveryFactory,'), true);
         Assert.strictEqual(eventPageSource.includes('proxy.settings.set'), false);
 
       });

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/verify-package.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/verify-package.js
@@ -13,6 +13,7 @@ const EXPECTED_FILES = Object.freeze([
   'background/dataset-store.js',
   'background/event-page.js',
   'background/off-state.js',
+  'background/product-config.js',
   'background/provider-lookup.js',
   'background/provider-updater.js',
   'background/proxy-auth.js',
@@ -98,6 +99,7 @@ function verifyPackage(packageRoot, sourceRoot) {
     'background/dataset-runtime.js',
     'background/routing-adapter.js',
     'background/proxy-auth.js',
+    'background/product-config.js',
     'background/activation-controller.js',
     'background/event-page.js',
   ]);


### PR DESCRIPTION
## Summary

- Adds a strict versioned Firefox production routing-configuration schema and exact SHA-256 descriptor binding.
- Separates proxy credentials into their own descriptor-bound storage record; durable ON, routing descriptors, dataset metadata, RPC/status, errors, logs, and diagnostics never contain credential values.
- Supplies the production event page with a real recovery factory backed by the existing IndexedDB dataset store.
- Requires exact provider key, dataset identity, routing descriptor, owned floor, and complete in-memory credentials before publishing READY.
- Keeps production Apply unavailable (`ACTIVATION_NOT_IMPLEMENTED`); clean installs remain OFF and no real provider data, update URL, signing key, updater trigger, health, UI, or external recovery request is added.

## Failure behavior

Missing, malformed, or future configuration; descriptor/provider/dataset mismatch; missing credentials; storage/hash failure; and missing/corrupt exact dataset all leave the session unavailable and the exact floor fail-closed for Clear. Stable non-secret recovery codes are allowlisted; arbitrary thrown values do not escape.

## Verification

- Supply-chain pins: 11; supply-chain tests: 12/12
- PAC: 26/26
- Chromium MV3: 428/428
- Firefox deterministic: 208/208
- Aggregate: 643/643
- Firefox 154.0.1 recovery E2E: 10 genuine event-page recreation cycles, exact dataset/config recovery, authenticated HTTP/HTTPS after recovery, 0 unexpected protected-origin contacts, 0 credential leaks
- Maintained Chrome and Firefox lifecycle smoke: passed
- Chromium package: 70/70 files, added 0, missing 0, SHA-256 differences 0
- Firefox package: 15 files; the sole added runtime file is `background/product-config.js`
- Production npm audit: 0 vulnerabilities
- Dependencies/lockfiles: unchanged
- `git diff --check`: passed

## Security boundary

No activation RPC or startup path creates ON. Recovery performs no network request, reads no newer staged/active dataset in place of the durable exact identity, builds the full session before publication, and leaves listener registration synchronous and fail-closed throughout boot.