### PR TITLE
Add Firefox production settings control plane

### DIFF
--- a/docs/development/FIREFOX_MV3_SKELETON.md
+++ b/docs/development/FIREFOX_MV3_SKELETON.md
@@ -222,9 +222,37 @@ Configuration содержит только `authRef`; credential record сод�
 до publication, проверяется наличие всех и только требуемых `authRef`, после
 чего READY session получает синхронный in-memory resolver. Passwords не входят
 в durable `ON`, routing descriptor, dataset metadata, RPC/status/errors/logs
-или diagnostics. Missing/malformed/future config, descriptor/provider/dataset
+или diagnostics. Settings RPC может записывать эту запись, но никогда не
+возвращает password: ответ использует явные `NONE`/`KEEP`, а новый секрет
+принимается только как `SET` внутри полного OFF-only replace.
+Missing/malformed/future config, descriptor/provider/dataset
 mismatch, missing credential, hash failure или недоступный dataset store
 оставляют session недоступной, а exact floor — fail-closed до Clear.
+
+Production settings control plane предоставляет только строгие
+`firefox.settings.get` и `firefox.settings.replace`. Get не раскрывает
+provider/dataset identity, routing descriptor/hash, `authRef` или floor.
+Replace принимает complete schema v1 и разрешён только при одновременных
+durable/runtime `OFF`; Apply, Clear и settings writes проходят через одну
+event-page queue. Optimistic numeric revision отклоняет stale concurrent save.
+
+Public schema хранит Direct/Proxy/whitelist patterns, own proxies, отдельные
+local Tor/Tor Browser/WARP scopes и четыре общих routing flags. Patterns и
+proxy hosts нормализуются в lowercase с удалением внешних пробелов и конечной
+точки; `*.example` по-прежнему совпадает с base domain и subdomains, а простой
+pattern — только с exact host. В отличие от Chromium UI, Firefox control plane
+пока не имеет UI-level `enabled` master-toggle для Tor: три явных boolean scope
+показывают участие кандидата в Proxy rules, onion и Direct replacement. Это
+позволяет без скрытой семантики представить production default, где Tor
+кандидаты доступны для `.onion`, но не расширяют explicit Proxy chain.
+
+Сохранение использует write-ahead marker, затем один `storage.local.set` для
+descriptor-bound product config, credential record и redacted settings commit.
+Apply/recovery отказываются читать snapshot, пока marker существует. После
+crash завершённый exact commit может быть reconciled, а partial/mismatched
+config остаётся fail-closed; новая config никогда не принимается вместе со
+старыми credentials. RPC caller не выбирает provider или dataset identity и не
+может promote staged data.
 
 Recovery не выполняет network request: production dataset store открывается
 локально через IndexedDB, exact stored artifact ещё раз проверяется существующим

--- a/docs/development/FIREFOX_PROVIDER_DATASET.md
+++ b/docs/development/FIREFOX_PROVIDER_DATASET.md
@@ -87,3 +87,9 @@ The bootstrap performs no external request: its only reads use
 `browser.runtime.getURL()` for fixed package paths. It does not set proxy
 settings or activate routing. Remote update configuration remains disabled and
 contains neither a URL nor a trust key.
+
+The Firefox settings control plane can replace only the user-routing portion of
+the product configuration while durable and runtime state are both `OFF`.
+Provider key, packaged dataset identity, provider candidates, and provider
+fallback come from this production module and are never RPC input. A settings
+write therefore cannot select, mutate, or promote a provider artifact.

