### PR TITLE
Prepare dual-browser 0.0.4.0 release candidate

### DIFF
--- a/.github/workflows/mv3.yml
+++ b/.github/workflows/mv3.yml
@@ -81,6 +81,9 @@ jobs:
       - name: Build MV3
         run: npm --prefix ./extensions/chromium/runet-censorship-bypass run build:mv3
 
+      - name: Build deterministic Chromium release candidate
+        run: npm --prefix ./extensions/chromium/runet-censorship-bypass run release:chromium
+
       - name: Run Chrome Stable MV3 browser smoke
         run: npm --prefix ./extensions/chromium/runet-censorship-bypass run test:browser:mv3
 
@@ -119,7 +122,9 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: runet-censorship-bypass-mv3-${{ github.sha }}
-          path: extensions/chromium/runet-censorship-bypass/build/extension-chromium-mv3
+          path: |
+            extensions/chromium/runet-censorship-bypass/build/extension-chromium-mv3
+            extensions/chromium/runet-censorship-bypass/dist/chromium-release
           if-no-files-found: error
           retention-days: 7
 

--- a/docs/development/FIREFOX_MV3_ARCHITECTURE.md
+++ b/docs/development/FIREFOX_MV3_ARCHITECTURE.md
@@ -263,7 +263,7 @@ provider artifact и default product configuration присутствуют; upd
 Production Gecko ID — неизменяемый UUIDv4
 `{adf5f697-1149-42a2-92eb-c163cb9a4146}`. Он создан для этого Firefox MV3
 продукта и не переиспользует legacy AMO identity. Firefox следует общей версии
-репозитория: текущий release candidate имеет manifest version `0.0.3.0`,
+репозитория: текущий release candidate имеет manifest version `0.0.4.0`,
 совпадающую с `storeVersion` Chromium release train; следующий публичный
 release обновляет обе версии согласованно через обычный release-процесс.
 

--- a/docs/development/FIREFOX_RELEASE_BUILD.md
+++ b/docs/development/FIREFOX_RELEASE_BUILD.md
@@ -2,7 +2,7 @@
 
 Firefox MV3 follows the repository release train. Its manifest version is the
 same `0.0.<storeVersion>` derived from `src/templates-data.js` for Chromium;
-the current candidate is `0.0.3.0`. A future public release updates the shared
+the current candidate is `0.0.4.0`. A future public release updates the shared
 release version through the normal release process rather than creating an
 independent Firefox-only version.
 
@@ -29,10 +29,10 @@ package allowlist/integrity verifier after each build, and compares both
 release sets byte for byte. It refuses a dirty tracked tree and refuses to
 overwrite an existing release output. It then writes:
 
-- `dist/firefox-release/runet-censorship-bypass-firefox-0.0.3.0.xpi` — unsigned
+- `dist/firefox-release/runet-censorship-bypass-firefox-0.0.4.0.xpi` — unsigned
   release candidate with `manifest.json` at archive root;
 - the matching `.xpi.sha256` file;
-- `runet-censorship-bypass-firefox-0.0.3.0-source.zip` — all tracked source
+- `runet-censorship-bypass-firefox-0.0.4.0-source.zip` — all tracked source
   files needed for review and reproduction, under one versioned root;
 - the matching source-archive `.sha256` file.
 
@@ -57,7 +57,7 @@ version recorded in the PR. For this candidate the command is:
 
 ```powershell
 npx --yes --ignore-scripts addons-linter@10.10.0 `