--- a/extensions/chromium/runet-censorship-bypass/gulpfile.js
+++ b/extensions/chromium/runet-censorship-bypass/gulpfile.js
@@ -71,6 +71,7 @@ const firefoxMv3RuntimeSrc = [
   './src/extension-firefox-mv3/background/proxy-auth.js',
   './src/extension-firefox-mv3/background/product-config.js',
   './src/extension-firefox-mv3/background/production-provider.js',
+  './src/extension-firefox-mv3/background/settings-control.js',
   './src/extension-firefox-mv3/background/activation-controller.js',
   './src/extension-firefox-mv3/background/event-page.js',
   './src/extension-firefox-mv3/provider/anticensority-hosts-v1.json',

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/background/event-page.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/background/event-page.js
@@ -10,7 +10,9 @@
   const datasetStoreApi = root.rucbFirefoxDatasetStore;
   const productConfigApi = root.rucbFirefoxProductConfig;
   const productionProviderApi = root.rucbFirefoxProductionProvider;
+  const settingsControlApi = root.rucbFirefoxSettingsControl;
   let activationController = null;
+  let settingsController = null;
   let productionDatasetStore = null;
   let providerBootstrapState = Object.freeze({
     ok: false,
@@ -117,6 +119,11 @@
     proxyAuth,
     storageArea: browser.storage.local,
   });
+  settingsController = settingsControlApi.createController({
+    storageArea: browser.storage.local,
+    sha256,
+    activationSnapshot: () => activationController.snapshot(),
+  });
   const bootId = root.crypto && typeof root.crypto.randomUUID === 'function' ?
     root.crypto.randomUUID() :
     `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
@@ -135,6 +142,9 @@
     'NO_USABLE_PROVIDER_DATASET',
     'SELECTED_DATASET_UNAVAILABLE',
   ]);
+  const SAFE_SETTINGS_ERROR_CODES = new Set(
+      Object.values(settingsControlApi.ERRORS),
+  );
 
   function exactRpcRequest(message, type) {
 
@@ -150,6 +160,26 @@
       value && typeof value === 'object' ? value.code : null;
     return SAFE_APPLY_ERROR_CODES.has(code) ? code :
       activationApi.ERRORS.ACTIVATION_FAILED;
+
+  }
+
+  function safeSettingsErrorCode(value) {
+
+    const code = typeof value === 'string' ? value :
+      value && typeof value === 'object' ? value.code : null;
+    return SAFE_SETTINGS_ERROR_CODES.has(code) ? code :
+      settingsControlApi.ERRORS.SETTINGS_STATE_UNAVAILABLE;
+
+  }
+
+  function exactSettingsReplaceRequest(message) {
+
+    return Boolean(message) && typeof message === 'object' &&
+      !Array.isArray(message) &&
+      message.type === 'firefox.settings.replace' &&
+      Object.keys(message).length === 3 &&
+      Object.prototype.hasOwnProperty.call(message, 'expectedRevision') &&
+      Object.prototype.hasOwnProperty.call(message, 'settings');
 
   }
 
@@ -221,6 +251,32 @@
 
   }
 
+  async function getProductSettings() {
+
+    try {
+      return {ok: true, result: await settingsController.get()};
+    } catch (error) {
+      return errorResponse(safeSettingsErrorCode(error));
+    }
+
+  }
+
+  async function replaceProductSettings(message) {
+
+    try {
+      return {
+        ok: true,
+        result: await settingsController.replace(
+            message.expectedRevision,
+            message.settings,
+        ),
+      };
+    } catch (error) {
+      return errorResponse(safeSettingsErrorCode(error));
+    }
+
+  }
+
   async function handleMessage(message) {
 
     await initialization;
@@ -255,7 +311,22 @@
       return enqueueRpcControlOperation(applyPersistedProductConfiguration);
     }
     if (type === 'firefox.activation.clear') {
+      if (!exactRpcRequest(message, type)) {
+        return errorResponse('INVALID_RPC_REQUEST');
+      }
       return enqueueRpcControlOperation(clearProductActivation);
+    }
+    if (type === 'firefox.settings.get') {
+      if (!exactRpcRequest(message, type)) {
+        return errorResponse('INVALID_RPC_REQUEST');
+      }
+      return enqueueRpcControlOperation(getProductSettings);
+    }
+    if (type === 'firefox.settings.replace') {
+      if (!exactSettingsReplaceRequest(message)) {
+        return errorResponse('INVALID_RPC_REQUEST');
+      }
+      return enqueueRpcControlOperation(() => replaceProductSettings(message));
     }
     return errorResponse('UNKNOWN_RPC');
 
@@ -299,6 +370,7 @@
   const initialization = (async () => {
 
     providerBootstrapState = await providerBootstrap.initialize();
+    await settingsController.initialize();
     return activationController.initializeFromDurable();
 
   })();

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/background/product-config.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/background/product-config.js
@@ -20,6 +20,8 @@
 
       const CONFIG_STORAGE_KEY = 'firefoxMv3ProductRoutingConfig';
       const CREDENTIALS_STORAGE_KEY = 'firefoxMv3ProxyCredentials';
+      const SETTINGS_COMMIT_STORAGE_KEY = 'firefoxMv3SettingsCommit';
+      const SETTINGS_TRANSACTION_STORAGE_KEY = 'firefoxMv3SettingsMutation';
       const SCHEMA_VERSION = 1;
       const MAX_RULES = 4096;
       const MAX_CANDIDATES = 256;
@@ -77,6 +79,12 @@
         'password',
         'username',
       ]);
+      const SETTINGS_COMMIT_KEYS = Object.freeze([
+        'revision',
+        'routingDescriptor',
+        'schemaVersion',
+        'settings',
+      ]);
       const AUTH_REF_PATTERN = /^[A-Za-z0-9._:-]{1,128}$/;
       const CANDIDATE_ID_PATTERN = /^[A-Za-z0-9._:-]{1,128}$/;
       const SHA256_PATTERN = /^[a-f0-9]{64}$/;
@@ -99,6 +107,8 @@
         PRODUCT_CONFIG_PROVIDER_MISMATCH: 'PRODUCT_CONFIG_PROVIDER_MISMATCH',
         PRODUCT_CONFIG_STORAGE_UNAVAILABLE:
           'PRODUCT_CONFIG_STORAGE_UNAVAILABLE',
+        PRODUCT_CONFIG_UPDATE_INCOMPLETE:
+          'PRODUCT_CONFIG_UPDATE_INCOMPLETE',
         PRODUCT_CONFIG_VERSION_UNSUPPORTED:
           'PRODUCT_CONFIG_VERSION_UNSUPPORTED',
         REQUIRED_CREDENTIAL_MISSING: 'REQUIRED_CREDENTIAL_MISSING',
@@ -497,6 +507,8 @@
             stored = await storageArea.get([
               CONFIG_STORAGE_KEY,
               CREDENTIALS_STORAGE_KEY,
+              SETTINGS_COMMIT_STORAGE_KEY,
+              SETTINGS_TRANSACTION_STORAGE_KEY,
             ]);
           } catch (_error) {
             throw configError(ERRORS.PRODUCT_CONFIG_STORAGE_UNAVAILABLE);
@@ -507,11 +519,33 @@
           if (!Object.prototype.hasOwnProperty.call(stored, CONFIG_STORAGE_KEY)) {
             throw configError(ERRORS.PRODUCT_CONFIG_MISSING);
           }
+          if (Object.prototype.hasOwnProperty.call(
+              stored,
+              SETTINGS_TRANSACTION_STORAGE_KEY,
+          )) {
+            throw configError(ERRORS.PRODUCT_CONFIG_UPDATE_INCOMPLETE);
+          }
           const verified = await verifyProductConfig(
               stored[CONFIG_STORAGE_KEY],
               sha256,
           );
           const config = verified.config;
+          if (Object.prototype.hasOwnProperty.call(
+              stored,
+              SETTINGS_COMMIT_STORAGE_KEY,
+          )) {
+            const commit = stored[SETTINGS_COMMIT_STORAGE_KEY];
+            if (!hasExactKeys(commit, SETTINGS_COMMIT_KEYS) ||
+                commit.schemaVersion !== 1 ||
+                !Number.isSafeInteger(commit.revision) ||
+                commit.revision < 1 || !sameDescriptor(
+                commit.routingDescriptor,
+                config.routingDescriptor,
+            ) || !commit.settings || typeof commit.settings !== 'object' ||
+                Array.isArray(commit.settings)) {
+              throw configError(ERRORS.PRODUCT_CONFIG_DESCRIPTOR_MISMATCH);
+            }
+          }
           const hasCredentialConfig = Object.prototype.hasOwnProperty.call(
               stored,
               CREDENTIALS_STORAGE_KEY,
@@ -644,6 +678,8 @@
       return Object.freeze({
         CONFIG_STORAGE_KEY,
         CREDENTIALS_STORAGE_KEY,
+        SETTINGS_COMMIT_STORAGE_KEY,
+        SETTINGS_TRANSACTION_STORAGE_KEY,
         ERRORS,
         MAX_CANDIDATES,
         MAX_CREDENTIALS,

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/background/settings-control.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/background/settings-control.js
@@ -1,0 +1,839 @@
+'use strict';
+/* global require */
+
+(function publishFirefoxSettingsControl(root, factory) {
+
+  const productConfig = typeof module === 'object' && module.exports ?
+    require('./product-config') : root.rucbFirefoxProductConfig;
+  const productionProvider = typeof module === 'object' && module.exports ?
+    require('./production-provider') : root.rucbFirefoxProductionProvider;
+  const routing = typeof module === 'object' && module.exports ?
+    require('../../extension-mv3-common/routing-contract') :
+    root.mv3RoutingContract;
+  const api = factory(productConfig, productionProvider, routing);
+  if (typeof module === 'object' && module.exports) {
+    module.exports = api;
+    return;
+  }
+  root.rucbFirefoxSettingsControl = api;
+
+})(typeof globalThis === 'object' ? globalThis : this,
+    function(ProductConfig, ProductionProvider, Routing) {
+
+      const SCHEMA_VERSION = 1;
+      const COMMIT_SCHEMA_VERSION = 1;
+      const MUTATION_SCHEMA_VERSION = 1;
+      const MAX_PUBLIC_PROXIES = 128;
+      const MAX_IDENTIFIER_LENGTH = 96;
+      const SETTINGS_KEYS = Object.freeze([
+        'flags',
+        'localTor',
+        'ownProxies',
+        'rules',
+        'schemaVersion',
+        'torBrowser',
+        'warp',
+      ]);
+      const RULE_KEYS = Object.freeze(['direct', 'proxy', 'whitelist']);
+      const FLAG_KEYS = Object.freeze([
+        'noDirect',
+        'ownProxiesOnlyForOwnSites',
+        'replaceDirectWithProxy',
+        'useProviderProxies',
+      ]);
+      const OWN_PROXY_KEYS = Object.freeze([
+        'credentials',
+        'enabled',
+        'failoverTimeoutSeconds',
+        'host',
+        'id',
+        'port',
+        'proxyDNS',
+        'type',
+        'useAsDirectReplacement',
+      ]);
+      const SCOPED_PROXY_KEYS = Object.freeze([
+        'failoverTimeoutSeconds',
+        'host',
+        'port',
+        'proxyDNS',
+        'type',
+        'useAsDirectReplacement',
+        'useForOnion',
+        'useForProxyRules',
+      ]);
+      const WARP_KEYS = Object.freeze([
+        'candidates',
+        'useAsDirectReplacement',
+        'useForProxyRules',
+      ]);
+      const WARP_CANDIDATE_KEYS = Object.freeze([
+        'failoverTimeoutSeconds',
+        'host',
+        'id',
+        'port',
+        'proxyDNS',
+        'type',
+      ]);
+      const COMMIT_KEYS = Object.freeze([
+        'revision',
+        'routingDescriptor',
+        'schemaVersion',
+        'settings',
+      ]);
+      const MUTATION_KEYS = Object.freeze([
+        'schemaVersion',
+        'status',
+      ]);
+      const ID_PATTERN = /^[A-Za-z0-9._:-]{1,96}$/;
+      const ERRORS = Object.freeze({
+        INVALID_SETTINGS_DEPENDENCIES: 'INVALID_SETTINGS_DEPENDENCIES',
+        SETTINGS_CREDENTIAL_AMBIGUOUS: 'SETTINGS_CREDENTIAL_AMBIGUOUS',
+        SETTINGS_CREDENTIAL_STALE: 'SETTINGS_CREDENTIAL_STALE',
+        SETTINGS_DATASET_BINDING_FAILED: 'SETTINGS_DATASET_BINDING_FAILED',
+        SETTINGS_MALFORMED: 'SETTINGS_MALFORMED',
+        SETTINGS_MUTATION_REQUIRES_OFF: 'SETTINGS_MUTATION_REQUIRES_OFF',
+        SETTINGS_REVISION_CONFLICT: 'SETTINGS_REVISION_CONFLICT',
+        SETTINGS_STATE_UNAVAILABLE: 'SETTINGS_STATE_UNAVAILABLE',
+        SETTINGS_STORAGE_FAILED: 'SETTINGS_STORAGE_FAILED',
+        SETTINGS_TRANSACTION_INCOMPLETE: 'SETTINGS_TRANSACTION_INCOMPLETE',
+        SETTINGS_VERSION_UNSUPPORTED: 'SETTINGS_VERSION_UNSUPPORTED',
+      });
+
+      function settingsError(code) {
+
+        const error = new TypeError(code);
+        error.code = code;
+        return error;
+
+      }
+
+      function hasExactKeys(value, expected) {
+
+        if (!value || typeof value !== 'object' || Array.isArray(value)) {
+          return false;
+        }
+        const actual = Object.keys(value).sort();
+        const wanted = [...expected].sort();
+        return actual.length === wanted.length &&
+          actual.every((key, index) => key === wanted[index]);
+
+      }
+
+      function clone(value) {
+
+        return JSON.parse(JSON.stringify(value));
+
+      }
+
+      function sameDescriptor(left, right) {
+
+        return Boolean(left && right &&
+          left.schemaVersion === right.schemaVersion &&
+          left.configurationKey === right.configurationKey &&
+          left.configurationVersion === right.configurationVersion &&
+          left.configurationSha256 === right.configurationSha256);
+
+      }
+
+      function canonicalPattern(value, storedOnly) {
+
+        if (typeof value !== 'string') {
+          throw settingsError(ERRORS.SETTINGS_MALFORMED);
+        }
+        let pattern = value.trim().toLowerCase();
+        while (pattern.endsWith('.')) {
+          pattern = pattern.slice(0, -1);
+        }
+        if (!pattern || (storedOnly && pattern !== value)) {
+          throw settingsError(ERRORS.SETTINGS_MALFORMED);
+        }
+        return pattern;
+
+      }
+
+      function canonicalRules(value, storedOnly) {
+
+        if (!hasExactKeys(value, RULE_KEYS)) {
+          throw settingsError(ERRORS.SETTINGS_MALFORMED);
+        }
+        const result = {};
+        for (const key of RULE_KEYS) {
+          if (!Array.isArray(value[key])) {
+            throw settingsError(ERRORS.SETTINGS_MALFORMED);
+          }
+          result[key] = value[key].map((pattern) =>
+            canonicalPattern(pattern, storedOnly));
+        }
+        return result;
+
+      }
+
+      function canonicalFlags(value) {
+
+        if (!hasExactKeys(value, FLAG_KEYS) ||
+            FLAG_KEYS.some((key) => typeof value[key] !== 'boolean')) {
+          throw settingsError(ERRORS.SETTINGS_MALFORMED);
+        }
+        return {
+          noDirect: value.noDirect,
+          ownProxiesOnlyForOwnSites: value.ownProxiesOnlyForOwnSites,
+          replaceDirectWithProxy: value.replaceDirectWithProxy,
+          useProviderProxies: value.useProviderProxies,
+        };
+
+      }
+
+      function canonicalProxyFields(value, keys, storedOnly) {
+
+        if (!hasExactKeys(value, keys) || typeof value.host !== 'string' ||
+            typeof value.type !== 'string' ||
+            !Routing.CANDIDATE_TYPES.includes(value.type) ||
+            !Number.isSafeInteger(value.port) || value.port < 1 ||
+            value.port > 65535 || typeof value.proxyDNS !== 'boolean' ||
+            (value.failoverTimeoutSeconds !== null &&
+              (!Number.isSafeInteger(value.failoverTimeoutSeconds) ||
+               value.failoverTimeoutSeconds < 1))) {
+          throw settingsError(ERRORS.SETTINGS_MALFORMED);
+        }
+        const host = value.host.trim().toLowerCase();
+        if (!host || (storedOnly && host !== value.host)) {
+          throw settingsError(ERRORS.SETTINGS_MALFORMED);
+        }
+        return {
+          type: value.type,
+          host,
+          port: value.port,
+          proxyDNS: value.proxyDNS,
+          failoverTimeoutSeconds: value.failoverTimeoutSeconds,
+        };
+
+      }
+
+      function canonicalCredentials(value, storedOnly) {
+
+        if (!value || typeof value !== 'object' || Array.isArray(value) ||
+            typeof value.mode !== 'string') {
+          throw settingsError(ERRORS.SETTINGS_MALFORMED);
+        }
+        if (value.mode === 'NONE' && hasExactKeys(value, ['mode'])) {
+          return {mode: 'NONE'};
+        }
+        if (value.mode === 'KEEP' &&
+            hasExactKeys(value, ['mode', 'username']) &&
+            typeof value.username === 'string') {
+          return {mode: 'KEEP', username: value.username};
+        }
+        if (!storedOnly && value.mode === 'SET' &&
+            hasExactKeys(value, ['mode', 'password', 'username']) &&
+            typeof value.username === 'string' &&
+            typeof value.password === 'string') {
+          return {
+            mode: 'SET',
+            username: value.username,
+            password: value.password,
+          };
+        }
+        throw settingsError(ERRORS.SETTINGS_MALFORMED);
+
+      }
+
+      function canonicalOwnProxy(value, storedOnly) {
+
+        const fields = canonicalProxyFields(value, OWN_PROXY_KEYS, storedOnly);
+        if (typeof value.id !== 'string' || !ID_PATTERN.test(value.id) ||
+            typeof value.enabled !== 'boolean' ||
+            typeof value.useAsDirectReplacement !== 'boolean') {
+          throw settingsError(ERRORS.SETTINGS_MALFORMED);
+        }
+        return Object.assign({
+          id: value.id,
+          enabled: value.enabled,
+        }, fields, {
+          useAsDirectReplacement: value.useAsDirectReplacement,
+          credentials: canonicalCredentials(value.credentials, storedOnly),
+        });
+
+      }
+
+      function canonicalScopedProxy(value, storedOnly) {
+
+        const fields = canonicalProxyFields(value, SCOPED_PROXY_KEYS, storedOnly);
+        for (const key of [
+          'useAsDirectReplacement',
+          'useForOnion',
+          'useForProxyRules',
+        ]) {
+          if (typeof value[key] !== 'boolean') {
+            throw settingsError(ERRORS.SETTINGS_MALFORMED);
+          }
+        }
+        return Object.assign(fields, {
+          useAsDirectReplacement: value.useAsDirectReplacement,
+          useForOnion: value.useForOnion,
+          useForProxyRules: value.useForProxyRules,
+        });
+
+      }
+
+      function canonicalWarp(value, storedOnly) {
+
+        if (!hasExactKeys(value, WARP_KEYS) ||
+            !Array.isArray(value.candidates) ||
+            typeof value.useAsDirectReplacement !== 'boolean' ||
+            typeof value.useForProxyRules !== 'boolean') {
+          throw settingsError(ERRORS.SETTINGS_MALFORMED);
+        }
+        return {
+          candidates: value.candidates.map((candidate) => {
+            const fields = canonicalProxyFields(
+                candidate,
+                WARP_CANDIDATE_KEYS,
+                storedOnly,
+            );
+            if (typeof candidate.id !== 'string' ||
+                !ID_PATTERN.test(candidate.id)) {
+              throw settingsError(ERRORS.SETTINGS_MALFORMED);
+            }
+            return Object.assign({id: candidate.id}, fields);
+          }),
+          useAsDirectReplacement: value.useAsDirectReplacement,
+          useForProxyRules: value.useForProxyRules,
+        };
+
+      }
+
+      function canonicalSettings(value, storedOnly = false) {
+
+        if (!value || typeof value !== 'object' || Array.isArray(value)) {
+          throw settingsError(ERRORS.SETTINGS_MALFORMED);
+        }
+        if (value.schemaVersion !== SCHEMA_VERSION) {
+          throw settingsError(Number.isSafeInteger(value.schemaVersion) ?
+            ERRORS.SETTINGS_VERSION_UNSUPPORTED : ERRORS.SETTINGS_MALFORMED);
+        }
+        if (!hasExactKeys(value, SETTINGS_KEYS) ||
+            !Array.isArray(value.ownProxies) ||
+            value.ownProxies.length > MAX_PUBLIC_PROXIES) {
+          throw settingsError(ERRORS.SETTINGS_MALFORMED);
+        }
+        const ownProxies = value.ownProxies.map((proxy) =>
+          canonicalOwnProxy(proxy, storedOnly));
+        const localTor = canonicalScopedProxy(value.localTor, storedOnly);
+        const torBrowser = canonicalScopedProxy(value.torBrowser, storedOnly);
+        const warp = canonicalWarp(value.warp, storedOnly);
+        if (ownProxies.length + warp.candidates.length > MAX_PUBLIC_PROXIES) {
+          throw settingsError(ERRORS.SETTINGS_MALFORMED);
+        }
+        const identifiers = ownProxies.map((proxy) => proxy.id)
+            .concat(warp.candidates.map((candidate) => candidate.id));
+        if (new Set(identifiers).size !== identifiers.length) {
+          throw settingsError(ERRORS.SETTINGS_MALFORMED);
+        }
+        return Object.freeze({
+          schemaVersion: SCHEMA_VERSION,
+          rules: canonicalRules(value.rules, storedOnly),
+          ownProxies,
+          localTor,
+          torBrowser,
+          warp,
+          flags: canonicalFlags(value.flags),
+        });
+
+      }
+
+      function publicCandidate(id, value, authRef = null) {
+
+        return {
+          id,
+          type: value.type,
+          host: value.host,
+          port: value.port,
+          proxyDNS: value.proxyDNS,
+          authRef,
+          failoverTimeoutSeconds: value.failoverTimeoutSeconds,
+        };
+
+      }
+
+      function emptyGroup() {
+
+        return {own: [], localTor: [], torBrowser: [], warp: []};
+
+      }
+
+      function endpointKey(candidate) {
+
+        return `${candidate.type}\n${candidate.host.toLowerCase()}\n${candidate.port}`;
+
+      }
+
+      function buildRoutingSnapshot(settings, current = null) {
+
+        const base = ProductionProvider.createProductionRoutingConfig();
+        const configured = emptyGroup();
+        const directReplacement = emptyGroup();
+        const onion = emptyGroup();
+        const credentialEntries = [];
+        const sanitizedOwn = [];
+        const currentById = new Map();
+        if (current) {
+          current.settings.ownProxies.forEach((proxy) =>
+            currentById.set(proxy.id, proxy));
+        }
+        const currentCredentials = current ? current.credentials : new Map();
+        const definitions = [];
+
+        for (const proxy of settings.ownProxies) {
+          if (!proxy.enabled && proxy.credentials.mode !== 'NONE') {
+            throw settingsError(ERRORS.SETTINGS_CREDENTIAL_AMBIGUOUS);
+          }
+          let authRef = null;
+          let storedCredentials = {mode: 'NONE'};
+          if (proxy.credentials.mode !== 'NONE') {
+            authRef = `own.${proxy.id}`;
+            const username = proxy.credentials.username;
+            let password;
+            if (proxy.credentials.mode === 'SET') {
+              password = proxy.credentials.password;
+            } else {
+              const previous = currentById.get(proxy.id);
+              const previousCredentials = currentCredentials.get(authRef);
+              if (!previous || !previousCredentials ||
+                  previous.type !== proxy.type ||
+                  previous.host !== proxy.host ||
+                  previous.port !== proxy.port ||
+                  previous.credentials.mode !== 'KEEP' ||
+                  previous.credentials.username !== username ||
+                  previousCredentials.username !== username) {
+                throw settingsError(ERRORS.SETTINGS_CREDENTIAL_STALE);
+              }
+              password = previousCredentials.password;
+            }
+            credentialEntries.push({authRef, username, password});
+            storedCredentials = {mode: 'KEEP', username};
+          }
+          const candidate = publicCandidate(proxy.id, proxy, authRef);
+          definitions.push(candidate);
+          if (proxy.enabled) {
+            configured.own.push(candidate);
+          }
+          if (proxy.enabled && proxy.useAsDirectReplacement) {
+            directReplacement.own.push(candidate);
+          }
+          sanitizedOwn.push(Object.assign({}, proxy, {
+            credentials: storedCredentials,
+          }));
+        }
+
+        const scoped = [
+          ['localTor', 'anticensority-local-tor', settings.localTor],
+          ['torBrowser', 'anticensority-tor-browser', settings.torBrowser],
+        ];
+        for (const [groupName, id, value] of scoped) {
+          const candidate = publicCandidate(id, value);
+          definitions.push(candidate);
+          if (value.useForProxyRules) {
+            configured[groupName].push(candidate);
+          }
+          if (value.useAsDirectReplacement) {
+            directReplacement[groupName].push(candidate);
+          }
+          if (value.useForOnion) {
+            onion[groupName].push(candidate);
+          }
+        }
+        for (const value of settings.warp.candidates) {
+          const candidate = publicCandidate(value.id, value);
+          definitions.push(candidate);
+          if (settings.warp.useForProxyRules) {
+            configured.warp.push(candidate);
+          }
+          if (settings.warp.useAsDirectReplacement) {
+            directReplacement.warp.push(candidate);
+          }
+        }
+        const allDefinitions = definitions.concat(base.providerCandidates);
+        const endpoints = new Map();
+        for (const candidate of allDefinitions) {
+          const endpoint = endpointKey(candidate);
+          if (endpoints.has(endpoint)) {
+            const previous = endpoints.get(endpoint);
+            const duplicatesAllowed = candidate.authRef === null &&
+              previous.authRef === null && previous.id === candidate.id &&
+              ['anticensority-local-tor', 'anticensority-tor-browser']
+                  .includes(candidate.id);
+            if (!duplicatesAllowed) {
+              throw settingsError(ERRORS.SETTINGS_CREDENTIAL_AMBIGUOUS);
+            }
+          }
+          endpoints.set(endpoint, candidate);
+        }
+        const sanitizedSettings = Object.assign({}, settings, {
+          ownProxies: sanitizedOwn,
+        });
+        const routingConfig = {
+          candidateGroups: {configured, directReplacement, onion},
+          flags: settings.flags,
+          providerCandidates: base.providerCandidates,
+          providerFallback: base.providerFallback,
+          rules: settings.rules,
+        };
+        let canonicalRoutingConfig;
+        try {
+          canonicalRoutingConfig = ProductConfig.canonicalRoutingConfig(
+              routingConfig,
+          ).value;
+        } catch (_error) {
+          throw settingsError(ERRORS.SETTINGS_MALFORMED);
+        }
+        return Object.freeze({
+          credentials: credentialEntries,
+          routingConfig: canonicalRoutingConfig,
+          settings: canonicalSettings(sanitizedSettings, true),
+        });
+
+      }
+
+      function createDefaultSettings() {
+
+        return clone(canonicalSettings({
+          schemaVersion: SCHEMA_VERSION,
+          rules: {direct: [], proxy: [], whitelist: []},
+          ownProxies: [],
+          localTor: {
+            type: 'SOCKS5',
+            host: 'localhost',
+            port: 9050,
+            proxyDNS: true,
+            failoverTimeoutSeconds: null,
+            useForProxyRules: false,
+            useForOnion: true,
+            useAsDirectReplacement: false,
+          },
+          torBrowser: {
+            type: 'SOCKS5',
+            host: 'localhost',
+            port: 9150,
+            proxyDNS: true,
+            failoverTimeoutSeconds: null,
+            useForProxyRules: false,
+            useForOnion: true,
+            useAsDirectReplacement: false,
+          },
+          warp: {
+            candidates: [
+              {
+                id: 'firefox-warp-socks5',
+                type: 'SOCKS5',
+                host: '127.0.0.1',
+                port: 40000,
+                proxyDNS: true,
+                failoverTimeoutSeconds: null,
+              },
+              {
+                id: 'firefox-warp-https',
+                type: 'HTTPS',
+                host: '127.0.0.1',
+                port: 40000,
+                proxyDNS: false,
+                failoverTimeoutSeconds: null,
+              },
+            ],
+            useForProxyRules: false,
+            useAsDirectReplacement: false,
+          },
+          flags: {
+            useProviderProxies: true,
+            ownProxiesOnlyForOwnSites: true,
+            replaceDirectWithProxy: false,
+            noDirect: false,
+          },
+        }, true));
+
+      }
+
+      function canonicalCommit(value) {
+
+        if (!hasExactKeys(value, COMMIT_KEYS) ||
+            value.schemaVersion !== COMMIT_SCHEMA_VERSION ||
+            !Number.isSafeInteger(value.revision) || value.revision < 1) {
+          throw settingsError(ERRORS.SETTINGS_STATE_UNAVAILABLE);
+        }
+        const settings = canonicalSettings(value.settings, true);
+        return Object.freeze({
+          schemaVersion: COMMIT_SCHEMA_VERSION,
+          revision: value.revision,
+          routingDescriptor: value.routingDescriptor,
+          settings,
+        });
+
+      }
+
+      function validMutation(value) {
+
+        return hasExactKeys(value, MUTATION_KEYS) &&
+          value.schemaVersion === MUTATION_SCHEMA_VERSION &&
+          value.status === 'WRITING';
+
+      }
+
+      function createController(options = {}) {
+
+        const storageArea = options.storageArea;
+        const sha256 = options.sha256;
+        const activationSnapshot = options.activationSnapshot;
+        if (!storageArea || typeof storageArea.get !== 'function' ||
+            typeof storageArea.set !== 'function' ||
+            typeof storageArea.remove !== 'function' ||
+            typeof sha256 !== 'function' ||
+            typeof activationSnapshot !== 'function') {
+          throw settingsError(ERRORS.INVALID_SETTINGS_DEPENDENCIES);
+        }
+        let queue = Promise.resolve();
+
+        function enqueue(operation) {
+
+          const result = queue.then(operation, operation);
+          queue = result.catch(() => undefined);
+          return result;
+
+        }
+
+        async function readStored() {
+
+          try {
+            return await storageArea.get([
+              ProductConfig.CONFIG_STORAGE_KEY,
+              ProductConfig.CREDENTIALS_STORAGE_KEY,
+              ProductConfig.SETTINGS_COMMIT_STORAGE_KEY,
+              ProductConfig.SETTINGS_TRANSACTION_STORAGE_KEY,
+            ]);
+          } catch (_error) {
+            throw settingsError(ERRORS.SETTINGS_STORAGE_FAILED);
+          }
+
+        }
+
+        function credentialsMap(value, descriptor) {
+
+          if (value === undefined) {
+            return new Map();
+          }
+          let canonical;
+          try {
+            canonical = ProductConfig.canonicalCredentialConfig(value);
+          } catch (_error) {
+            throw settingsError(ERRORS.SETTINGS_STATE_UNAVAILABLE);
+          }
+          if (!sameDescriptor(canonical.routingDescriptor, descriptor)) {
+            throw settingsError(ERRORS.SETTINGS_STATE_UNAVAILABLE);
+          }
+          return new Map(canonical.entries.map((entry) => [entry.authRef, entry]));
+
+        }
+
+        async function currentSnapshot(options = {}) {
+
+          const stored = await readStored();
+          const mutation = stored[ProductConfig.SETTINGS_TRANSACTION_STORAGE_KEY];
+          const rawCommit = stored[ProductConfig.SETTINGS_COMMIT_STORAGE_KEY];
+          if (mutation !== undefined) {
+            if (!validMutation(mutation) || rawCommit === undefined) {
+              if (!options.allowIncomplete) {
+                throw settingsError(ERRORS.SETTINGS_TRANSACTION_INCOMPLETE);
+              }
+              return {incomplete: true, stored};
+            }
+          }
+          const rawConfig = stored[ProductConfig.CONFIG_STORAGE_KEY];
+          if (rawConfig === undefined) {
+            throw settingsError(ERRORS.SETTINGS_STATE_UNAVAILABLE);
+          }
+          let verified;
+          try {
+            verified = await ProductConfig.verifyProductConfig(rawConfig, sha256);
+          } catch (_error) {
+            throw settingsError(ERRORS.SETTINGS_STATE_UNAVAILABLE);
+          }
+          const config = verified.config;
+          const expectedIdentity = ProductionProvider.datasetIdentity();
+          if (config.providerKey !== ProductionProvider.PROVIDER_KEY ||
+              config.datasetIdentity.providerKey !== expectedIdentity.providerKey ||
+              config.datasetIdentity.datasetVersion !==
+                expectedIdentity.datasetVersion ||
+              config.datasetIdentity.artifactSha256 !==
+                expectedIdentity.artifactSha256) {
+            throw settingsError(ERRORS.SETTINGS_DATASET_BINDING_FAILED);
+          }
+          const credentials = credentialsMap(
+              stored[ProductConfig.CREDENTIALS_STORAGE_KEY],
+              config.routingDescriptor,
+          );
+          let commit;
+          if (rawCommit === undefined) {
+            const expected = await ProductionProvider.createProductionProductConfig(
+                sha256,
+            );
+            if (!sameDescriptor(config.routingDescriptor,
+                expected.routingDescriptor)) {
+              throw settingsError(ERRORS.SETTINGS_STATE_UNAVAILABLE);
+            }
+            commit = {
+              schemaVersion: COMMIT_SCHEMA_VERSION,
+              revision: 0,
+              routingDescriptor: config.routingDescriptor,
+              settings: createDefaultSettings(),
+            };
+            if (credentials.size !== 0) {
+              throw settingsError(ERRORS.SETTINGS_STATE_UNAVAILABLE);
+            }
+          } else {
+            commit = canonicalCommit(rawCommit);
+            if (!sameDescriptor(commit.routingDescriptor,
+                config.routingDescriptor)) {
+              throw settingsError(ERRORS.SETTINGS_STATE_UNAVAILABLE);
+            }
+            const rebuilt = buildRoutingSnapshot(commit.settings, {
+              settings: commit.settings,
+              credentials,
+            });
+            const expected = await ProductConfig.createProductConfig({
+              configurationKey: ProductionProvider.CONFIGURATION_KEY,
+              configurationVersion: `settings-${commit.revision}`,
+              datasetIdentity: ProductionProvider.datasetIdentity(),
+              providerKey: ProductionProvider.PROVIDER_KEY,
+              routingConfig: rebuilt.routingConfig,
+              sha256,
+            });
+            if (!sameDescriptor(expected.routingDescriptor,
+                config.routingDescriptor)) {
+              throw settingsError(ERRORS.SETTINGS_STATE_UNAVAILABLE);
+            }
+            if (rebuilt.credentials.length !== credentials.size ||
+                rebuilt.credentials.some((entry) =>
+                  !credentials.has(entry.authRef))) {
+              throw settingsError(ERRORS.SETTINGS_STATE_UNAVAILABLE);
+            }
+          }
+          if (mutation !== undefined) {
+            try {
+              await storageArea.remove(
+                  ProductConfig.SETTINGS_TRANSACTION_STORAGE_KEY,
+              );
+            } catch (_error) {
+              throw settingsError(ERRORS.SETTINGS_TRANSACTION_INCOMPLETE);
+            }
+          }
+          return {commit, config, credentials, stored};
+
+        }
+
+        async function getUnchecked() {
+
+          const current = await currentSnapshot();
+          return Object.freeze({
+            revision: current.commit.revision,
+            settings: clone(current.commit.settings),
+          });
+
+        }
+
+        async function replaceUnchecked(expectedRevision, proposed) {
+
+          const activation = activationSnapshot();
+          if (!activation || activation.durableIntent !== 'OFF' ||
+              activation.runtimeState !== 'OFF' || activation.active === true) {
+            throw settingsError(ERRORS.SETTINGS_MUTATION_REQUIRES_OFF);
+          }
+          const settings = canonicalSettings(proposed, false);
+          const current = await currentSnapshot();
+          if (!Number.isSafeInteger(expectedRevision) || expectedRevision < 0 ||
+              current.commit.revision !== expectedRevision) {
+            throw settingsError(ERRORS.SETTINGS_REVISION_CONFLICT);
+          }
+          const nextRevision = expectedRevision + 1;
+          const built = buildRoutingSnapshot(settings, {
+            settings: current.commit.settings,
+            credentials: current.credentials,
+          });
+          const config = await ProductConfig.createProductConfig({
+            configurationKey: ProductionProvider.CONFIGURATION_KEY,
+            configurationVersion: `settings-${nextRevision}`,
+            datasetIdentity: ProductionProvider.datasetIdentity(),
+            providerKey: ProductionProvider.PROVIDER_KEY,
+            routingConfig: built.routingConfig,
+            sha256,
+          });
+          const credentialConfig = ProductConfig.canonicalCredentialConfig({
+            schemaVersion: ProductConfig.SCHEMA_VERSION,
+            routingDescriptor: config.routingDescriptor,
+            entries: built.credentials,
+          });
+          const commit = {
+            schemaVersion: COMMIT_SCHEMA_VERSION,
+            revision: nextRevision,
+            routingDescriptor: config.routingDescriptor,
+            settings: built.settings,
+          };
+          try {
+            await storageArea.set({
+              [ProductConfig.SETTINGS_TRANSACTION_STORAGE_KEY]: {
+                schemaVersion: MUTATION_SCHEMA_VERSION,
+                status: 'WRITING',
+              },
+            });
+            await storageArea.set({
+              [ProductConfig.CONFIG_STORAGE_KEY]: config,
+              [ProductConfig.CREDENTIALS_STORAGE_KEY]: credentialConfig,
+              [ProductConfig.SETTINGS_COMMIT_STORAGE_KEY]: commit,
+            });
+            await storageArea.remove(
+                ProductConfig.SETTINGS_TRANSACTION_STORAGE_KEY,
+            );
+          } catch (_error) {
+            throw settingsError(ERRORS.SETTINGS_STORAGE_FAILED);
+          }
+          return Object.freeze({
+            revision: nextRevision,
+            settings: clone(built.settings),
+          });
+
+        }
+
+        return Object.freeze({
+          initialize: () => enqueue(async () => {
+
+            try {
+              await currentSnapshot({allowIncomplete: true});
+              return Object.freeze({ok: true});
+            } catch (error) {
+              return Object.freeze({
+                ok: false,
+                code: error && error.code ? error.code :
+                  ERRORS.SETTINGS_STATE_UNAVAILABLE,
+              });
+            }
+
+          }),
+          get: () => enqueue(getUnchecked),
+          replace: (expectedRevision, settings) =>
+            enqueue(() => replaceUnchecked(expectedRevision, settings)),
+        });
+
+      }
+
+      return Object.freeze({
+        COMMIT_SCHEMA_VERSION,
+        ERRORS,
+        MAX_IDENTIFIER_LENGTH,
+        MAX_PUBLIC_PROXIES,
+        MUTATION_SCHEMA_VERSION,
+        SCHEMA_VERSION,
+        buildRoutingSnapshot,
+        canonicalSettings,
+        createController,
+        createDefaultSettings,
+      });
+
+    });

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/manifest.json
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/manifest.json
@@ -27,6 +27,7 @@
       "background/proxy-auth.js",
       "background/product-config.js",
       "background/production-provider.js",
+      "background/settings-control.js",
       "background/activation-controller.js",
       "background/event-page.js"
     ],

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/settings-control.test.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/settings-control.test.js
@@ -1,0 +1,568 @@
+'use strict';
+
+const Assert = require('node:assert');
+const Crypto = require('node:crypto');
+const Config = require('../background/product-config');
+const Production = require('../background/production-provider');
+const Settings = require('../background/settings-control');
+
+function sha256(bytes) {
+
+  return Promise.resolve(Crypto.createHash('sha256').update(bytes).digest('hex'));
+
+}
+
+function storage(initial = {}, options = {}) {
+
+  const values = structuredClone(initial);
+  const writes = [];
+  const removals = [];
+  let setCalls = 0;
+  return {
+    values,
+    writes,
+    removals,
+    area: {
+      async get(keys) {
+
+        const result = {};
+        for (const key of keys) {
+          if (Object.prototype.hasOwnProperty.call(values, key)) {
+            result[key] = structuredClone(values[key]);
+          }
+        }
+        return result;
+
+      },
+      async set(update) {
+
+        setCalls += 1;
+        writes.push(structuredClone(update));
+        if (options.failSetCall === setCalls) {
+          if (typeof options.partialSet === 'function') {
+            options.partialSet(values, update);
+          }
+          throw new Error('synthetic storage interruption');
+        }
+        Object.assign(values, structuredClone(update));
+
+      },
+      async remove(key) {
+
+        removals.push(key);
+        if (options.failRemove === true) {
+          throw new Error('synthetic remove failure');
+        }
+        delete values[key];
+
+      },
+    },
+  };
+
+}
+
+async function initialStorage(options = {}) {
+
+  const config = await Production.createProductionProductConfig(sha256);
+  return storage({[Config.CONFIG_STORAGE_KEY]: config}, options);
+
+}
+
+function activation(state = {}) {
+
+  return Object.assign({
+    active: false,
+    durableIntent: 'OFF',
+    runtimeState: 'OFF',
+  }, state);
+
+}
+
+function controller(store, state = activation()) {
+
+  return Settings.createController({
+    storageArea: store.area,
+    sha256,
+    activationSnapshot: () => state,
+  });
+
+}
+
+function ownProxy(overrides = {}) {
+
+  return Object.assign({
+    id: 'primary',
+    enabled: true,
+    type: 'HTTPS',
+    host: 'proxy.example',
+    port: 8443,
+    proxyDNS: false,
+    failoverTimeoutSeconds: null,
+    useAsDirectReplacement: false,
+    credentials: {mode: 'NONE'},
+  }, overrides);
+
+}
+
+async function rejectsCode(operation, code) {
+
+  await Assert.rejects(operation, (error) => error && error.code === code);
+
+}
+
+describe('Firefox production settings control plane', function() {
+
+  it('maps defaults exactly to the packaged production routing config', function() {
+
+    const settings = Settings.createDefaultSettings();
+    const built = Settings.buildRoutingSnapshot(settings);
+
+    Assert.deepStrictEqual(
+        built.routingConfig,
+        Production.createProductionRoutingConfig(),
+    );
+    Assert.deepStrictEqual(settings.flags, {
+      noDirect: false,
+      ownProxiesOnlyForOwnSites: true,
+      replaceDirectWithProxy: false,
+      useProviderProxies: true,
+    });
+
+  });
+
+  it('reads revision zero without exposing internal product identity', async function() {
+
+    const store = await initialStorage();
+    const result = await controller(store).get();
+
+    Assert.strictEqual(result.revision, 0);
+    Assert.strictEqual(result.settings.schemaVersion, 1);
+    for (const forbidden of [
+      'artifactSha256', 'authRef', 'configurationSha256', 'datasetIdentity',
+      'floorIdentity', 'providerKey',
+    ]) {
+      Assert.strictEqual(JSON.stringify(result).includes(forbidden), false);
+    }
+
+  });
+
+  it('preserves every routing flag and exact rule list', async function() {
+
+    const store = await initialStorage();
+    const api = controller(store);
+    const settings = Settings.createDefaultSettings();
+    settings.flags = {
+      noDirect: true,
+      ownProxiesOnlyForOwnSites: false,
+      replaceDirectWithProxy: true,
+      useProviderProxies: false,
+    };
+    settings.rules = {
+      direct: ['direct.example'],
+      proxy: ['*.proxy.example'],
+      whitelist: ['allowed.example'],
+    };
+    const replaced = await api.replace(0, settings);
+
+    Assert.deepStrictEqual(replaced.settings.flags, settings.flags);
+    Assert.deepStrictEqual(replaced.settings.rules, settings.rules);
+    Assert.strictEqual(replaced.revision, 1);
+
+  });
+
+  it('normalizes user host and wildcard input before persistence', function() {
+
+    const settings = Settings.createDefaultSettings();
+    settings.rules.direct = ['  *.Example.COM.  '];
+    settings.ownProxies = [ownProxy({host: ' Proxy.Example '})];
+    const canonical = Settings.canonicalSettings(settings);
+
+    Assert.deepStrictEqual(canonical.rules.direct, ['*.example.com']);
+    Assert.strictEqual(canonical.ownProxies[0].host, 'proxy.example');
+
+  });
+
+  it('preserves own, Tor, Tor Browser, and WARP candidate ordering', function() {
+
+    const settings = Settings.createDefaultSettings();
+    settings.ownProxies = [
+      ownProxy({id: 'own-a', host: 'a.example'}),
+      ownProxy({id: 'own-b', host: 'b.example'}),
+    ];
+    settings.localTor.useForProxyRules = true;
+    settings.torBrowser.useForProxyRules = true;
+    settings.warp.useForProxyRules = true;
+    const configured = Settings.buildRoutingSnapshot(settings)
+        .routingConfig.candidateGroups.configured;
+
+    Assert.deepStrictEqual(
+        configured.own.map((item) => item.id),
+        ['own-a', 'own-b'],
+    );
+    Assert.deepStrictEqual(
+        configured.localTor.map((item) => item.id),
+        ['anticensority-local-tor'],
+    );
+    Assert.deepStrictEqual(
+        configured.torBrowser.map((item) => item.id),
+        ['anticensority-tor-browser'],
+    );
+    Assert.deepStrictEqual(
+        configured.warp.map((item) => item.id),
+        ['firefox-warp-socks5', 'firefox-warp-https'],
+    );
+
+  });
+
+  it('keeps onion and Direct-replacement scopes explicit', function() {
+
+    const settings = Settings.createDefaultSettings();
+    settings.localTor.useForOnion = false;
+    settings.localTor.useAsDirectReplacement = true;
+    settings.torBrowser.useForOnion = true;
+    settings.warp.useAsDirectReplacement = true;
+    settings.ownProxies = [ownProxy({useAsDirectReplacement: true})];
+    const groups = Settings.buildRoutingSnapshot(settings)
+        .routingConfig.candidateGroups;
+
+    Assert.deepStrictEqual(groups.onion.localTor, []);
+    Assert.strictEqual(groups.onion.torBrowser.length, 1);
+    Assert.strictEqual(groups.directReplacement.own.length, 1);
+    Assert.strictEqual(groups.directReplacement.localTor.length, 1);
+    Assert.strictEqual(groups.directReplacement.warp.length, 2);
+
+  });
+
+  it('derives authRef internally and stores credentials separately', async function() {
+
+    const store = await initialStorage();
+    const settings = Settings.createDefaultSettings();
+    settings.ownProxies = [ownProxy({
+      credentials: {
+        mode: 'SET',
+        username: 'fixture-user',
+        password: 'synthetic-password',
+      },
+    })];
+    const result = await controller(store).replace(0, settings);
+    const config = store.values[Config.CONFIG_STORAGE_KEY];
+    const credentials = store.values[Config.CREDENTIALS_STORAGE_KEY];
+
+    Assert.deepStrictEqual(result.settings.ownProxies[0].credentials, {
+      mode: 'KEEP', username: 'fixture-user',
+    });
+    Assert.strictEqual(
+        config.routingConfig.candidateGroups.configured.own[0].authRef,
+        'own.primary',
+    );
+    Assert.deepStrictEqual(credentials.entries, [{
+      authRef: 'own.primary',
+      username: 'fixture-user',
+      password: 'synthetic-password',
+    }]);
+    Assert.strictEqual(JSON.stringify(config).includes('synthetic-password'), false);
+    Assert.strictEqual(JSON.stringify(result).includes('synthetic-password'), false);
+
+  });
+
+  it('round-trips a redacted credential only for the same exact proxy', async function() {
+
+    const store = await initialStorage();
+    const api = controller(store);
+    const settings = Settings.createDefaultSettings();
+    settings.ownProxies = [ownProxy({credentials: {
+      mode: 'SET', username: 'fixture-user', password: 'fixture-secret',
+    }})];
+    const first = await api.replace(0, settings);
+    first.settings.flags.noDirect = true;
+    const second = await api.replace(1, first.settings);
+
+    Assert.strictEqual(second.revision, 2);
+    Assert.strictEqual(
+        store.values[Config.CREDENTIALS_STORAGE_KEY].entries[0].password,
+        'fixture-secret',
+    );
+
+  });
+
+  it('rejects stale credential preservation after endpoint change', async function() {
+
+    const store = await initialStorage();
+    const api = controller(store);
+    const settings = Settings.createDefaultSettings();
+    settings.ownProxies = [ownProxy({credentials: {
+      mode: 'SET', username: 'fixture-user', password: 'fixture-secret',
+    }})];
+    const current = await api.replace(0, settings);
+    current.settings.ownProxies[0].port = 9443;
+
+    await rejectsCode(
+        api.replace(1, current.settings),
+        Settings.ERRORS.SETTINGS_CREDENTIAL_STALE,
+    );
+
+  });
+
+  it('does not persist an unreachable credential for a disabled proxy', function() {
+
+    const settings = Settings.createDefaultSettings();
+    settings.ownProxies = [ownProxy({
+      enabled: false,
+      credentials: {mode: 'SET', username: 'user', password: 'secret'},
+    })];
+    Assert.throws(
+        () => Settings.buildRoutingSnapshot(
+            Settings.canonicalSettings(settings),
+        ),
+        (error) => error.code ===
+          Settings.ERRORS.SETTINGS_CREDENTIAL_AMBIGUOUS,
+    );
+
+  });
+
+  it('removes credentials only through an explicit NONE intent', async function() {
+
+    const store = await initialStorage();
+    const api = controller(store);
+    const settings = Settings.createDefaultSettings();
+    settings.ownProxies = [ownProxy({credentials: {
+      mode: 'SET', username: 'fixture-user', password: 'fixture-secret',
+    }})];
+    const current = await api.replace(0, settings);
+    current.settings.ownProxies[0].credentials = {mode: 'NONE'};
+    await api.replace(1, current.settings);
+
+    Assert.deepStrictEqual(
+        store.values[Config.CREDENTIALS_STORAGE_KEY].entries,
+        [],
+    );
+    Assert.strictEqual(
+        store.values[Config.CONFIG_STORAGE_KEY]
+            .routingConfig.candidateGroups.configured.own[0].authRef,
+        null,
+    );
+
+  });
+
+  it('rejects unknown, malformed, future, and unsafe rule input', function() {
+
+    const defaults = Settings.createDefaultSettings();
+    const cases = [
+      Object.assign({}, defaults, {extra: true}),
+      Object.assign({}, defaults, {schemaVersion: 2}),
+      Object.assign({}, defaults, {rules: {
+        direct: ['HTTPS://unsafe.example'], proxy: [], whitelist: [],
+      }}),
+      Object.assign({}, defaults, {rules: {
+        direct: ['same.example', 'same.example'], proxy: [], whitelist: [],
+      }}),
+    ];
+    for (const value of cases) {
+      Assert.throws(
+          () => Settings.buildRoutingSnapshot(
+              Settings.canonicalSettings(value),
+          ),
+      );
+    }
+
+  });
+
+  it('rejects duplicate identifiers and ambiguous proxy endpoints', function() {
+
+    const duplicateId = Settings.createDefaultSettings();
+    duplicateId.ownProxies = [ownProxy(), ownProxy({host: 'other.example'})];
+    Assert.throws(() => Settings.canonicalSettings(duplicateId));
+
+    const duplicateEndpoint = Settings.createDefaultSettings();
+    duplicateEndpoint.ownProxies = [
+      ownProxy({id: 'a'}), ownProxy({id: 'b'}),
+    ];
+    Assert.throws(() => Settings.buildRoutingSnapshot(
+        Settings.canonicalSettings(duplicateEndpoint),
+    ), (error) => error.code === Settings.ERRORS.SETTINGS_CREDENTIAL_AMBIGUOUS);
+
+  });
+
+  it('rejects password-like unknown fields outside the credential record', function() {
+
+    const settings = Settings.createDefaultSettings();
+    settings.ownProxies = [Object.assign(ownProxy(), {
+      password: 'must-not-be-accepted',
+    })];
+    Assert.throws(() => Settings.canonicalSettings(settings));
+
+  });
+
+  it('enforces optimistic revision checks across serialized writes', async function() {
+
+    const store = await initialStorage();
+    const api = controller(store);
+    const first = Settings.createDefaultSettings();
+    const second = Settings.createDefaultSettings();
+    first.flags.noDirect = true;
+    second.flags.replaceDirectWithProxy = true;
+    const results = await Promise.allSettled([
+      api.replace(0, first),
+      api.replace(0, second),
+    ]);
+
+    Assert.strictEqual(results.filter((item) => item.status === 'fulfilled').length, 1);
+    Assert.strictEqual(results.find((item) => item.status === 'rejected')
+        .reason.code, Settings.ERRORS.SETTINGS_REVISION_CONFLICT);
+
+  });
+
+  it('rejects writes in ACTIVE, INITIALIZING, or recovery-blocked states', async function() {
+
+    for (const state of [
+      activation({active: true, durableIntent: 'ON', runtimeState: 'READY'}),
+      activation({runtimeState: 'INITIALIZING'}),
+      activation({durableIntent: 'ON', runtimeState: 'FAILED'}),
+    ]) {
+      const store = await initialStorage();
+      await rejectsCode(
+          controller(store, state).replace(0, Settings.createDefaultSettings()),
+          Settings.ERRORS.SETTINGS_MUTATION_REQUIRES_OFF,
+      );
+      Assert.strictEqual(store.writes.length, 0);
+    }
+
+  });
+
+  it('writes a mutation marker before one descriptor-bound record set', async function() {
+
+    const store = await initialStorage();
+    await controller(store).replace(0, Settings.createDefaultSettings());
+
+    Assert.strictEqual(store.writes.length, 2);
+    Assert.deepStrictEqual(store.writes[0], {
+      [Config.SETTINGS_TRANSACTION_STORAGE_KEY]: {
+        schemaVersion: 1, status: 'WRITING',
+      },
+    });
+    Assert.deepStrictEqual(Object.keys(store.writes[1]).sort(), [
+      Config.CONFIG_STORAGE_KEY,
+      Config.CREDENTIALS_STORAGE_KEY,
+      Config.SETTINGS_COMMIT_STORAGE_KEY,
+    ].sort());
+    Assert.strictEqual(store.removals.length, 1);
+
+  });
+
+  it('blocks activation when a settings write is interrupted', async function() {
+
+    const store = await initialStorage({
+      failSetCall: 2,
+      partialSet(values, update) {
+
+        values[Config.CONFIG_STORAGE_KEY] = structuredClone(
+            update[Config.CONFIG_STORAGE_KEY],
+        );
+        values[Config.SETTINGS_COMMIT_STORAGE_KEY] = structuredClone(
+            update[Config.SETTINGS_COMMIT_STORAGE_KEY],
+        );
+
+      },
+    });
+    await rejectsCode(
+        controller(store).replace(0, Settings.createDefaultSettings()),
+        Settings.ERRORS.SETTINGS_STORAGE_FAILED,
+    );
+    Assert.strictEqual(
+        Config.SETTINGS_TRANSACTION_STORAGE_KEY in store.values,
+        true,
+    );
+    Assert.strictEqual(
+        Config.CREDENTIALS_STORAGE_KEY in store.values,
+        false,
+    );
+    const factory = Config.createActivationFactory({
+      storageArea: store.area,
+      createDatasetStore: () => ({loadVerifications() {}}),
+      sha256,
+    });
+    await Assert.rejects(factory(), (error) =>
+      error.code === Config.ERRORS.PRODUCT_CONFIG_UPDATE_INCOMPLETE);
+
+  });
+
+  it('clears a completed crash marker only after all descriptors match', async function() {
+
+    const store = await initialStorage({failRemove: true});
+    await rejectsCode(
+        controller(store).replace(0, Settings.createDefaultSettings()),
+        Settings.ERRORS.SETTINGS_STORAGE_FAILED,
+    );
+    Assert.strictEqual(
+        Config.SETTINGS_TRANSACTION_STORAGE_KEY in store.values,
+        true,
+    );
+    const resumed = storage(store.values);
+    const result = await controller(resumed).get();
+
+    Assert.strictEqual(result.revision, 1);
+    Assert.strictEqual(
+        Config.SETTINGS_TRANSACTION_STORAGE_KEY in resumed.values,
+        false,
+    );
+
+  });
+
+  it('never pairs a committed settings record with old credentials', async function() {
+
+    const store = await initialStorage();
+    const api = controller(store);
+    const settings = Settings.createDefaultSettings();
+    settings.ownProxies = [ownProxy({credentials: {
+      mode: 'SET', username: 'fixture-user', password: 'fixture-secret',
+    }})];
+    await api.replace(0, settings);
+    store.values[Config.CREDENTIALS_STORAGE_KEY].routingDescriptor = {
+      schemaVersion: 1,
+      configurationKey: 'old',
+      configurationVersion: 'old',
+      configurationSha256: '0'.repeat(64),
+    };
+
+    await rejectsCode(api.get(), Settings.ERRORS.SETTINGS_STATE_UNAVAILABLE);
+    const factory = Config.createActivationFactory({
+      storageArea: store.area,
+      createDatasetStore: () => ({loadVerifications() {}}),
+      sha256,
+    });
+    await Assert.rejects(factory(), (error) =>
+      error.code === Config.ERRORS.CREDENTIAL_CONFIG_DESCRIPTOR_MISMATCH);
+
+  });
+
+  it('survives controller recreation with the exact sanitized settings', async function() {
+
+    const store = await initialStorage();
+    const settings = Settings.createDefaultSettings();
+    settings.rules.proxy = ['*.proxy.example'];
+    settings.ownProxies = [ownProxy()];
+    await controller(store).replace(0, settings);
+    const recreated = await controller(store).get();
+
+    Assert.strictEqual(recreated.revision, 1);
+    Assert.deepStrictEqual(recreated.settings.rules.proxy, ['*.proxy.example']);
+    Assert.strictEqual(recreated.settings.ownProxies[0].id, 'primary');
+
+  });
+
+  it('has no browser, network, logging, or dataset mutation dependency', function() {
+
+    const source = require('node:fs').readFileSync(
+        require.resolve('../background/settings-control'),
+        'utf8',
+    );
+    for (const forbidden of [
+      'browser.', 'chrome.', 'fetch(', 'console.', 'promoteStaged',
+      'commitPackagedBaseline', 'proxy.settings',
+    ]) {
+      Assert.strictEqual(source.includes(forbidden), false, forbidden);
+    }
+
+  });
+
+});

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/skeleton.test.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/skeleton.test.js
@@ -1,11 +1,14 @@
 'use strict';
 
 const Assert = require('node:assert');
+const Crypto = require('node:crypto');
 const Fs = require('node:fs');
 const Path = require('node:path');
 const Vm = require('node:vm');
 const DatasetStore = require('../background/dataset-store');
 const OffState = require('../background/off-state');
+const ProductConfig = require('../background/product-config');
+const ProductionProvider = require('../background/production-provider');
 const Routing = require('../../extension-mv3-common/routing-contract');
 const Helpers = require('./dataset-test-helpers');
 
@@ -71,6 +74,10 @@ const productionProviderSource = Fs.readFileSync(
     Path.join(sourceRoot, 'background', 'production-provider.js'),
     'utf8',
 );
+const settingsControlSource = Fs.readFileSync(
+    Path.join(sourceRoot, 'background', 'settings-control.js'),
+    'utf8',
+);
 const activationControllerSource = Fs.readFileSync(
     Path.join(sourceRoot, 'background', 'activation-controller.js'),
     'utf8',
@@ -105,6 +112,11 @@ function makeStorage(initialValue) {
 
         writes.push(update);
         Object.assign(values, update);
+
+      },
+      async remove(key) {
+
+        delete values[key];
 
       },
     },
@@ -260,6 +272,12 @@ function startEventPage(options = {}) {
           return storage.area.set(update);
 
         },
+        async remove(key) {
+
+          events.push('storage-remove');
+          return storage.area.remove(key);
+
+        },
       },
     },
     webRequest: {
@@ -299,6 +317,8 @@ function startEventPage(options = {}) {
   };
   const context = Vm.createContext({
     browser,
+    TextDecoder,
+    TextEncoder,
     indexedDB: {
       open() {
 
@@ -307,6 +327,7 @@ function startEventPage(options = {}) {
       },
     },
     crypto: {
+      subtle: Crypto.webcrypto.subtle,
       randomUUID: () => options.bootId || 'test-boot',
       getRandomValues(words) {
 
@@ -348,6 +369,9 @@ function startEventPage(options = {}) {
   Vm.runInContext(productConfigSource, context, {filename: 'product-config.js'});
   Vm.runInContext(productionProviderSource, context, {
     filename: 'production-provider.js',
+  });
+  Vm.runInContext(settingsControlSource, context, {
+    filename: 'settings-control.js',
   });
   context.rucbFirefoxProductionProvider = Object.freeze(Object.assign(
       {},
@@ -428,6 +452,7 @@ describe('Firefox MV3 production control package', function() {
         'background/proxy-auth.js',
         'background/product-config.js',
         'background/production-provider.js',
+        'background/settings-control.js',
         'background/activation-controller.js',
         'background/event-page.js',
       ],
@@ -587,7 +612,7 @@ describe('Firefox MV3 production control package', function() {
           'completed-listener-registered',
           'error-listener-registered',
           'listener-registered',
-          'storage-get',
+          'product-config-storage-get',
         ]);
         Assert.deepStrictEqual(
             JSON.parse(JSON.stringify(
@@ -735,7 +760,7 @@ describe('Firefox MV3 production control package', function() {
         Assert.strictEqual(
             eventPage.events.filter((event) =>
               event === 'product-config-storage-get').length,
-            1,
+            2,
         );
 
       });
@@ -956,6 +981,197 @@ describe('Firefox MV3 production control package', function() {
               false,
           );
         }
+
+      });
+
+  it('exposes strict redacted production settings RPCs', async function() {
+
+    const productConfig = await ProductionProvider.createProductionProductConfig(
+        async (bytes) => Helpers.sha256(Buffer.from(bytes)),
+    );
+    const storage = makeStorage();
+    storage.values[ProductConfig.CONFIG_STORAGE_KEY] = productConfig;
+    const eventPage = startEventPage({storage});
+    await eventPage.ready();
+    const invalidGet = await eventPage.send({
+      type: 'firefox.settings.get',
+      extra: true,
+    });
+    Assert.deepStrictEqual(invalidGet, {
+      ok: false, error: {code: 'INVALID_RPC_REQUEST'},
+    });
+    const current = await eventPage.send({type: 'firefox.settings.get'});
+    Assert.strictEqual(current.ok, true);
+    Assert.strictEqual(current.result.revision, 0);
+    current.result.settings.ownProxies = [{
+      id: 'fixture-authenticated',
+      enabled: true,
+      type: 'HTTP',
+      host: '127.0.0.1',
+      port: 18080,
+      proxyDNS: false,
+      failoverTimeoutSeconds: null,
+      useAsDirectReplacement: false,
+      credentials: {
+        mode: 'SET',
+        username: 'fixture-user',
+        password: 'fixture-password',
+      },
+    }];
+    const replaced = await eventPage.send({
+      type: 'firefox.settings.replace',
+      expectedRevision: 0,
+      settings: current.result.settings,
+    });
+
+    Assert.strictEqual(replaced.ok, true);
+    Assert.strictEqual(replaced.result.revision, 1);
+    Assert.deepStrictEqual(
+        replaced.result.settings.ownProxies[0].credentials,
+        {mode: 'KEEP', username: 'fixture-user'},
+    );
+    Assert.strictEqual(JSON.stringify(replaced).includes('fixture-password'), false);
+    Assert.strictEqual(
+        JSON.stringify(storage.values[ProductConfig.CONFIG_STORAGE_KEY])
+            .includes('fixture-password'),
+        false,
+    );
+    Assert.strictEqual(
+        storage.values[ProductConfig.CREDENTIALS_STORAGE_KEY]
+            .entries[0].password,
+        'fixture-password',
+    );
+
+  });
+
+  it('serializes settings writes and rejects stale revisions', async function() {
+
+    const productConfig = await ProductionProvider.createProductionProductConfig(
+        async (bytes) => Helpers.sha256(Buffer.from(bytes)),
+    );
+    const storage = makeStorage();
+    storage.values[ProductConfig.CONFIG_STORAGE_KEY] = productConfig;
+    const eventPage = startEventPage({storage});
+    const current = await eventPage.send({type: 'firefox.settings.get'});
+    const first = JSON.parse(JSON.stringify(current.result.settings));
+    const second = JSON.parse(JSON.stringify(current.result.settings));
+    first.flags.noDirect = true;
+    second.flags.replaceDirectWithProxy = true;
+    const results = await Promise.all([
+      eventPage.send({
+        type: 'firefox.settings.replace',
+        expectedRevision: 0,
+        settings: first,
+      }),
+      eventPage.send({
+        type: 'firefox.settings.replace',
+        expectedRevision: 0,
+        settings: second,
+      }),
+    ]);
+
+    Assert.strictEqual(results.filter((result) => result.ok).length, 1);
+    Assert.deepStrictEqual(
+        results.find((result) => !result.ok),
+        {ok: false, error: {code: 'SETTINGS_REVISION_CONFLICT'}},
+    );
+
+  });
+
+  it('rejects settings mutation while production routing is active',
+      async function() {
+
+        const productConfig = await ProductionProvider.createProductionProductConfig(
+            async (bytes) => Helpers.sha256(Buffer.from(bytes)),
+        );
+        const storage = makeStorage();
+        storage.values[ProductConfig.CONFIG_STORAGE_KEY] = productConfig;
+        const prepared = await preparedActivation();
+        const eventPage = startEventPage({
+          storage,
+          privateWindowAccess: true,
+          activationFactory: async () => prepared,
+        });
+        const current = await eventPage.send({type: 'firefox.settings.get'});
+        Assert.strictEqual((await eventPage.send({
+          type: 'firefox.activation.apply',
+        })).ok, true);
+        const result = await eventPage.send({
+          type: 'firefox.settings.replace',
+          expectedRevision: current.result.revision,
+          settings: current.result.settings,
+        });
+
+        Assert.deepStrictEqual(result, {
+          ok: false,
+          error: {code: 'SETTINGS_MUTATION_REQUIRES_OFF'},
+        });
+
+      });
+
+  it('supports Clear then settings replace then a new explicit Apply',
+      async function() {
+
+        const productConfig = await ProductionProvider.createProductionProductConfig(
+            async (bytes) => Helpers.sha256(Buffer.from(bytes)),
+        );
+        const storage = makeStorage();
+        storage.values[ProductConfig.CONFIG_STORAGE_KEY] = productConfig;
+        const prepared = await preparedActivation();
+        const eventPage = startEventPage({
+          storage,
+          privateWindowAccess: true,
+          activationFactory: async () => prepared,
+        });
+        Assert.strictEqual((await eventPage.send({
+          type: 'firefox.activation.apply',
+        })).ok, true);
+        Assert.strictEqual((await eventPage.send({
+          type: 'firefox.activation.clear',
+        })).ok, true);
+        const current = await eventPage.send({type: 'firefox.settings.get'});
+        current.result.settings.flags.noDirect = true;
+        Assert.strictEqual((await eventPage.send({
+          type: 'firefox.settings.replace',
+          expectedRevision: current.result.revision,
+          settings: current.result.settings,
+        })).ok, true);
+        Assert.strictEqual((await eventPage.send({
+          type: 'firefox.activation.apply',
+        })).ok, true);
+        Assert.strictEqual(eventPage.proxySettingsCalls.set, 2);
+        Assert.strictEqual(eventPage.proxySettingsCalls.clear, 1);
+
+      });
+
+  it('reloads committed settings after genuine event-page recreation',
+      async function() {
+
+        const productConfig = await ProductionProvider.createProductionProductConfig(
+            async (bytes) => Helpers.sha256(Buffer.from(bytes)),
+        );
+        const storage = makeStorage();
+        storage.values[ProductConfig.CONFIG_STORAGE_KEY] = productConfig;
+        const first = startEventPage({storage, bootId: 'settings-boot-one'});
+        const current = await first.send({type: 'firefox.settings.get'});
+        current.result.settings.rules.direct = ['direct.example'];
+        Assert.strictEqual((await first.send({
+          type: 'firefox.settings.replace',
+          expectedRevision: 0,
+          settings: current.result.settings,
+        })).ok, true);
+        const second = startEventPage({storage, bootId: 'settings-boot-two'});
+        const restored = await second.send({type: 'firefox.settings.get'});
+
+        Assert.strictEqual(restored.result.revision, 1);
+        Assert.deepStrictEqual(
+            restored.result.settings.rules.direct,
+            ['direct.example'],
+        );
+        Assert.notStrictEqual(
+            first.context.rucbFirefoxSkeletonRuntime.bootId,
+            second.context.rucbFirefoxSkeletonRuntime.bootId,
+        );
 
       });
 

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/verify-package.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/verify-package.js
@@ -22,6 +22,7 @@ const EXPECTED_FILES = Object.freeze([
   'background/proxy-auth.js',
   'background/proxy-control.js',
   'background/routing-adapter.js',
+  'background/settings-control.js',
   'manifest.json',
   'provider/anticensority-hosts-v1.envelope.json',
   'provider/anticensority-hosts-v1.json',
@@ -105,6 +106,7 @@ function verifyPackage(packageRoot, sourceRoot) {
     'background/proxy-auth.js',
     'background/product-config.js',
     'background/production-provider.js',
+    'background/settings-control.js',
     'background/activation-controller.js',
     'background/event-page.js',
   ]);


### PR DESCRIPTION
## Summary

- adds strict `firefox.settings.get` and `firefox.settings.replace` production RPCs
- supports Direct, Proxy, and whitelist rules; own proxies; local Tor; Tor Browser; WARP; and the four browser-neutral routing flags
- derives provider/dataset bindings, routing descriptors, hashes, floor identity, and `authRef` values internally
- separates proxy passwords into the existing descriptor-bound credential record and never returns them through RPC
- permits complete configuration replacement only while durable and runtime state are both OFF
- serializes Apply, Clear, and settings operations and uses optimistic revisions plus a write-ahead marker to fail closed across interrupted writes
- adds no UI, updater, remote configuration, dataset mutation, permissions, or dependencies

## Chromium parity

The Firefox settings map to the existing browser-neutral routing contract and retain the current precedence and candidate order: explicit Direct, explicit Proxy, whitelist miss, `.onion`, then provider; own proxy, local Tor, Tor Browser, then WARP. Safe defaults remain provider proxies enabled, own proxies limited to own sites, Direct replacement disabled, and `noDirect` disabled. Exact-host and `*.example` base/subdomain behavior are unchanged.

The Firefox schema exposes explicit Tor scope booleans rather than Chromium's current UI-level Tor master toggle. This preserves the same routing inputs without introducing a separate A/P/D implementation. Chromium PAC/runtime code is unchanged.

## Persistence and credential safety

One settings mutation writes a marker first, then product config, credential record, and redacted settings commit together. Apply/recovery rejects any incomplete marker or descriptor mismatch. A completed crash marker is removed only after exact config, credential, dataset, and settings reconstruction succeeds. Passwords never enter routing descriptors, settings responses, logs, errors, dataset metadata, or diagnostics.

## Verification

- supply-chain direct pins: 11; verifier tests: 12/12
- PAC: 26/26
- Chromium MV3: 428/428
- Firefox deterministic: 260/260
- aggregate: 701/701
- Chromium package: 70/70 files, added 0, missing 0, SHA-256 differences 0
- Firefox package: 18 -> 19 files; only `background/settings-control.js` was added; manifest, event page, and product config changed as required
- Chrome Stable MV3 smoke: passed
- Firefox 154.0.1 lifecycle smoke: passed with genuine event-page recreation and durable OFF
- Firefox 154.0.1 settings/routing QA through the production RPC: explicit Direct/Proxy, provider match/miss, own/Tor/Tor Browser/WARP routing, authenticated HTTP, Clear, and recovered READY all passed
- unexpected protected-origin contacts: 0
- credential leaks: 0
- external fixture traffic: 0
- production npm audit: 0 vulnerabilities
- maintained full audit: 2 low dev-only Mocha/jsdiff findings, unchanged from main
- dependencies and lockfile: unchanged

Production remains local-only: the packaged provider dataset and Apply/Clear/recovery paths are reused, but no settings UI or network-supplied configuration is introduced.