-  "$Project\dist\firefox-release\runet-censorship-bypass-firefox-0.0.3.0.xpi"
+  "$Project\dist\firefox-release\runet-censorship-bypass-firefox-0.0.4.0.xpi"
 ```
 
 This command is an explicit release audit tool invocation; it is not a project

--- a/docs/development/RELEASE_PROCESS.md
+++ b/docs/development/RELEASE_PROCESS.md
@@ -41,6 +41,7 @@ npm --prefix $Project run test:pac
 npm --prefix $Project run test:mv3
 npm --prefix $Project run lint:mv3
 npm --prefix $Project run build:mv3
+npm --prefix $Project run release:chromium
 npm --prefix $Project run test:firefox
 npm --prefix $Project run lint:firefox
 npm --prefix $Project run build:firefox
@@ -71,7 +72,8 @@ artifact этого run. Dispatch другой ветки не является 
 - aggregate `verify`;
 - runtime icons и package integrity внутри build;
 - exact-output и tracked-worktree checks;
-- trusted-main-only Chromium и Firefox artifact uploads.
+- trusted-main-only Chromium и Firefox artifact uploads, включая
+  детерминированные Chromium ZIP/checksum и Firefox XPI/source/checksums.
 
 Если обязательного шага нет, release блокирован до исправления workflow и
 нового успешного trusted-main run. Артефакт PR не является trusted release
@@ -112,7 +114,10 @@ unsigned XPI не считается пользовательским release pa
 
 Пакуется содержимое trusted artifact directory, а не сам каталог. После
 распаковки `manifest.json` должен находиться в корне ZIP. Не допускается ни
-одного runtime-byte отличия от проверенного artifact.
+одного runtime-byte отличия от проверенного artifact. Локальный release
+candidate создаётся детерминированно командой `npm --prefix $Project run
+release:chromium`: два независимых build сравниваются побайтово, а ZIP и
+checksum записываются в `dist/chromium-release`.
 
 Пример упаковки:
 

--- a/extensions/chromium/runet-censorship-bypass/package-lock.json
+++ b/extensions/chromium/runet-censorship-bypass/package-lock.json
@@ -719,6 +719,13 @@
         "node": ">= 8"
       }
     },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
     "node_modules/arr-diff": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
@@ -2273,6 +2280,29 @@
         "@pkgjs/parseargs": "^0.11.0"
       }
     },
+    "node_modules/js-yaml": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -2487,13 +2517,6 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
-    "node_modules/mocha/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
-      "license": "Python-2.0"
-    },
     "node_modules/mocha/node_modules/brace-expansion": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
@@ -2589,29 +2612,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/mocha/node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/mocha/node_modules/minimatch": {
@@ -4211,6 +4211,12 @@
         "picomatch": "^2.0.4"
       }
     },
+    "argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
+    },
     "arr-diff": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
@@ -5244,6 +5250,15 @@
         "@pkgjs/parseargs": "^0.11.0"
       }
     },
+    "js-yaml": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
+      "dev": true,
+      "requires": {
+        "argparse": "^2.0.1"
+      }
+    },
     "json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -5387,7 +5402,7 @@
         "glob": "^10.4.5",
         "he": "^1.2.0",
         "is-path-inside": "^3.0.3",
-        "js-yaml": "^4.1.0",
+        "js-yaml": "4.3.2",
         "log-symbols": "^4.1.0",
         "minimatch": "^9.0.5",
         "ms": "^2.1.3",
@@ -5401,12 +5416,6 @@
         "yargs-unparser": "^2.0.0"
       },
       "dependencies": {
-        "argparse": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-          "dev": true
-        },
         "brace-expansion": {
           "version": "2.1.4",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
@@ -5467,15 +5476,6 @@
             "minipass": "^7.1.2",
             "package-json-from-dist": "^1.0.0",
             "path-scurry": "^1.11.1"
-          }
-        },
-        "js-yaml": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-          "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
-          "dev": true,
-          "requires": {
-            "argparse": "^2.0.1"
           }
         },
         "minimatch": {

--- a/extensions/chromium/runet-censorship-bypass/package.json
+++ b/extensions/chromium/runet-censorship-bypass/package.json
@@ -14,6 +14,7 @@
     "test:firefox": "mocha --recursive ./src/extension-firefox-mv3/test/*.test.js",
     "test:browser:mv3": "node ./src/extension-chromium-mv3/test/chrome-stable-smoke.js",
     "test:browser:firefox-lifecycle": "node ./src/extension-firefox-mv3/test/firefox-lifecycle-smoke.js",
+    "release:chromium": "node ./scripts/package-chromium-release.js --verify-rebuild",
     "release:firefox": "node ./scripts/package-firefox-release.js --verify-rebuild",
     "verify:mv3": "npm run lint:mv3 && npm run test:mv3 && npm run build:mv3",
     "verify:firefox": "npm run lint:firefox && npm run test:firefox && npm run build:firefox",
@@ -37,6 +38,7 @@
     "tldts": "7.4.8"
   },
   "overrides": {
+    "js-yaml": "4.3.2",
     "mocha": {
       "serialize-javascript": "7.0.5"
     }

--- a/extensions/chromium/runet-censorship-bypass/scripts/package-chromium-release.js
+++ b/extensions/chromium/runet-censorship-bypass/scripts/package-chromium-release.js
@@ -1,0 +1,149 @@
+'use strict';
+
+const Assert = require('node:assert');
+const ChildProcess = require('node:child_process');
+const Crypto = require('node:crypto');
+const Fs = require('node:fs');
+const Path = require('node:path');
+const Templates = require('../src/templates-data');
+const FirefoxRelease = require('./package-firefox-release');
+
+const PROJECT_ROOT = Path.resolve(__dirname, '..');
+const REPOSITORY_ROOT = Path.resolve(PROJECT_ROOT, '..', '..', '..');
+const BUILD_ROOT = Path.join(PROJECT_ROOT, 'build', 'extension-chromium-mv3');
+const RELEASE_ROOT = Path.join(PROJECT_ROOT, 'dist', 'chromium-release');
+
+function runGit(args) {
+
+  const result = ChildProcess.spawnSync('git', args, {
+    cwd: REPOSITORY_ROOT,
+    encoding: 'utf8',
+    maxBuffer: 32 * 1024 * 1024,
+    windowsHide: true,
+  });
+  if (result.status !== 0) {
+    throw new Error('Git command failed while creating the Chromium release.');
+  }
+  return result.stdout.trim();
+
+}
+
+function assertCleanTrackedTree() {
+
+  if (runGit(['status', '--porcelain=v1', '--untracked-files=normal']) !== '') {
+    throw new Error('Chromium release packaging requires a clean tracked tree.');
+  }
+
+}
+
+function runChromiumBuild() {
+
+  for (const args of [
+    ['./node_modules/gulp/bin/gulp.js', 'buildChromiumMv3'],
+    ['./src/extension-chromium-mv3/test/verify-runtime-icons.js'],
+    ['./src/extension-chromium-mv3/test/verify-package-integrity.js'],
+  ]) {
+    const result = ChildProcess.spawnSync(process.execPath, args, {
+      cwd: PROJECT_ROOT,
+      stdio: 'inherit',
+      windowsHide: true,
+    });
+    if (result.status !== 0) {
+      throw new Error('Chromium release build failed.');
+    }
+  }
+
+}
+
+function releaseIdentity() {
+
+  const manifest = JSON.parse(Fs.readFileSync(
+      Path.join(BUILD_ROOT, 'manifest.json'),
+      'utf8',
+  ));
+  const expectedVersion = `0.0.${Templates.contexts.chromiumMv3.storeVersion}`;
+  const expectedVersionName = `0.0.${Templates.contexts.chromiumMv3.version}`;
+  Assert.strictEqual(manifest.version, expectedVersion);
+  Assert.strictEqual(manifest.version_name, expectedVersionName);
+  const shortSha = runGit(['rev-parse', '--short=7', 'HEAD']);
+  Assert.match(shortSha, /^[0-9a-f]{7}$/u);
+  return Object.freeze({shortSha, version: manifest.version});
+
+}
+
+function createRelease() {
+
+  const identity = releaseIdentity();
+  const filename = [
+    'runet-censorship-bypass-mv3',
+    identity.version,
+    identity.shortSha,
+  ].join('-') + '.zip';
+  const archive = FirefoxRelease.createDeterministicZip(
+      FirefoxRelease.listDirectoryEntries(BUILD_ROOT),
+  );
+  const sha256 = Crypto.createHash('sha256').update(archive).digest('hex');
+  return Object.freeze({archive, filename, sha256, ...identity});
+
+}
+
+function writeRelease(release) {
+
+  if (Fs.existsSync(RELEASE_ROOT) && Fs.readdirSync(RELEASE_ROOT).length !== 0) {
+    throw new Error('Chromium release output already exists; refusing overwrite.');
+  }
+  Fs.mkdirSync(RELEASE_ROOT, {recursive: true});
+  Fs.writeFileSync(
+      Path.join(RELEASE_ROOT, release.filename),
+      release.archive,
+      {flag: 'wx'},
+  );
+  const checksumName = `${release.filename}.sha256.txt`;
+  Fs.writeFileSync(
+      Path.join(RELEASE_ROOT, checksumName),
+      `${release.sha256}  ${release.filename}\n`,
+      {flag: 'wx'},
+  );
+  return checksumName;
+
+}
+
+function main() {
+
+  assertCleanTrackedTree();
+  const verifyRebuild = process.argv.slice(2).includes('--verify-rebuild');
+  if (verifyRebuild) {
+    runChromiumBuild();
+  }
+  const first = createRelease();
+  if (verifyRebuild) {
+    runChromiumBuild();
+    const second = createRelease();
+    Assert.deepStrictEqual(first.archive, second.archive,
+        'Chromium release ZIP is not deterministic.');
+    Assert.strictEqual(first.sha256, second.sha256);
+  }
+  const checksumName = writeRelease(first);
+  console.log(JSON.stringify({
+    deterministicRebuilds: verifyRebuild ? 2 : 1,
+    outputDirectory: Path.relative(REPOSITORY_ROOT, RELEASE_ROOT)
+        .split(Path.sep).join('/'),
+    release: {
+      checksumFilename: checksumName,
+      filename: first.filename,
+      sha256: first.sha256,
+      size: first.archive.length,
+    },
+    version: first.version,
+  }, null, 2));
+
+}
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error && error.message ? error.message : 'Release build failed.');
+    process.exitCode = 1;
+  }
+}

--- a/extensions/chromium/runet-censorship-bypass/src/extension-chromium-mv3/test/verify-package-integrity.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-chromium-mv3/test/verify-package-integrity.js
@@ -17,8 +17,8 @@ const PACKAGED_MV3_ROOT = Path.resolve(
 
 const MV3_SOURCE_ROOT = Path.resolve(__dirname, '..');
 const MV3_LOCALES = Object.freeze(['en', 'ru']);
-const EXPECTED_MV3_VERSION = '0.0.3.0';
-const EXPECTED_MV3_VERSION_NAME = '0.0.3.00';
+const EXPECTED_MV3_VERSION = '0.0.4.0';
+const EXPECTED_MV3_VERSION_NAME = '0.0.4.00';
 
 const ALLOWED_RUNTIME_DIRECTORIES = new Set([
   'background/vendor/tldts/dist',

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/manifest.json
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_extensionName__",
-  "version": "0.0.3.0",
+  "version": "0.0.4.0",
   "description": "__MSG_extensionDescription__",
   "default_locale": "en",
   "permissions": [

--- a/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/firefox-lifecycle-smoke.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-firefox-mv3/test/firefox-lifecycle-smoke.js
@@ -101,41 +101,12 @@ function safeRemoveTemporary(directory, prefix) {
 
 }
 
-function makeInstrumentedExtension(collectorPort) {
+function makeInstrumentedExtension() {
 
   const directory = Fs.mkdtempSync(
       Path.join(Os.tmpdir(), 'rucb-firefox-runtime-extension-'),
   );
   Fs.cpSync(packageRoot, directory, {recursive: true});
-  const manifestPath = Path.join(directory, 'manifest.json');
-  const manifest = JSON.parse(Fs.readFileSync(manifestPath, 'utf8'));
-  manifest.permissions.push('alarms');
-  manifest.host_permissions = ['http://127.0.0.1/*'];
-  manifest.background.scripts.push('test-observer.js');
-  Fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
-  const collectorUrl = `http://127.0.0.1:${collectorPort}/boot`;
-  Fs.writeFileSync(Path.join(directory, 'test-observer.js'), [
-    '\'use strict\';',
-    'browser.alarms.onAlarm.addListener(() => {});',
-    'browser.alarms.create(\'lifecycle-wake\', {delayInMinutes: 1});',
-    '(async () => {',
-    '  const initialization = await',
-    '    globalThis.rucbFirefoxRuntime.whenReady();',
-    '  const stored = await browser.storage.local.get(',
-    '    globalThis.rucbFirefoxOffState.STORAGE_KEY,',
-    '  );',
-    '  const state = stored[globalThis.rucbFirefoxOffState.STORAGE_KEY];',
-    `  await fetch(${JSON.stringify(collectorUrl)}, {`,
-    '    method: \'POST\',',
-    '    headers: {\'content-type\': \'application/json\'},',
-    '    body: JSON.stringify({',
-    '      bootId: globalThis.rucbFirefoxRuntime.bootId,',
-    '      initialization,',
-    '      state,',
-    '    }),',
-    '  });',
-    '})();',
-  ].join('\n'));
   Fs.writeFileSync(Path.join(directory, 'probe.html'), [
     '<!doctype html>',
     '<meta charset="utf-8">',
@@ -388,17 +359,26 @@ async function readCapabilities(client, origin) {
 
 }
 
-async function waitForBoot(bootEvents, predicate, timeoutMilliseconds) {
+async function readProductionCapabilities(client, origin) {
 
-  const deadline = Date.now() + timeoutMilliseconds;
-  while (Date.now() < deadline) {
-    const event = bootEvents.find(predicate);
-    if (event) {
-      return event;
-    }
-    await delay(100);
-  }
-  throw new Error('Timed out waiting for a Firefox event-page boot.');
+  await navigate(client, `${origin}/pages/popup/index.html`);
+  const result = webdriverValue(
+      await client.command('WebDriver:ExecuteAsyncScript', {
+        args: [],
+        filename: 'firefox-runtime-lifecycle-smoke.js',
+        line: 1,
+        newSandbox: false,
+        script: [
+          'const done = arguments[arguments.length - 1];',
+          'browser.runtime.sendMessage({',
+          '  type: "firefox.capabilities.get",',
+          '}).then(done, (error) => done({error: String(error)}));',
+        ].join('\n'),
+      }),
+  );
+  Assert.strictEqual(result && result.ok, true, JSON.stringify(result));
+  await navigate(client, 'about:blank');
+  return result;
 
 }
 
@@ -427,27 +407,14 @@ async function main() {
       'Firefox production package is missing.',
   );
   const firefox = resolveFirefox();
-  const bootEvents = [];
   const proxyRequests = [];
-  const collector = Http.createServer((request, response) => {
-    const chunks = [];
-    request.on('data', (chunk) => chunks.push(chunk));
-    request.on('end', () => {
-      if (request.method === 'POST' && request.url === '/boot') {
-        bootEvents.push(JSON.parse(Buffer.concat(chunks).toString('utf8')));
-      }
-      response.writeHead(204);
-      response.end();
-    });
-  });
   const proxy = Http.createServer((request, response) => {
     proxyRequests.push(request.url);
     response.writeHead(200, {'content-type': 'text/plain'});
     response.end(MANUAL_PROXY_MARKER);
   });
-  await listen(collector);
   await listen(proxy);
-  const extensionDirectory = makeInstrumentedExtension(collector.address().port);
+  const extensionDirectory = makeInstrumentedExtension();
   const profileDirectory = Fs.mkdtempSync(
       Path.join(Os.tmpdir(), 'rucb-firefox-runtime-profile-'),
   );
@@ -475,11 +442,13 @@ async function main() {
   });
   let client;
   let stderr = '';
+  let phase = 'CONNECT_MARIONETTE';
   child.stderr.on('data', (chunk) => {
     stderr = `${stderr}${chunk}`.slice(-8000);
   });
   try {
     client = await connectMarionette(marionettePort);
+    phase = 'CREATE_SESSION';
     await client.command('WebDriver:NewSession', {
       capabilities: {
         alwaysMatch: {pageLoadStrategy: 'normal'},
@@ -499,56 +468,61 @@ async function main() {
       script: 15000,
     });
 
+    phase = 'MANUAL_PROXY_BEFORE_INSTALL';
     await navigate(client, 'http://manual-proxy-check.invalid/before-install');
     Assert.strictEqual(await bodyText(client), MANUAL_PROXY_MARKER);
+    phase = 'INSTALL_PRODUCTION_PACKAGE';
     await client.command('Addon:Install', {
       allowPrivateBrowsing: false,
       path: productionPackagePath,
       temporary: true,
     });
-    await delay(500);
+    phase = 'WAIT_FOR_PRODUCTION_OFF';
+    const productionOrigin = await extensionOrigin(client);
+    const productionCapabilities = await readProductionCapabilities(
+        client,
+        productionOrigin,
+    );
+    Assert.strictEqual(productionCapabilities.result.runtimeState, 'OFF');
+    Assert.strictEqual(productionCapabilities.result.durableIntent, 'OFF');
+    phase = 'MANUAL_PROXY_AFTER_PRODUCTION_INSTALL';
     await navigate(
         client,
         'http://manual-proxy-check.invalid/after-production-install',
     );
     Assert.strictEqual(await bodyText(client), MANUAL_PROXY_MARKER);
+    phase = 'UNINSTALL_PRODUCTION_PACKAGE';
     await client.command('Addon:Uninstall', {
       id: '{adf5f697-1149-42a2-92eb-c163cb9a4146}',
     });
+    phase = 'INSTALL_LIFECYCLE_PROBE';
     await client.command('Addon:Install', {
       allowPrivateBrowsing: false,
       path: extensionDirectory,
       temporary: true,
     });
-    const first = await waitForBoot(bootEvents, () => true, 15000);
-    Assert.deepStrictEqual(first.state, {
-      schemaVersion: 3,
-      intent: 'OFF',
-      floorIdentity: null,
-    });
+    phase = 'READ_INITIAL_CAPABILITIES';
     const origin = await extensionOrigin(client);
     const firstRpc = await readCapabilities(client, origin);
-    Assert.strictEqual(firstRpc.bootId, first.bootId);
     Assert.strictEqual(firstRpc.capabilities.result.runtimeState, 'OFF');
     Assert.strictEqual(firstRpc.capabilities.result.durableIntent, 'OFF');
+    phase = 'MANUAL_PROXY_AFTER_PROBE_INSTALL';
     await navigate(client, 'http://manual-proxy-check.invalid/after-install');
     Assert.strictEqual(await bodyText(client), MANUAL_PROXY_MARKER);
 
-    console.log('Waiting for automatic Firefox event-page idle recreation...');
-    const second = await waitForBoot(
-        bootEvents,
-        (event) => event.bootId !== first.bootId,
-        105000,
-    );
-    Assert.deepStrictEqual(second.state, {
-      schemaVersion: 3,
-      intent: 'OFF',
-      floorIdentity: null,
-    });
+    phase = 'IDLE_EVENT_PAGE';
+    console.log('Leaving the Firefox event page genuinely idle...');
+    await delay(65000);
+    phase = 'READ_RECREATED_CAPABILITIES';
     const secondRpc = await readCapabilities(client, origin);
-    Assert.strictEqual(secondRpc.bootId, second.bootId);
+    Assert.notStrictEqual(
+        secondRpc.bootId,
+        firstRpc.bootId,
+        'Firefox event page was not destroyed and recreated while idle.',
+    );
     Assert.strictEqual(secondRpc.capabilities.result.runtimeState, 'OFF');
     Assert.strictEqual(secondRpc.capabilities.result.durableIntent, 'OFF');
+    phase = 'MANUAL_PROXY_AFTER_RECREATION';
     await navigate(client, 'http://manual-proxy-check.invalid/after-recreation');
     Assert.strictEqual(await bodyText(client), MANUAL_PROXY_MARKER);
 
@@ -563,8 +537,8 @@ async function main() {
     }
     console.log(JSON.stringify({
       firefox: firefoxVersion(firefox),
-      firstBootId: first.bootId,
-      recreatedBootId: second.bootId,
+      firstBootId: firstRpc.bootId,
+      recreatedBootId: secondRpc.bootId,
       runtimeState: secondRpc.capabilities.result.runtimeState,
       durableIntent: secondRpc.capabilities.result.durableIntent,
       privateWindowAccess: secondRpc.capabilities.result.privateWindowAccess,
@@ -574,7 +548,10 @@ async function main() {
         'UNSIGNED_XPI' : 'UNPACKED',
     }, null, 2));
   } catch (error) {
-    throw new Error(`${error && error.stack ? error.stack : error}\n${stderr}`);
+    throw new Error(
+        `Lifecycle phase ${phase} failed:\n` +
+        `${error && error.stack ? error.stack : error}\n${stderr}`,
+    );
   } finally {
     if (client) {
       try {
@@ -590,7 +567,6 @@ async function main() {
       child.kill();
       await waitForExit(child, 5000).catch(() => {});
     }
-    await closeServer(collector);
     await closeServer(proxy);
     safeRemoveTemporary(
         extensionDirectory,

--- a/extensions/chromium/runet-censorship-bypass/src/templates-data.js
+++ b/extensions/chromium/runet-censorship-bypass/src/templates-data.js
@@ -2,7 +2,7 @@
 
 exports.contexts = Object.freeze({
   chromiumMv3: Object.freeze({
-    version: '3.00',
-    storeVersion: '3.0',
+    version: '4.00',
+    storeVersion: '4.0',
   }),
 });


### PR DESCRIPTION
## Summary

- prepares the shared Chromium/Firefox release train `v0.0.4.0`
- fixes `GHSA-2883-xcg3-v3hh` with the smallest transitive override from `js-yaml@4.3.1` to `4.3.2`
- replaces the Firefox lifecycle smoke's CSP-incompatible localhost observer with an extension-local boot-ID probe
- adds deterministic Chromium ZIP/checksum tooling and includes it in trusted-main CI artifacts
- does not add or change Firefox routing, updater, health, migration, or runtime features

## Dependency review

`js-yaml@4.3.2` is the official MIT-licensed `nodeca/js-yaml` package. Its npm `gitHead` matches tag `4.3.2`, it was published more than 13 days before review, the registry tarball is signed, and it has no install lifecycle script. The lockfile changes only the Mocha transitive selection and hoists its existing `argparse` dependency; no production dependency changes.

- production npm audit: 0
- full npm audit: 2 low dev-only findings in the existing Mocha -> `diff` chain; the available fix is the separately scoped Mocha 12 major upgrade
- registry signatures: 314/314

## Lifecycle harness

The release CSP remains unchanged. The test no longer adds `alarms`, localhost host permission, or a network observer. It waits for production initialization through the packaged capability RPC, then uses a test-only local extension page to read the ephemeral boot ID before and after 65 seconds of complete event-page inactivity. Firefox 154.0.1 produced a different boot ID, remained durable/runtime OFF, and preserved the previous manual proxy.

## Release artifacts

- Chromium ZIP: `runet-censorship-bypass-mv3-0.0.4.0-da6abd2.zip`
  - size: 1,137,540 bytes
  - SHA-256: `706de23c2f7476ef1a27c389d29d438495ffced416d2a58c1d4793361ca33bc8`
- Firefox unsigned XPI: `runet-censorship-bypass-firefox-0.0.4.0.xpi`
  - size: 11,969,182 bytes
  - SHA-256: `bcc8528910b8924602c72dd0bf07a90f51c8f0fbca754454e2726b9a99e74fb7`
- Firefox reviewer source ZIP: `runet-censorship-bypass-firefox-0.0.4.0-source.zip`
  - size: 15,790,214 bytes
  - SHA-256: `749809bf952c707f93d3464083eba33af2361487bc79a29a34bd0de2b1baa04a`

Each release command performed two independent builds and byte-for-byte archive comparison. The archives contain `manifest.json` at root and exactly match the unpacked 70-file Chromium and 30-file Firefox packages. Mozilla `addons-linter@10.10.0` reports 0 errors, 0 warnings, and 0 notices for the exact XPI.

## Verification and browser QA

- PAC: 26/26
- Chromium MV3: 428/428
- Firefox deterministic: 314/314
- aggregate: 755/755
- Chrome Stable 153 smoke: pass
- Brave/Chromium 152 smoke: pass
- Firefox 154.0.1 exact-XPI lifecycle and product/UI QA: pass
- Firefox protected-origin contacts: 0
- credential leaks: 0
- external Firefox QA traffic: 0

The Firefox product QA covered clean-install OFF, Apply/ACTIVE, provider routing, explicit Direct/Proxy, authenticated proxy, settings/revision/secret behavior, event-page recovery, Clear/manual-proxy restoration, and private-access revocation.

No artifact is published and no release/tag is created by this PR.
